### PR TITLE
Improve the error message when the geometry column is not called "geom"

### DIFF
--- a/packages/react-api/src/hooks/useViewportFeatures.js
+++ b/packages/react-api/src/hooks/useViewportFeatures.js
@@ -118,6 +118,10 @@ export default function useViewportFeatures(
           });
           setGeoJSONLoaded(true);
         } catch (error) {
+          if (error.name === 'DataCloneError')
+            throw new Error(
+              `Unable to retrieve GeoJSON. Please check that your query is returning a column called "geom" or that you are using the geoColumn property to indicate the geometry column in the table.`
+            );
           if (error.name === 'AbortError') return;
           throw error;
         }


### PR DESCRIPTION
Story details: https://app.shortcut.com/cartoteam/story/181081