### PR TITLE
feat: expose createTheme as createCartoTheme

### DIFF
--- a/packages/react-ui/src/index.js
+++ b/packages/react-ui/src/index.js
@@ -1,4 +1,4 @@
-import { cartoThemeOptions } from './theme/carto-theme';
+import { cartoThemeOptions, createTheme } from './theme/carto-theme';
 import WrapperWidgetUI from './widgets/WrapperWidgetUI';
 import CategoryWidgetUI from './widgets/CategoryWidgetUI';
 import FormulaWidgetUI from './widgets/FormulaWidgetUI';
@@ -7,9 +7,10 @@ import PieWidgetUI from './widgets/PieWidgetUI';
 
 export {
   cartoThemeOptions,
+  createTheme as createCartoTheme,
   WrapperWidgetUI,
   CategoryWidgetUI,
   FormulaWidgetUI,
   HistogramWidgetUI,
-  PieWidgetUI,
+  PieWidgetUI
 };

--- a/packages/react-ui/src/theme/carto-theme.js
+++ b/packages/react-ui/src/theme/carto-theme.js
@@ -1175,16 +1175,10 @@ export const cartoThemeOptions = {
   }
 };
 
-export function createTheme(options = {}) {
-  const themeOptions = {
-    ...cartoThemeOptions,
-    ...options
-  };
-
-  let theme = createMuiTheme(themeOptions);
-
+export function createTheme() {
+  let theme = createMuiTheme(cartoThemeOptions);
   theme = responsiveFontSizes(theme, {
-    breakpoints: themeOptions.breakpoints.keys,
+    breakpoints: cartoThemeOptions.breakpoints.keys,
     disableAlign: false,
     factor: 2,
     variants: [


### PR DESCRIPTION
Expose `cartoTheme` as `createCartoTheme`.

Related with `documentation`: https://github.com/CartoDB/documentation/pull/78