### PR TITLE
Add unit tests for carto-cloud-native

### DIFF
--- a/packages/react-api/__tests__/hooks/useCartoLayerProps.test.js
+++ b/packages/react-api/__tests__/hooks/useCartoLayerProps.test.js
@@ -1,4 +1,5 @@
 import { DataFilterExtension } from '@deck.gl/extensions';
+import { MAP_TYPES, API_VERSIONS } from '@deck.gl/carto';
 import { renderHook } from '@testing-library/react-hooks';
 import useCartoLayerProps from '../../src/hooks/useCartoLayerProps';
 import { mockReduxHooks, mockClear } from '../mockReduxHooks';
@@ -6,47 +7,192 @@ import { mockReduxHooks, mockClear } from '../mockReduxHooks';
 describe('useCartoLayerProps', () => {
   mockReduxHooks();
 
-  const { result } = renderHook(() => useCartoLayerProps());
-
-  test('should return correct filter props', () => {
-    expect(Object.keys(result.current)).toEqual([
-      'binary',
+  describe('return props', () => {
+    const COMMON_PROPS = [
       'uniqueIdProperty',
-      'onViewportLoad',
+      'data',
+      'type',
+      'provider',
+      'connection',
       'getFilterValue',
       'filterRange',
       'extensions',
       'updateTriggers'
-    ]);
+    ];
+
+    describe('when maps_api_version is V2', () => {
+      test('should return correct props when source type is tileset', () => {
+        const source = {
+          credentials: {
+            apiVersion: API_VERSIONS.V2
+          },
+          type: MAP_TYPES.TILESET
+        };
+
+        const { result } = renderHook(() => useCartoLayerProps(source));
+
+        expect(Object.keys(result.current)).toEqual([
+          'binary',
+          'onViewportLoad',
+          ...COMMON_PROPS
+        ]);
+      });
+
+      test('should return correct props when source type is sql', () => {
+        const source = {
+          credentials: {
+            apiVersion: API_VERSIONS.V2
+          },
+          type: MAP_TYPES.SQL
+        };
+
+        const { result } = renderHook(() => useCartoLayerProps(source));
+
+        expect(Object.keys(result.current)).toEqual([
+          'binary',
+          'onViewportLoad',
+          ...COMMON_PROPS
+        ]);
+      });
+
+      test('should return correct props when source type is table', () => {
+        const source = {
+          credentials: {
+            apiVersion: API_VERSIONS.V2
+          },
+          type: MAP_TYPES.TABLE
+        };
+
+        const { result } = renderHook(() => useCartoLayerProps(source));
+
+        expect(Object.keys(result.current)).toEqual([
+          'binary',
+          'onViewportLoad',
+          ...COMMON_PROPS
+        ]);
+      });
+    });
+
+    describe('when maps_api_version is V3', () => {
+      test('should return correct props when source type is tileset', () => {
+        const source = {
+          credentials: {
+            apiVersion: API_VERSIONS.V3
+          },
+          type: MAP_TYPES.TILESET
+        };
+
+        const { result } = renderHook(() => useCartoLayerProps(source));
+
+        expect(Object.keys(result.current)).toEqual([
+          'binary',
+          'onViewportLoad',
+          ...COMMON_PROPS
+        ]);
+      });
+
+      test('should return correct props when source type is sql', () => {
+        const source = {
+          credentials: {
+            apiVersion: API_VERSIONS.V3
+          },
+          type: MAP_TYPES.SQL
+        };
+
+        const { result } = renderHook(() => useCartoLayerProps(source));
+
+        expect(Object.keys(result.current)).toEqual(['onDataLoad', ...COMMON_PROPS]);
+      });
+
+      test('should return correct props when source type is table', () => {
+        const source = {
+          credentials: {
+            apiVersion: API_VERSIONS.V3
+          },
+          type: MAP_TYPES.TABLE
+        };
+
+        const { result } = renderHook(() => useCartoLayerProps(source));
+
+        expect(Object.keys(result.current)).toEqual(['onDataLoad', ...COMMON_PROPS]);
+      });
+    });
   });
 
   describe('should has correct filter configurations', () => {
     test('uniqueIdProperty should be undefined', () => {
+      const { result } = renderHook(() => useCartoLayerProps());
+
       expect(result.current.uniqueIdProperty).toBeUndefined();
     });
 
-    test('onViewporLoad should be a function', () => {
+    test('onViewportLoad should be a function', () => {
+      const source = {
+        credentials: {
+          apiVersion: API_VERSIONS.V2
+        },
+        type: MAP_TYPES.TILESET
+      };
+
+      const { result } = renderHook(() => useCartoLayerProps(source));
+
       expect(result.current.onViewportLoad).toBeInstanceOf(Function);
     });
 
+    test('binary should be true', () => {
+      const source = {
+        credentials: {
+          apiVersion: API_VERSIONS.V2
+        },
+        type: MAP_TYPES.TILESET
+      };
+
+      const { result } = renderHook(() => useCartoLayerProps(source));
+
+      expect(result.current.binary).toBe(true);
+    });
+
+    test('onDataLoad should be a function', () => {
+      const source = {
+        credentials: {
+          apiVersion: API_VERSIONS.V3
+        },
+        type: MAP_TYPES.SQL
+      };
+
+      const { result } = renderHook(() => useCartoLayerProps(source));
+
+      expect(result.current.onDataLoad).toBeInstanceOf(Function);
+    });
+
     test('getFilterValue should be a function', () => {
+      const { result } = renderHook(() => useCartoLayerProps());
+
       expect(result.current.getFilterValue).toBeInstanceOf(Function);
     });
 
     test('filter range should be between 1 and 1', () => {
+      const { result } = renderHook(() => useCartoLayerProps());
+
       expect(result.current.filterRange).toEqual([1, 1]);
     });
 
     test('extensions should have an unique instance of DataFilterExtension', () => {
+      const { result } = renderHook(() => useCartoLayerProps());
+
       expect(result.current.extensions.length).toBe(1);
       expect(result.current.extensions[0]).toBeInstanceOf(DataFilterExtension);
     });
 
     test('filter size should be 1', () => {
+      const { result } = renderHook(() => useCartoLayerProps());
+
       expect(result.current.extensions[0].opts.filterSize).toEqual(1);
     });
 
     test('getFilterValue trigger should be present', () => {
+      const { result } = renderHook(() => useCartoLayerProps());
+
       expect(result.current.updateTriggers).toHaveProperty('getFilterValue');
     });
   });

--- a/packages/react-core/__tests__/filters/viewportFeaturesGeoJSON.test.js
+++ b/packages/react-core/__tests__/filters/viewportFeaturesGeoJSON.test.js
@@ -1,0 +1,284 @@
+import { viewportFeaturesGeoJSON } from '../../src/filters/viewportFeaturesGeoJSON';
+
+describe('viewport features with geojson data', () => {
+  const viewport = [-10, -10, 10, 10]; // west - south - east - north
+
+  describe('return no data', () => {
+    test('should return an empty array if no geojson features present', () => {
+      const geojson = {
+        type: 'FeatureCollection',
+        features: []
+      };
+
+      const properties = viewportFeaturesGeoJSON({
+        geojson,
+        viewport
+      });
+
+      expect(properties).toEqual([]);
+    });
+  });
+
+  describe('correctly returns data', () => {
+    test('should handle linestrings correctly fwsf', () => {
+      const linestrings = {
+        type: 'FeatureCollection',
+        features: [...Array(3)].map((_, i) => ({
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            // prettier-ignore
+            coordinates: [0, 0]
+          },
+          properties: {
+            cartodb_id: i + 1,
+            other_prop: i
+          }
+        }))
+      };
+
+      const properties = viewportFeaturesGeoJSON({
+        geojson: linestrings,
+        viewport,
+        uniqueIdProperty: 'cartodb_id'
+      });
+
+      // prettier-ignore
+      expect(properties).toEqual([
+        { 'cartodb_id': 1, 'other_prop': 0 },
+        { 'cartodb_id': 2, 'other_prop': 1 },
+        { 'cartodb_id': 3, 'other_prop': 2 },
+      ]);
+    });
+
+    test('should handle multilinestrings correctly', () => {
+      const multilinestrings = {
+        type: 'FeatureCollection',
+        features: [...Array(3)].map((_, i) => ({
+          type: 'Feature',
+          geometry: {
+            type: 'MultiLineString',
+            // prettier-ignore
+            coordinates: [[[i, i], [i + 1, i + 1]], [[i + 2, i + 2], [i + 3, i + 3]]]
+          },
+          properties: {
+            cartodb_id: i + 1,
+            other_prop: i
+          }
+        }))
+      };
+
+      const properties = viewportFeaturesGeoJSON({
+        geojson: multilinestrings,
+        viewport,
+        uniqueIdProperty: 'cartodb_id'
+      });
+
+      // prettier-ignore
+      expect(properties).toStrictEqual([
+        { 'cartodb_id': 1, 'other_prop': 0 },
+        { 'cartodb_id': 2, 'other_prop': 1 },
+        { 'cartodb_id': 3, 'other_prop': 2 }
+      ]);
+    });
+
+    test('should handle polygons correctly', () => {
+      const polygons = {
+        type: 'FeatureCollection',
+        features: [...Array(3)].map((_, i) => ({
+          type: 'Feature',
+          geometry: {
+            type: 'Polygon',
+            // prettier-ignore
+            coordinates: [[[i, i], [i + 1, i], [i + 1, i + 1], [i, i + 1], [i, i]]]
+          },
+          properties: {
+            cartodb_id: i + 1,
+            other_prop: i
+          }
+        }))
+      };
+
+      const properties = viewportFeaturesGeoJSON({
+        geojson: polygons,
+        viewport,
+        uniqueIdProperty: 'cartodb_id'
+      });
+
+      // prettier-ignore
+      expect(properties).toStrictEqual([
+        { 'cartodb_id': 1, 'other_prop': 0 },
+        { 'cartodb_id': 2, 'other_prop': 1 },
+        { 'cartodb_id': 3, 'other_prop': 2 }
+      ]);
+    });
+
+    test('should handle multilipolygons correctly', () => {
+      const multipolygons = {
+        type: 'FeatureCollection',
+        features: [...Array(3)].map((_, i) => ({
+          type: 'Feature',
+          geometry: {
+            type: 'MultiPolygon',
+            // prettier-ignore
+            coordinates: [
+              [[[i, i], [i + 1, i], [i + 1, i + 1], [i, i + 1], [i, i]]],
+              [[[i + 1, i + 1], [i + 2, i + 1], [i + 2, i + 2], [i + 1, i + 2], [i + 1, i + 1]]]
+            ]
+          },
+          properties: {
+            cartodb_id: i + 1,
+            other_prop: i
+          }
+        }))
+      };
+
+      const properties = viewportFeaturesGeoJSON({
+        geojson: multipolygons,
+        viewport,
+        uniqueIdProperty: 'cartodb_id'
+      });
+
+      // prettier-ignore
+      expect(properties).toStrictEqual([
+        { 'cartodb_id': 1, 'other_prop': 0 },
+        { 'cartodb_id': 2, 'other_prop': 1 },
+        { 'cartodb_id': 3, 'other_prop': 2 }
+      ]);
+    });
+  });
+
+  describe('with repeated features', () => {
+    test('should handle points correctly', () => {
+      const points = {
+        type: 'FeatureCollection',
+        features: [...Array(4)].map(() => ({
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [0, 0]
+          },
+          properties: {
+            cartodb_id: 1,
+            other_prop: 1
+          }
+        }))
+      };
+
+      const properties = viewportFeaturesGeoJSON({
+        geojson: points,
+        viewport,
+        uniqueIdProperty: 'cartodb_id'
+      });
+
+      expect(properties).toEqual([{ cartodb_id: 1, other_prop: 1 }]);
+    });
+
+    test('should handle linestrings correctly', () => {
+      const linestrings = {
+        type: 'FeatureCollection',
+        features: [...Array(4)].map(() => ({
+          type: 'Feature',
+          geometry: {
+            type: 'LineString',
+            // prettier-ignore
+            coordinates: [[0, 0], [0, 1], [1, 2]]
+          },
+          properties: {
+            cartodb_id: 1,
+            other_prop: 1
+          }
+        }))
+      };
+
+      const properties = viewportFeaturesGeoJSON({
+        geojson: linestrings,
+        viewport,
+        uniqueIdProperty: 'cartodb_id'
+      });
+
+      expect(properties).toEqual([{ cartodb_id: 1, other_prop: 1 }]);
+    });
+
+    test('should handle multilinestrings correctly', () => {
+      const multilinestrings = {
+        type: 'FeatureCollection',
+        features: [...Array(4)].map(() => ({
+          type: 'Feature',
+          geometry: {
+            type: 'MultiLineString',
+            // prettier-ignore
+            coordinates: [[[0, 0], [1, 1]], [[2, 2], [3, 3]]]
+          },
+          properties: {
+            cartodb_id: 1,
+            other_prop: 1
+          }
+        }))
+      };
+
+      const properties = viewportFeaturesGeoJSON({
+        geojson: multilinestrings,
+        viewport,
+        uniqueIdProperty: 'cartodb_id'
+      });
+
+      expect(properties).toEqual([{ cartodb_id: 1, other_prop: 1 }]);
+    });
+
+    test('should handle polygons correctly', () => {
+      const polygons = {
+        type: 'FeatureCollection',
+        features: [...Array(4)].map(() => ({
+          type: 'Feature',
+          geometry: {
+            type: 'Polygon',
+            // prettier-ignore
+            coordinates: [[[0, 0], [1, 0], [1, 1], [0, 2], [0, 0]]]
+          },
+          properties: {
+            cartodb_id: 1,
+            other_prop: 1
+          }
+        }))
+      };
+
+      const properties = viewportFeaturesGeoJSON({
+        geojson: polygons,
+        viewport,
+        uniqueIdProperty: 'cartodb_id'
+      });
+
+      expect(properties).toEqual([{ cartodb_id: 1, other_prop: 1 }]);
+    });
+
+    test('should handle multipolygons correctly', () => {
+      const multipolygons = {
+        type: 'FeatureCollection',
+        features: [...Array(4)].map(() => ({
+          type: 'Feature',
+          geometry: {
+            type: 'MultiPolygon',
+            // prettier-ignore
+            coordinates: [
+              [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+              [[[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]]]
+            ]
+          },
+          properties: {
+            cartodb_id: 1,
+            other_prop: 1
+          }
+        }))
+      };
+
+      const properties = viewportFeaturesGeoJSON({
+        geojson: multipolygons,
+        viewport,
+        uniqueIdProperty: 'cartodb_id'
+      });
+
+      expect(properties).toEqual([{ cartodb_id: 1, other_prop: 1 }]);
+    });
+  });
+});

--- a/packages/react-core/src/filters/viewportFeaturesGeoJSON.js
+++ b/packages/react-core/src/filters/viewportFeaturesGeoJSON.js
@@ -8,7 +8,9 @@ export function viewportFeaturesGeoJSON({ geojson, viewport, uniqueIdProperty })
   const bbox = bboxPolygon(viewport);
 
   for (const feature of geojson.features) {
-    const uniqueId = uniqueIdProperty ? geojson.features[uniqueIdProperty] : ++uniqueIdx;
+    const uniqueId = uniqueIdProperty
+      ? feature.properties[uniqueIdProperty]
+      : ++uniqueIdx;
     if (!map.has(uniqueId) && intersects(bbox, feature)) {
       map.set(uniqueId, feature.properties);
     }


### PR DESCRIPTION
For: https://app.clubhouse.io/cartoteam/story/155287/adapt-tests

- A little fix was implemented in `viewportFeaturesGeoJSON`. It was not correctly handling the `uniqueIdProperty` accessibility.

- Current coverage is **82.28%**