### PR TITLE
Avoid unuseful view state updates

### DIFF
--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -3,6 +3,7 @@ import { WebMercatorViewport } from '@deck.gl/core';
 import { debounce } from '@carto/react-core';
 import { removeWorker } from '@carto/react-workers';
 import { setDefaultCredentials } from '@deck.gl/carto';
+import { dequal } from 'dequal';
 
 /**
  *
@@ -87,8 +88,7 @@ export const createCartoSlice = (initialState) => {
         state.basemap = action.payload;
       },
       setViewState: (state, action) => {
-        const viewState = action.payload;
-        state.viewState = { ...state.viewState, ...viewState };
+        state.viewState = action.payload;
       },
       setViewPort: (state) => {
         state.viewport = new WebMercatorViewport(state.viewState).getBounds();
@@ -254,7 +254,7 @@ export const selectIsViewportFeaturesReadyForSource = (state, id) =>
 
 const debouncedSetViewPort = debounce((dispatch, setViewPort) => {
   dispatch(setViewPort());
-}, 200);
+}, 25);
 
 const NOT_ALLOWED_DECK_PROPS = [
   'transitionDuration',
@@ -268,7 +268,7 @@ const NOT_ALLOWED_DECK_PROPS = [
  * @param {Object} viewState
  */
 export const setViewState = (viewState) => {
-  return (dispatch) => {
+  return (dispatch, getState) => {
     /**
      * "transition" deck props contain non-serializable values, like:
      *  - transitionInterpolator: instance of LinearInterpolator
@@ -280,8 +280,13 @@ export const setViewState = (viewState) => {
       delete viewState[viewProp];
     }
 
-    dispatch(_setViewState(viewState));
-    debouncedSetViewPort(dispatch, _setViewPort);
+    const { carto: currentState } = getState();
+    const newViewState = { ...currentState.viewState, ...viewState };
+    // Deep compare current viewState and the new one.
+    if (!dequal(currentState.viewState, newViewState)) {
+      dispatch(_setViewState(newViewState));
+      debouncedSetViewPort(dispatch, _setViewPort);
+    }
   };
 };
 


### PR DESCRIPTION
### FAQs

- Why have you reduced viewport update debounce time?
  - To make it almost invisible. We also have a debounce in useFeatures hooks, this is almost not needed. The point to use a minimal debounce is that setViewState is called many many times while zooming, which is awful, so a minimal debounce is still needed.

- Why are you deep comparing view state?
  - Because some calles are made with the same view state, and that causes duplicated calculations.