### PR TITLE
Fix: DrawingToolLayer disables interactivity of the layers behind it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix: DrawingToolLayer disables interactivity of the layers behind it [#263](https://github.com/CartoDB/carto-react/pull/263)
+
 ## 1.2.0-alpha.0 (2021-12-30)
 
 - Track clientId for tracing purposes [#261](https://github.com/CartoDB/carto-react/pull/261)

--- a/packages/react-widgets/src/layers/DrawingToolLayer.js
+++ b/packages/react-widgets/src/layers/DrawingToolLayer.js
@@ -52,7 +52,7 @@ export default function DrawingToolLayer() {
 
   return new EditableGeoJsonLayer({
     id: 'DrawingToolLayer',
-    pickable: isEdit,
+    pickable: !!selectedMode,
     data: {
       type: 'FeatureCollection',
       features: spatialFilterGeometry ? [spatialFilterGeometry] : []

--- a/packages/react-widgets/src/layers/DrawingToolLayer.js
+++ b/packages/react-widgets/src/layers/DrawingToolLayer.js
@@ -52,6 +52,7 @@ export default function DrawingToolLayer() {
 
   return new EditableGeoJsonLayer({
     id: 'DrawingToolLayer',
+    pickable: isEdit,
     data: {
       type: 'FeatureCollection',
       features: spatialFilterGeometry ? [spatialFilterGeometry] : []


### PR DESCRIPTION
When you finish drawing, all layers behind the DrawingToolLayer lose their interactivity. For example, all these layers will not show their popup. To solve it we disable the pick DrawingToolLayer property unless you're editing or drawing