### PR TITLE
Fix material-ui warnings due to wrong styles in theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Fix material-ui warnings due to wrong styles in theme [#124](https://github.com/CartoDB/carto-react/pull/124)
 - Add Widgets from @carto/react-widgets to StoryBook [#120](https://github.com/CartoDB/carto-react/pull/120)
 - Improve GoogleMap component [#121](https://github.com/CartoDB/carto-react/pull/121)
 

--- a/packages/react-ui/src/theme/carto-theme.js
+++ b/packages/react-ui/src/theme/carto-theme.js
@@ -649,7 +649,9 @@ export const cartoThemeOptions = {
       }
     },
     MuiInputLabel: {
-      ...variables.typography.body1,
+      root: {
+        ...variables.typography.body1
+      },
 
       formControl: {
         transform: 'translate(16px, 20px) scale(1)',
@@ -693,7 +695,7 @@ export const cartoThemeOptions = {
         marginBottom: spacing(1.5),
         color: variables.palette.text.secondary,
 
-        '&$disabled': {
+        '&:disabled': {
           color: variables.palette.action.disabled
         },
 
@@ -748,8 +750,10 @@ export const cartoThemeOptions = {
     MuiSelect: {
       selectMenu: {},
 
-      '&$hover': {
-        backgroundColor: 'transparent'
+      root: {
+        '&:hover': {
+          backgroundColor: 'transparent'
+        }
       },
 
       select: {


### PR DESCRIPTION
- Warnings violation about `ms` cannot be resolved because it comes from chrome and are shown when an action takes a lot of time.
- SharedArrayBuffer warning comes from react https://github.com/facebook/create-react-app/issues/10474