### PR TITLE
Improve Widgets calculations sync with tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Improve Widgets calculations sync with tiles [#223](https://github.com/CartoDB/carto-react/pull/223)
+
 ## 1.1.0 (2021-10-29)
 
 - Histogram tooltip formatter receiving dataIndex and ticks [#220](https://github.com/CartoDB/carto-react/pull/220)
@@ -87,8 +89,6 @@
 - Add new ScatterplotWidget component [#149](https://github.com/CartoDB/carto-react/pull/149)
 - Update to latest 8.5.0-alpha.10 deck.gl version [#149](https://github.com/CartoDB/carto-react/pull/149)
 - Add support to Cloud Native SQL API [#150](https://github.com/CartoDB/carto-react/pull/150)
-
-
 
 ## 1.0.1 (2021-04-12)
 

--- a/packages/react-api/__tests__/hooks/useCartoLayerProps.test.js
+++ b/packages/react-api/__tests__/hooks/useCartoLayerProps.test.js
@@ -34,6 +34,7 @@ describe('useCartoLayerProps', () => {
         expect(Object.keys(result.current)).toEqual([
           'binary',
           'onViewportLoad',
+          'fetch',
           ...COMMON_PROPS
         ]);
       });
@@ -51,6 +52,7 @@ describe('useCartoLayerProps', () => {
         expect(Object.keys(result.current)).toEqual([
           'binary',
           'onViewportLoad',
+          'fetch',
           ...COMMON_PROPS
         ]);
       });
@@ -68,6 +70,7 @@ describe('useCartoLayerProps', () => {
         expect(Object.keys(result.current)).toEqual([
           'binary',
           'onViewportLoad',
+          'fetch',
           ...COMMON_PROPS
         ]);
       });
@@ -87,6 +90,7 @@ describe('useCartoLayerProps', () => {
         expect(Object.keys(result.current)).toEqual([
           'binary',
           'onViewportLoad',
+          'fetch',
           ...COMMON_PROPS
         ]);
       });

--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -7,12 +7,12 @@ export default function useCartoLayerProps({
   source,
   uniqueIdProperty,
   viewportFeatures = true,
-  debounceTimeOut = 500
+  viewporFeaturesDebounceTimeout = 500
 }) {
   const [onViewportLoad, onDataLoad, fetch] = useViewportFeatures(
     source,
     uniqueIdProperty,
-    debounceTimeOut
+    viewporFeaturesDebounceTimeout
   );
 
   let props = {};

--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -6,9 +6,14 @@ import { MAP_TYPES, API_VERSIONS } from '@deck.gl/carto';
 export default function useCartoLayerProps({
   source,
   uniqueIdProperty,
-  viewportFeatures = true
+  viewportFeatures = true,
+  debounceTimeOut = 500
 }) {
-  const [onViewportLoad, onDataLoad] = useViewportFeatures(source, uniqueIdProperty);
+  const [onViewportLoad, onDataLoad, fetch] = useViewportFeatures(
+    source,
+    uniqueIdProperty,
+    debounceTimeOut
+  );
 
   let props = {};
 
@@ -18,7 +23,8 @@ export default function useCartoLayerProps({
   ) {
     props = {
       binary: true,
-      onViewportLoad: viewportFeatures ? onViewportLoad : null
+      onViewportLoad: viewportFeatures ? onViewportLoad : null,
+      fetch: viewportFeatures ? fetch : null
     };
   } else if (source?.type === MAP_TYPES.QUERY || source?.type === MAP_TYPES.TABLE) {
     props = {

--- a/packages/react-api/src/hooks/useViewportFeatures.js
+++ b/packages/react-api/src/hooks/useViewportFeatures.js
@@ -23,13 +23,13 @@ export default function useViewportFeatures(
   const viewport = useSelector((state) => state.carto.viewport);
   const [tiles, setTiles] = useState([]);
   const [isGeoJSONLoaded, setGeoJSONLoaded] = useState(false);
-  const debounceId = useRef(0);
+  const debounceId = useRef(null);
 
   const clearDebounce = () => {
     if (debounceId.current) {
       clearTimeout(debounceId.current);
     }
-    debounceId.current = 0;
+    debounceId.current = null;
   };
 
   const sourceId = source?.id;

--- a/packages/react-api/src/hooks/useViewportFeatures.js
+++ b/packages/react-api/src/hooks/useViewportFeatures.js
@@ -17,7 +17,7 @@ function isV3(source) {
 export default function useViewportFeatures(
   source,
   uniqueIdProperty,
-  debounceTimeOut = 500
+  debounceTimeout = 500
 ) {
   const dispatch = useDispatch();
   const viewport = useSelector((state) => state.carto.viewport);
@@ -73,7 +73,7 @@ export default function useViewportFeatures(
       } finally {
         clearDebounce();
       }
-    }, debounceTimeOut),
+    }, debounceTimeout),
     [setSourceViewportFeaturesReady]
   );
 
@@ -91,7 +91,7 @@ export default function useViewportFeatures(
         if (error.name === 'AbortError') return;
         throw error;
       }
-    }, debounceTimeOut),
+    }, debounceTimeout),
     [setSourceViewportFeaturesReady]
   );
 

--- a/packages/react-core/src/utils/debounce.js
+++ b/packages/react-core/src/utils/debounce.js
@@ -6,5 +6,6 @@ export function debounce(fn, ms) {
       timer = null;
       fn.apply(this, args);
     }, ms);
+    return timer;
   };
 }


### PR DESCRIPTION
Story details: https://app.shortcut.com/cartoteam/story/148156

Approach:

I store in a ref the timeoutId of the debounced function. Everytime that an update in tiles or viewport can happens, the debounce is cleared.
Using fetch, we know that a tile is being fetched. Knowing that, we can stop the debounce because we know in advance that in a few seconds a tile will be loaded, avoiding unnecessary calculations.