### PR TITLE
Fix TS type declarations for BasemapName and CartoSlice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Refactor useViewportFeatures [#238](https://github.com/CartoDB/carto-react/pull/238)
 - Add clear button for TimeSeriesWidget widget and enable the speed button even though the animation has not started  [#239](https://github.com/CartoDB/carto-react/pull/239)
 - Improve timeseries animation performance [#243](https://github.com/CartoDB/carto-react/pull/243)
+- Fix TS type declarations for BasemapName and CartoSlice [#248](https://github.com/CartoDB/carto-react/pull/248) 
 
 ## 1.1.3 (2021-12-04)
 

--- a/packages/react-redux/src/slices/cartoSlice.d.ts
+++ b/packages/react-redux/src/slices/cartoSlice.d.ts
@@ -1,7 +1,8 @@
 import { Credentials } from '@carto/react-api/';
 import { SourceProps } from '@carto/react-api/types';
 import { CartoBasemapsNames, GMapsBasemapsNames } from '@carto/react-basemaps/';
-import { InitialCartoState, Reducer, ViewState } from '../types';
+import { InitialCartoState, ViewState } from '../types';
+import { AnyAction, Reducer } from 'redux';
 
 type Source = SourceProps & { id: string } & { filters?: any};
 
@@ -57,7 +58,7 @@ declare enum CartoActions {
   SET_CREDENTIALS = 'carto/setCredentials'
 }
 
-export function createCartoSlice(initialState: InitialCartoState): Reducer;
+export function createCartoSlice(initialState: InitialCartoState): Reducer<any, AnyAction>;
 
 export function addSource(
   source: Source

--- a/packages/react-redux/src/slices/cartoSlice.d.ts
+++ b/packages/react-redux/src/slices/cartoSlice.d.ts
@@ -12,7 +12,7 @@ type Layer = {
   layerAttributes?: object;
 };
 
-type BasemapName = CartoBasemapsNames & GMapsBasemapsNames;
+type BasemapName = CartoBasemapsNames | GMapsBasemapsNames;
 
 type FilterBasic = {
   type: '';

--- a/packages/react-redux/src/slices/cartoSlice.d.ts
+++ b/packages/react-redux/src/slices/cartoSlice.d.ts
@@ -2,7 +2,7 @@ import { Credentials } from '@carto/react-api/';
 import { SourceProps } from '@carto/react-api/types';
 import { CartoBasemapsNames, GMapsBasemapsNames } from '@carto/react-basemaps/';
 import { InitialCartoState, CartoState, ViewState } from '../types';
-import { AnyAction, Reducer, State } from 'redux';
+import { AnyAction, Reducer } from 'redux';
 
 type Source = SourceProps & { id: string } & { filters?: any};
 

--- a/packages/react-redux/src/slices/cartoSlice.d.ts
+++ b/packages/react-redux/src/slices/cartoSlice.d.ts
@@ -1,8 +1,8 @@
 import { Credentials } from '@carto/react-api/';
 import { SourceProps } from '@carto/react-api/types';
 import { CartoBasemapsNames, GMapsBasemapsNames } from '@carto/react-basemaps/';
-import { InitialCartoState, ViewState } from '../types';
-import { AnyAction, Reducer } from 'redux';
+import { InitialCartoState, CartoState, ViewState } from '../types';
+import { AnyAction, Reducer, State } from 'redux';
 
 type Source = SourceProps & { id: string } & { filters?: any};
 
@@ -58,7 +58,7 @@ declare enum CartoActions {
   SET_CREDENTIALS = 'carto/setCredentials'
 }
 
-export function createCartoSlice(initialState: InitialCartoState): Reducer<any, AnyAction>;
+export function createCartoSlice(initialState: InitialCartoState): Reducer<CartoState, AnyAction>;
 
 export function addSource(
   source: Source

--- a/packages/react-redux/src/slices/oauthSlice.d.ts
+++ b/packages/react-redux/src/slices/oauthSlice.d.ts
@@ -1,5 +1,6 @@
 import { OauthApp } from '@carto/react-auth/';
-import { InitialOauthState, Reducer } from '../types';
+import { InitialOauthState, OauthState } from '../types';
+import { AnyAction, Reducer } from 'redux';
 
 type OauthParams = {
   accessToken: string,
@@ -18,7 +19,7 @@ declare enum OauthActions {
   LOGOUT = 'oauth/logout'
 }
 
-export function createOauthCartoSlice(initialState: InitialOauthState): Reducer;
+export function createOauthCartoSlice(initialState: InitialOauthState): Reducer<OauthState, AnyAction>;
 
 export function setOAuthApp(arg: OauthApp): {
   type: OauthActions.SET_OAUTH_APP,

--- a/packages/react-redux/src/types.d.ts
+++ b/packages/react-redux/src/types.d.ts
@@ -2,7 +2,6 @@ import { Credentials } from '@carto/react-api';
 import { OauthApp } from '@carto/react-auth';
 import { CartoBasemapsNames } from '@carto/react-basemaps';
 import { Viewport } from '@carto/react-core';
-import { AnyAction } from 'redux';
 
 export type ViewState = {
   latitude?: number,
@@ -54,8 +53,3 @@ export type OauthState = {
   token: string,
   userInfo: string
 } & InitialOauthState;
-
-export type Reducer = {
-  state: CartoState | OauthState,
-  action: AnyAction
-}


### PR DESCRIPTION
Hello team! I've found some Typescript errors when setting up [a new project](https://github.com/cartodb/initiative-vision) from the template with Carto3 and Typescript and I saw a very easy correction of them so I created this PR. Let me know if you need any more context, tests, docs or anything like that

There are two changes in this PR:
* changing the type of the `createCartoSlice` function. Instead of using the custom `Reducer` type from the `types.ts` file of the C4R library, we are importing the `Reducer` type from `redux`. This is a generic type, and as such, it should be defined as `Reducer<any, AnyAction>`. The VS Code tooltips let me know about this when I saw that the types for adding the cartoSlice to the store in the TS-template were not matching the redux types.

* changing the type of `BasemapName` from using `&` to using `|`. The `&` operator in Typescript creates an intersection between types that does not work for joining two enum types together. I learned about that [here](https://stackoverflow.com/questions/48478361/how-to-merge-two-enums-in-typescript) when I was debugging why VS Code was again complaining in the basemap references scattered across the template. After much research, try, and error, I discovered that you just need to change the `&` for an `|` to mean "This type represents values from this enum OR this other enum"

Edit:
Following @Clebal comment and the [redux-typescript documentation](https://redux.js.org/usage/usage-with-typescript#type-checking-reducers) I've changed the `cartoSlice` type to further indicate the types of the reducer using `Reducer<CartoState, AnyAction>`

