### PR TITLE
Fix too long labels in CategoryWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add initialCollapsed prop to LegendWidget [#282](https://github.com/CartoDB/carto-react/pull/282)
 - Fix executeSQL typing [#280](https://github.com/CartoDB/carto-react/pull/280)
 - Fix widget long name going out of the frame [#266](https://github.com/CartoDB/carto-react/pull/266)
+- Fix too long labels in CategoryWidget [#267](https://github.com/CartoDB/carto-react/pull/267)
 
 ## 1.2.1-alpha.3 (2022-01-18)
 

--- a/packages/react-ui/src/widgets/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI.js
@@ -10,7 +10,8 @@ import {
   SvgIcon,
   TextField,
   Typography,
-  makeStyles
+  makeStyles,
+  Tooltip
 } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 
@@ -29,6 +30,7 @@ const useStyles = makeStyles((theme) => ({
 
   element: {
     cursor: 'pointer',
+    flexWrap: 'nowrap',
 
     '&$unselected': {
       color: theme.palette.text.disabled,
@@ -48,7 +50,8 @@ const useStyles = makeStyles((theme) => ({
   },
 
   label: {
-    fontWeight: theme.typography.fontWeightBold
+    fontWeight: theme.typography.fontWeightBold,
+    marginRight: theme.spacing(2)
   },
 
   progressbar: {
@@ -367,6 +370,22 @@ function CategoryWidgetUI(props) {
   const CategoryItem = (props) => {
     const { data, onCategoryClick } = props;
     const value = formatter(data.value || 0);
+    const [isOverflowed, setIsOverflowed] = useState(false);
+    const textElementRef = useRef();
+
+    const compareSize = () => {
+      const compare =
+        textElementRef?.current?.scrollWidth > textElementRef?.current?.clientWidth;
+      setIsOverflowed(compare);
+    };
+
+    useEffect(() => {
+      compareSize();
+      window.addEventListener('resize', compareSize);
+      return () => {
+        window.removeEventListener('resize', compareSize);
+      };
+    }, []);
 
     return (
       <Grid
@@ -392,8 +411,27 @@ function CategoryWidgetUI(props) {
           </Grid>
         )}
         <Grid container item xs>
-          <Grid container item direction='row' justifyContent='space-between'>
-            <span className={classes.label}>{getCategoryLabel(data.name)}</span>
+          <Grid
+            container
+            item
+            direction='row'
+            justifyContent='space-between'
+            wrap='nowrap'
+          >
+            <Tooltip
+              title={getCategoryLabel(data.name)}
+              disableHoverListener={!isOverflowed}
+            >
+              <Typography
+                variant='body2'
+                className={classes.label}
+                noWrap
+                zeroMinWidth
+                ref={textElementRef}
+              >
+                {getCategoryLabel(data.name)}
+              </Typography>
+            </Tooltip>
             {typeof value === 'object' && value !== null ? (
               <span>
                 {value.prefix}
@@ -428,9 +466,10 @@ function CategoryWidgetUI(props) {
       <Grid container item className={classes.categoriesWrapper}>
         {[...Array(4)].map((_, i) => (
           <Grid key={i} container direction='row' spacing={1} className={classes.element}>
-            <Grid container item xs>
+            <Grid container item xs zeroMinWidth>
               <Grid container item direction='row' justifyContent='space-between'>
-                <Typography variant='body2'>
+                <Typography variant='body2' noWrap>
+                  plop
                   <Skeleton variant='text' width={100} />
                 </Typography>
                 <Typography variant='body2'>

--- a/packages/react-ui/src/widgets/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI.js
@@ -472,7 +472,6 @@ function CategoryWidgetUI(props) {
             <Grid container item xs zeroMinWidth>
               <Grid container item direction='row' justifyContent='space-between'>
                 <Typography variant='body2' noWrap>
-                  plop
                   <Skeleton variant='text' width={100} />
                 </Typography>
                 <Typography variant='body2'>


### PR DESCRIPTION
Shortcut link: https://app.shortcut.com/cartoteam/story/198551/category-widgets-if-the-label-is-too-long-the-data-jumps-the-line-losing-its-natural-location

Always display category label and data on one line, text overflow ellipsis and tooltip if category label is too long.