### PR TITLE
Manage widgets selections through filters so they are more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Not released
 
-- Widgets with filters, use filters to derive its own "filter" state from redux state, instead of local state [224](https://github.com/CartoDB/carto-react/pull/224)
+- `CategoryWidget`, `HistogramWidget`, `PieWidget` use filters in datasource to derive selected
+  items (categories, bars) instead of local react state [224](https://github.com/CartoDB/carto-react/pull/224)
 
 ## 1.1.0 (2021-10-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Widgets with filters, use filters to derive its own "filter" state from redux state, instead of local state [224](https://github.com/CartoDB/carto-react/pull/224)
+
 ## 1.1.0 (2021-10-29)
 
 - Histogram tooltip formatter receiving dataIndex and ticks [#220](https://github.com/CartoDB/carto-react/pull/220)

--- a/packages/react-widgets/src/hooks/useWidgetFilterValues.js
+++ b/packages/react-widgets/src/hooks/useWidgetFilterValues.js
@@ -1,0 +1,26 @@
+import { selectSourceById } from '@carto/react-redux/';
+import { useSelector } from 'react-redux';
+import useCustomCompareMemo from './useCustomCompareMemo';
+import { dequal as deepEqual } from 'dequal';
+
+/**
+ * Obtain current widgets's filter values.
+ *
+ * @param  {object} props
+ * @param  {string} props.dataSource - ID of the source to get the filters from.
+ * @param  {string} props.id - ID of the widget that apply the filter you want to exclude.
+ * @param  {string} props.column - name of column of this widget.
+ * @param  {string} props.type - type of filter
+ */
+export function useWidgetFilterValues({ dataSource, id, column, type }) {
+  const columnFilters = useSelector((state) => {
+    // TODO: id ?
+    const dataSourceState = selectSourceById(state, dataSource);
+    const filterTypes = dataSourceState?.filters ? dataSourceState?.filters[column] : {};
+
+    console.log('useWidgetOwnFilters', dataSource, id, filterTypes);
+    return filterTypes ? filterTypes[type]?.values : null;
+  });
+
+  return useCustomCompareMemo(columnFilters, deepEqual);
+}

--- a/packages/react-widgets/src/hooks/useWidgetFilterValues.js
+++ b/packages/react-widgets/src/hooks/useWidgetFilterValues.js
@@ -4,22 +4,23 @@ import useCustomCompareMemo from './useCustomCompareMemo';
 import { dequal as deepEqual } from 'dequal';
 
 /**
- * Obtain current widgets's filter values.
+ * Obtain widget's filter values.
  *
  * @param  {object} props
  * @param  {string} props.dataSource - ID of the source to get the filters from.
- * @param  {string} props.id - ID of the widget that apply the filter you want to exclude.
+ * @param  {string} props.id - ID of the widget that applied the filter.
  * @param  {string} props.column - name of column of this widget.
  * @param  {string} props.type - type of filter
  */
 export function useWidgetFilterValues({ dataSource, id, column, type }) {
   const columnFilters = useSelector((state) => {
-    // TODO: id ?
     const dataSourceState = selectSourceById(state, dataSource);
-    const filterTypes = dataSourceState?.filters ? dataSourceState?.filters[column] : {};
 
-    console.log('useWidgetOwnFilters', dataSource, id, filterTypes);
-    return filterTypes ? filterTypes[type]?.values : null;
+    const filter = dataSourceState?.filters?.[column]?.[type];
+    if (!filter || filter.owner !== id) {
+      return null;
+    }
+    return filter.values;
   });
 
   return useCustomCompareMemo(columnFilters, deepEqual);

--- a/packages/react-widgets/src/hooks/useWidgetFilterValues.js
+++ b/packages/react-widgets/src/hooks/useWidgetFilterValues.js
@@ -1,7 +1,6 @@
 import { selectSourceById } from '@carto/react-redux/';
 import { useSelector } from 'react-redux';
-import useCustomCompareMemo from './useCustomCompareMemo';
-import { dequal as deepEqual } from 'dequal';
+import { useMemo } from 'react';
 
 /**
  * Obtain widget's filter values.
@@ -13,15 +12,13 @@ import { dequal as deepEqual } from 'dequal';
  * @param  {string} props.type - type of filter
  */
 export function useWidgetFilterValues({ dataSource, id, column, type }) {
-  const columnFilters = useSelector((state) => {
-    const dataSourceState = selectSourceById(state, dataSource);
+  const { filters } = useSelector((state) => selectSourceById(state, dataSource) || {});
 
-    const filter = dataSourceState?.filters?.[column]?.[type];
+  return useMemo(() => {
+    const filter = filters?.[column]?.[type];
     if (!filter || filter.owner !== id) {
       return null;
     }
     return filter.values;
-  });
-
-  return useCustomCompareMemo(columnFilters, deepEqual);
+  }, [filters, column, type, id]);
 }

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -7,6 +7,9 @@ import { _FilterTypes as FilterTypes, AggregationTypes } from '@carto/react-core
 import { getCategories } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
 import { selectIsViewportFeaturesReadyForSource } from '@carto/react-redux/';
+import { useWidgetFilterValues } from '../hooks/useWidgetFilterValues';
+
+const EMPTY_ARRAY = [];
 
 /**
  * Renders a <CategoryWidget /> component
@@ -46,10 +49,13 @@ function CategoryWidget(props) {
   );
 
   const [categoryData, setCategoryData] = useState([]);
-  const [selectedCategories, setSelectedCategories] = useState([]);
+
   const [isLoading, setIsLoading] = useState(true);
 
   const filters = useSourceFilters({ dataSource, id });
+  const selectedCategories =
+    useWidgetFilterValues({ dataSource, id, column, type: FilterTypes.IN }) ||
+    EMPTY_ARRAY;
 
   useEffect(() => {
     setIsLoading(true);
@@ -87,8 +93,6 @@ function CategoryWidget(props) {
 
   const handleSelectedCategoriesChange = useCallback(
     (categories) => {
-      setSelectedCategories(categories);
-
       if (categories && categories.length) {
         dispatch(
           addFilter({
@@ -108,7 +112,7 @@ function CategoryWidget(props) {
         );
       }
     },
-    [column, dataSource, id, setSelectedCategories, dispatch]
+    [column, dataSource, id, dispatch]
   );
 
   return (

--- a/packages/react-widgets/src/widgets/PieWidget.js
+++ b/packages/react-widgets/src/widgets/PieWidget.js
@@ -7,6 +7,9 @@ import { _FilterTypes as FilterTypes, AggregationTypes } from '@carto/react-core
 import { getCategories } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
 import { selectIsViewportFeaturesReadyForSource } from '@carto/react-redux/';
+import { useWidgetFilterValues } from '../hooks/useWidgetFilterValues';
+
+const EMPTY_ARRAY = [];
 
 /**
  * Renders a <PieWidget /> component
@@ -46,7 +49,9 @@ function PieWidget({
   const dispatch = useDispatch();
 
   const [categoryData, setCategoryData] = useState([]);
-  const [selectedCategories, setSelectedCategories] = useState([]);
+  const selectedCategories =
+    useWidgetFilterValues({ dataSource, id, column, type: FilterTypes.IN }) ||
+    EMPTY_ARRAY;
   const [isLoading, setIsLoading] = useState(true);
 
   const isSourceReady = useSelector((state) =>
@@ -90,8 +95,6 @@ function PieWidget({
 
   const handleSelectedCategoriesChange = useCallback(
     (categories) => {
-      setSelectedCategories(categories);
-
       if (categories && categories.length) {
         dispatch(
           addFilter({
@@ -111,7 +114,7 @@ function PieWidget({
         );
       }
     },
-    [column, dataSource, id, setSelectedCategories, dispatch]
+    [column, dataSource, id, dispatch]
   );
 
   return (


### PR DESCRIPTION
Widgets that affect datasource filters, use filters state in redux, to derive its own "filter/selection", instead of local state.

- [x] CategoryWidget
- [x] HistogramWidget
- [x] PieWidget
- [x] ~TimeSeriesWidget~ (not in scope)

Story details: https://app.shortcut.com/cartoteam/story/192425