### PR TITLE
Make Histogram more flexible, accepting filters with null to select bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## Not released
+- Histogram takes into account null values in filters for selected bars [#234](https://github.com/CartoDB/carto-react/pull/234)
 
 ## 1.1.2 (2021-12-01)
 

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -65,9 +65,9 @@ function HistogramWidget(props) {
   const selectedBars = useMemo(() => {
     return (thresholdsFromFilters || EMPTY_ARRAY)
       .map(([from, to]) => {
-        if (typeof from === 'undefined') {
+        if (typeof from === 'undefined' || from === null) {
           return 0;
-        } else if (typeof to === 'undefined') {
+        } else if (typeof to === 'undefined' || to === null) {
           return ticks.length - 1;
         } else {
           const idx = ticks.indexOf(from);


### PR DESCRIPTION
Histogram uses `undefined` value to save the value of its filters if you filter using the first column. The problem is that `stringify` an undefined value in array returns a null value so you cannot recover the selected bar from a stored configuration.