### PR TITLE
SQL API cloud native

### DIFF
--- a/packages/react-api/__tests__/mockSqlApiRequest.js
+++ b/packages/react-api/__tests__/mockSqlApiRequest.js
@@ -4,7 +4,7 @@ export function mockSqlApiRequest({
   response,
   responseIsOk = true,
   status = 200,
-  sql,
+  query,
   credentials
 }) {
   _global.fetch = jest.fn(() =>
@@ -17,7 +17,7 @@ export function mockSqlApiRequest({
 
   _global.Request = jest.fn(
     () =>
-      `https://public.carto.com/api/v2/sql?api_key=${credentials.apiKey}&client=${credentials.username}&q=${sql}`
+      `https://public.carto.com/api/v2/sql?api_key=${credentials.apiKey}&client=${credentials.username}&q=${query}`
   );
 }
 

--- a/packages/react-api/src/api/SQL.d.ts
+++ b/packages/react-api/src/api/SQL.d.ts
@@ -1,9 +1,13 @@
 import { Credentials, ExecuteSQL } from '../types';
 
-export function executeSQL(
-  credentials: Credentials,
-  query: string,
-  opts?: {
-    format: '' | 'geojson'
-  }
-): ExecuteSQL;
+export function executeSQL({
+    credentials,
+    query,
+    connection,
+    opts 
+  }: {
+    credentials: Credentials,
+    query: string,
+    connection?: string,
+    opts?: unknown
+  }): ExecuteSQL;

--- a/packages/react-api/src/api/SQL.js
+++ b/packages/react-api/src/api/SQL.js
@@ -18,6 +18,10 @@ import { dealWithApiError, generateApiUrl } from './common';
 export const executeSQL = async ({ credentials, query, connection, opts }) => {
   let response;
 
+  if (!credentials) {
+    throw new Error('No credentials provided');
+  }
+
   try {
     const request = createRequest({ credentials, connection, query, opts });
     response = await fetch(request);
@@ -46,14 +50,14 @@ export const executeSQL = async ({ credentials, query, connection, opts }) => {
  * Create an 'SQL query' request
  * (using GET or POST request, depending on url size)
  */
-function createRequest({ credentials, connection, query, opts }) {
+function createRequest({ credentials, connection, query, opts = {} }) {
   const { abortController, ...otherOptions } = opts;
 
   const { apiVersion = API_VERSIONS.V2 } = credentials;
 
   const rawParams = {
     client: 'carto-react',
-    q: query.trim(),
+    q: query?.trim(),
     ...otherOptions
   };
 

--- a/packages/react-api/src/api/common.js
+++ b/packages/react-api/src/api/common.js
@@ -8,9 +8,9 @@ const DEFAULT_USER_COMPONENT_IN_URL = '{user}';
 export function dealWithApiError({ credentials, response, data }) {
   switch (response.status) {
     case 401:
-      throw new Error(`Unauthorized access to SQL API. Invalid credentials.`);
+      throw new Error('Unauthorized access. Invalid credentials');
     case 403:
-      throw new Error(`Unauthorized access to SQL API. Invalid credentials.`);
+      throw new Error('Forbidden access to the requested data');
     default:
       throw new Error(`${JSON.stringify(data.error)}`);
   }

--- a/packages/react-api/src/api/common.js
+++ b/packages/react-api/src/api/common.js
@@ -1,18 +1,16 @@
+import { API_VERSIONS } from '@deck.gl/carto';
+
 const DEFAULT_USER_COMPONENT_IN_URL = '{user}';
 
 /**
  * Return more descriptive error from API
  */
-export function dealWithApiError({ API, credentials, response, data }) {
+export function dealWithApiError({ credentials, response, data }) {
   switch (response.status) {
     case 401:
-      throw new Error(
-        `Unauthorized access to ${API} API: invalid combination of user ('${credentials.username}') and apiKey ('${credentials.apiKey}')`
-      );
+      throw new Error(`Unauthorized access to SQL API. Invalid credentials.`);
     case 403:
-      throw new Error(
-        `Unauthorized access to ${API} API: the provided apiKey('${credentials.apiKey}') doesn't provide access to the requested data`
-      );
+      throw new Error(`Unauthorized access to SQL API. Invalid credentials.`);
     default:
       throw new Error(`${JSON.stringify(data.error)}`);
   }
@@ -20,22 +18,36 @@ export function dealWithApiError({ API, credentials, response, data }) {
 
 /**
  * Generate a valid API url for a request
- * @param {} param0
  */
-export function generateApiUrl({ API, credentials, parameters }) {
-  const base = `${serverUrl(credentials)}${API}`;
+export function generateApiUrl({ credentials, connection, parameters }) {
+  const { apiVersion = API_VERSIONS.V2, apiBaseUrl } = credentials;
 
-  if (!parameters) {
-    return base;
+  let url;
+  switch (apiVersion) {
+    case API_VERSIONS.V1:
+    case API_VERSIONS.V2:
+      url = `${sqlApiUrl(credentials)}api/v2/sql`;
+      break;
+
+    case API_VERSIONS.V3:
+      url = `${apiBaseUrl}/v3/sql/${connection}/query`;
+      break;
+
+    default:
+      throw new Error(`Unknown apiVersion ${apiVersion}`);
   }
 
-  return `${base}?${parameters.join('&')}`;
+  if (!parameters) {
+    return url;
+  }
+
+  return `${url}?${parameters.join('&')}`;
 }
 
 /**
  * Prepare a url valid for the specified user, from the serverUrlTemplate
  */
-function serverUrl(credentials) {
+function sqlApiUrl(credentials) {
   let url = credentials.serverUrlTemplate.replace(
     DEFAULT_USER_COMPONENT_IN_URL,
     credentials.username

--- a/packages/react-widgets/src/models/GeocodingModel.js
+++ b/packages/react-widgets/src/models/GeocodingModel.js
@@ -21,7 +21,7 @@ export const geocodeStreetPoint = async (
   const query = `SELECT ST_AsGeoJSON(cdb_geocode_street_point('${searchText}', '${
     city ?? ''
   }', '${state ?? ''}', '${country ?? ''}')) AS geometry`;
-  const results = await executeSQL(credentials, query, opts);
+  const results = await executeSQL({ credentials, query, opts });
 
   const geometry = JSON.parse(results[0].geometry);
   if (geometry === null) return null;


### PR DESCRIPTION
This PR gives support to SQL API for CARTO cloud native (v3)

It also supports CARTO SQL API v1 and v2.

There is a breaking change on the API, since executeSQL parameters are now destructuring.

How to use:

**Create a model**

```javascript
import { executeSQL } from '@carto/react-api';

const CONNECTION = 'bigquery';

export const getTotalArea = async ({ credentials, opts }) => {
  const query = `
  select SUM(do_area) as area from carto-do-public-data.carto.geography_aus_state_2016 
  `;

  return executeSQL({ credentials, connection: CONNECTION, query, opts });
};
```

**Call from a view**

```javascript
import { getTotalArea } from '../../data/models/BigQueryModel';
 const credentials = useSelector((state) => state.carto.credentials);

  useEffect(() => {
    getTotalArea({ credentials }).then( d => {
      // whatever
    })

  }, [ credentials ]);
```




