### PR TITLE
Fix CategoryWidget values during animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix CategoryWidget values during animation [#230](https://github.com/CartoDB/carto-react/pull/230)
+
 ## 1.1.1 (2021-11-23)
 
 - Improve Widgets calculations sync with tiles [#223](https://github.com/CartoDB/carto-react/pull/223)

--- a/packages/react-ui/src/widgets/utils/animations.js
+++ b/packages/react-ui/src/widgets/utils/animations.js
@@ -48,10 +48,14 @@ export function animateValues({ start, end, duration, drawFrame, requestRef }) {
 
   const animate = () => {
     if (currentFrame < frames) {
-      currentValues = currentValues.map((elem, i) => ({
-        ...elem,
-        value: Math.round(elem.value + steps[i])
-      }));
+      currentValues = currentValues.map((elem, i) => {
+        const value = Math.floor(elem.value + steps[i]);
+        const prevValue = i > 0 && Math.floor(elem.value + steps[i - 1]);
+        return {
+          ...elem,
+          value: value === prevValue ? end[i]?.value : value
+        };
+      });
       drawFrame(currentValues);
       currentFrame++;
       requestRef.current = requestAnimationFrame(animate);

--- a/packages/react-ui/src/widgets/utils/animations.js
+++ b/packages/react-ui/src/widgets/utils/animations.js
@@ -50,7 +50,7 @@ export function animateValues({ start, end, duration, drawFrame, requestRef }) {
     if (currentFrame < frames) {
       currentValues = currentValues.map((elem, i) => ({
         ...elem,
-        value: elem.value + steps[i]
+        value: Math.round(elem.value + steps[i])
       }));
       drawFrame(currentValues);
       currentFrame++;

--- a/packages/react-ui/src/widgets/utils/animations.js
+++ b/packages/react-ui/src/widgets/utils/animations.js
@@ -49,6 +49,9 @@ export function animateValues({ start, end, duration, drawFrame, requestRef }) {
   const animate = () => {
     if (currentFrame < frames) {
       currentValues = currentValues.map((elem, i) => {
+        // We use Math.floor to avoid displaying a long list of decimals during animation
+        // this happens especially when we don't have a formatting function for the widget
+        // TODO If values are between 0 and 1 we would not have animation effect
         const value = Math.floor(elem.value + steps[i]);
         const prevValue = i > 0 && Math.floor(elem.value + steps[i - 1]);
         return {


### PR DESCRIPTION
During the animation, the category widget shows a lot of decimals. After talking with Jose, we agree that has no sense to show decimals during the animation