### PR TITLE
Fix: add DrawingToolWidget and DrawingToolLayer to index.d.ts

### DIFF
--- a/packages/react-widgets/src/index.d.ts
+++ b/packages/react-widgets/src/index.d.ts
@@ -14,3 +14,5 @@ export {
 } from './models';
 export { default as TimeSeriesWidget } from './widgets/TimeSeriesWidget';
 export { default as useSourceFilters } from './hooks/useSourceFilters';
+export { default as DrawingToolWidget } from './widgets/DrawingToolWidget';
+export { default as DrawingToolLayer } from './layers/DrawingToolLayer';


### PR DESCRIPTION
If DrawingToolLayer and DrawingToolLayer are not exported in the index.d.ts they cannot be used in typescripts projects 