### PR TITLE
Use zero-based pagination for getRawFeatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix: use 0-based pagination in raw feature access and TableWidget [#265](https://github.com/CartoDB/carto-react/pull/265)
+
 ## 1.2.0-alpha.2 (2022-01-03)
 
 - Fix: DrawingToolLayer disables interactivity of the layers behind it [#263](https://github.com/CartoDB/carto-react/pull/263)

--- a/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
+++ b/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
@@ -81,12 +81,12 @@ function TableWidgetUI({
   };
 
   const handleChangePage = (_event, newPage) => {
-    onSetPage(newPage + 1);
+    onSetPage(newPage);
   };
 
   const handleChangeRowsPerPage = (event) => {
     onSetRowsPerPage(parseInt(event.target.value, 10));
-    onSetPage(1);
+    onSetPage(0);
   };
 
   return (
@@ -110,7 +110,7 @@ function TableWidgetUI({
           component='div'
           count={totalCount}
           rowsPerPage={rowsPerPage}
-          page={page - 1}
+          page={page}
           onPageChange={handleChangePage}
           onRowsPerPageChange={handleChangeRowsPerPage}
         />

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -27,7 +27,7 @@ function TableWidget({
   onError
 }) {
   const [rowsPerPage, setRowsPerPage] = useState(10);
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useState(0);
   const [totalCount, setTotalCount] = useState(0);
 
   const [sortBy, setSortBy] = useState(undefined);
@@ -41,8 +41,8 @@ function TableWidget({
   );
 
   useEffect(() => {
-    // force reset the page to 1 when the viewport or filters change
-    setPage(1);
+    // force reset the page to 0 when the viewport or filters change
+    setPage(0);
   }, [dataSource, isSourceReady, filters]);
 
   useEffect(() => {

--- a/packages/react-workers/src/workers/features.worker.js
+++ b/packages/react-workers/src/workers/features.worker.js
@@ -163,7 +163,7 @@ function getTimeSeries({ filters, column, stepSize, operation, operationColumn }
 function getRawFeatures({
   filters,
   limit = 10,
-  page = 1,
+  page = 0,
   sortBy,
   sortByDirection = 'asc'
 }) {
@@ -191,7 +191,7 @@ function getRawFeatures({
 }
 
 function applyPagination(features, { limit, page }) {
-  return features.slice(limit * Math.max(0, page - 1), limit * Math.max(1, page));
+  return features.slice(limit * Math.max(0, page), limit * Math.max(1, page + 1));
 }
 
 function getFilteredFeatures(filters = {}) {


### PR DESCRIPTION
Small adjustment on the TableWidget and getRawFeatures, following discussion with @Clebal https://github.com/CartoDB/carto-react/pull/154#discussion_r775987648

Instead of using a 1-based pagination, let's switch to 0-based. This makes it consistent with MUI pagination.