### PR TITLE
Remove sortBy prop default value

### DIFF
--- a/packages/react-workers/src/workers/features.worker.js
+++ b/packages/react-workers/src/workers/features.worker.js
@@ -164,7 +164,7 @@ function getRawFeatures({
   filters,
   limit = 10,
   page = 1,
-  sortBy = [],
+  sortBy,
   sortByDirection = 'asc'
 }) {
   let data = [];


### PR DESCRIPTION
Using `[]` as default sortBy value makes the execution to break due to it's an invalid sortBy value.