### PR TITLE
Warning with icon legend

### DIFF
--- a/packages/react-ui/src/widgets/legend/LegendIcon.js
+++ b/packages/react-ui/src/widgets/legend/LegendIcon.js
@@ -3,10 +3,7 @@ import { Box, Grid, makeStyles, Typography } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
   legendIcon: {
-    alignItems: 'center',
-    '&:hover': {
-      '& $circle': {}
-    }
+    alignItems: 'center'
   },
   icon: {
     width: theme.spacing(2),


### PR DESCRIPTION
I've removed the unused class in LegendIcon to remove warning console.

Story details: https://app.clubhouse.io/cartoteam/story/177765