### PR TITLE
Disable interactivity for widgets

### DIFF
--- a/packages/react-ui/src/widgets/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI.js
@@ -27,9 +27,15 @@ const useStyles = makeStyles((theme) => ({
     padding: theme.spacing(0, 1, 1, 0)
   },
 
-  element: {
+  selectable: {
     cursor: 'pointer',
 
+    '&:hover $progressbar div': {
+      backgroundColor: theme.palette.secondary.dark
+    }
+  },
+
+  element: {
     '&$unselected': {
       color: theme.palette.text.disabled,
 
@@ -40,10 +46,6 @@ const useStyles = makeStyles((theme) => ({
 
     '&$rest $progressbar div': {
       backgroundColor: theme.palette.text.disabled
-    },
-
-    '&:hover $progressbar div': {
-      backgroundColor: theme.palette.secondary.dark
     }
   },
 
@@ -132,11 +134,11 @@ function CategoryWidgetUI(props) {
     data,
     formatter,
     labels,
-    isLoading,
     maxItems,
     order,
     selectedCategories,
-    animation
+    animation,
+    filterable
   } = props;
   const [sortedData, setSortedData] = useState([]);
   const [maxValue, setMaxValue] = useState(1);
@@ -148,7 +150,7 @@ function CategoryWidgetUI(props) {
   const requestRef = useRef();
   const prevAnimValues = usePrevious(animValues);
   const referencedPrevAnimValues = useRef();
-  const classes = useStyles();
+  const classes = useStyles({ filterable });
 
   // Get blockedCategories in the same order as original data
   const sortBlockedSameAsData = (blockedCategories) =>
@@ -373,9 +375,10 @@ function CategoryWidgetUI(props) {
         container
         direction='row'
         spacing={1}
-        onClick={onCategoryClick}
+        onClick={filterable ? onCategoryClick : () => {}}
         className={`
           ${classes.element}
+          ${filterable ? classes.selectable : ''}
           ${
             !showAll &&
             selectedCategories.length > 0 &&
@@ -386,7 +389,7 @@ function CategoryWidgetUI(props) {
           ${data.name === REST_CATEGORY ? classes.rest : ''}
         `}
       >
-        {showAll && (
+        {filterable && showAll && (
           <Grid item>
             <Checkbox checked={tempBlockedCategories.indexOf(data.name) !== -1} />
           </Grid>
@@ -449,7 +452,7 @@ function CategoryWidgetUI(props) {
     <div className={classes.root}>
       {data?.length > 0 ? (
         <>
-          {sortedData.length > 0 && (
+          {filterable && sortedData.length > 0 && (
             <Grid
               container
               direction='row'
@@ -565,7 +568,8 @@ CategoryWidgetUI.defaultProps = {
   maxItems: 5,
   order: CategoryWidgetUI.ORDER_TYPES.RANKING,
   selectedCategories: [],
-  animation: true
+  animation: true,
+  filterable: true
 };
 
 CategoryWidgetUI.propTypes = {

--- a/packages/react-ui/src/widgets/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI.js
@@ -196,7 +196,8 @@ function HistogramWidgetUI(props) {
     xAxisFormatter,
     yAxisFormatter,
     height = theme.spacing(22),
-    animation
+    animation,
+    filterable
   } = props;
 
   const classes = useStyles();
@@ -264,7 +265,7 @@ function HistogramWidgetUI(props) {
 
   return (
     <div>
-      {onSelectedBarsChange && (
+      {filterable && onSelectedBarsChange && (
         <Grid
           container
           direction='row'
@@ -287,7 +288,7 @@ function HistogramWidgetUI(props) {
           ref={chartInstance}
           option={options}
           lazyUpdate={true}
-          onEvents={onEvents}
+          onEvents={filterable && onEvents}
           style={{ height }}
         />
       )}
@@ -303,7 +304,8 @@ HistogramWidgetUI.defaultProps = {
   dataAxis: [],
   name: null,
   onSelectedBarsChange: null,
-  animation: true
+  animation: true,
+  filterable: true
 };
 
 HistogramWidgetUI.propTypes = {
@@ -316,7 +318,8 @@ HistogramWidgetUI.propTypes = {
   name: PropTypes.string,
   onSelectedBarsChange: PropTypes.func,
   height: PropTypes.number,
-  animation: PropTypes.bool
+  animation: PropTypes.bool,
+  filterable: PropTypes.bool
 };
 
 export default HistogramWidgetUI;

--- a/packages/react-ui/src/widgets/PieWidgetUI.js
+++ b/packages/react-ui/src/widgets/PieWidgetUI.js
@@ -149,6 +149,7 @@ function PieWidgetUI({
   labels,
   colors,
   animation,
+  filterable,
   selectedCategories,
   onSelectedCategoriesChange
 }) {
@@ -286,11 +287,11 @@ function PieWidgetUI({
 
   const onEvents = useMemo(
     () => ({
-      click: clickEvent,
+      ...(filterable && { click: clickEvent }),
       mouseover: mouseoverEvent,
       mouseout: mouseoutEvent
     }),
-    [clickEvent, mouseoverEvent, mouseoutEvent]
+    [filterable, clickEvent, mouseoverEvent, mouseoutEvent]
   );
 
   return (

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -23,7 +23,7 @@ const EMPTY_ARRAY = [];
  * @param  {Function} [props.formatter] - Function to format each value returned.
  * @param  {Object} [props.labels] - Overwrite category labels.
  * @param  {boolean} [props.animation] - Enable/disable widget animations on data updates. Enabled by default.
- * @param  {boolean} [props.filterable] - Enable/disable widget filter capabilities. Enabled by default.
+ * @param  {boolean} [props.filterable] - Enable/disable widget filtering capabilities. Enabled by default.
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  * @param  {Object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]()

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -23,6 +23,7 @@ const EMPTY_ARRAY = [];
  * @param  {Function} [props.formatter] - Function to format each value returned.
  * @param  {Object} [props.labels] - Overwrite category labels.
  * @param  {boolean} [props.animation] - Enable/disable widget animations on data updates. Enabled by default.
+ * @param  {boolean} [props.filterable] - Enable/disable widget filter capabilities. Enabled by default.
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  * @param  {Object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]()
@@ -38,6 +39,7 @@ function CategoryWidget(props) {
     formatter,
     labels,
     animation,
+    filterable,
     onError,
     wrapperProps,
     noDataAlertProps
@@ -125,6 +127,7 @@ function CategoryWidget(props) {
           selectedCategories={selectedCategories}
           onSelectedCategoriesChange={handleSelectedCategoriesChange}
           animation={animation}
+          filterable={filterable}
         />
       ) : (
         <NoDataAlert {...noDataAlertProps} />
@@ -143,6 +146,7 @@ CategoryWidget.propTypes = {
   formatter: PropTypes.func,
   labels: PropTypes.object,
   animation: PropTypes.bool,
+  filterable: PropTypes.bool,
   onError: PropTypes.func,
   wrapperProps: PropTypes.object,
   noDataAlertProps: PropTypes.object
@@ -151,6 +155,7 @@ CategoryWidget.propTypes = {
 CategoryWidget.defaultProps = {
   labels: {},
   animation: true,
+  filterable: true,
   wrapperProps: {},
   noDataAlertProps: {}
 };

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -24,7 +24,7 @@ const EMPTY_ARRAY = [];
  * @param  {Function} [props.formatter] - Function to format Y axis values.
  * @param  {boolean} [props.tooltip=true] - Whether to show a tooltip or not
  * @param  {boolean} [props.animation] - Enable/disable widget animations on data updates. Enabled by default.
- * @param  {boolean} [props.filterable] - Enable/disable widget filter capabilities. Enabled by default.
+ * @param  {boolean} [props.filterable] - Enable/disable widget filtering capabilities. Enabled by default.
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  * @param  {Object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]()

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -24,6 +24,7 @@ const EMPTY_ARRAY = [];
  * @param  {Function} [props.formatter] - Function to format Y axis values.
  * @param  {boolean} [props.tooltip=true] - Whether to show a tooltip or not
  * @param  {boolean} [props.animation] - Enable/disable widget animations on data updates. Enabled by default.
+ * @param  {boolean} [props.filterable] - Enable/disable widget filter capabilities. Enabled by default.
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  * @param  {Object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]()
@@ -41,6 +42,7 @@ function HistogramWidget(props) {
     formatter,
     tooltip,
     animation,
+    filterable,
     onError,
     wrapperProps,
     noDataAlertProps
@@ -177,6 +179,7 @@ function HistogramWidget(props) {
           xAxisFormatter={xAxisFormatter}
           yAxisFormatter={formatter}
           animation={animation}
+          filterable={filterable}
         />
       ) : (
         <NoDataAlert {...noDataAlertProps} />
@@ -195,6 +198,7 @@ HistogramWidget.propTypes = {
   formatter: PropTypes.func,
   tooltip: PropTypes.bool,
   animation: PropTypes.bool,
+  filterable: PropTypes.bool,
   ticks: PropTypes.array.isRequired,
   onError: PropTypes.func,
   wrapperProps: PropTypes.object,
@@ -204,6 +208,7 @@ HistogramWidget.propTypes = {
 HistogramWidget.defaultProps = {
   tooltip: true,
   animation: true,
+  filterable: true,
   wrapperProps: {},
   noDataAlertProps: {}
 };

--- a/packages/react-widgets/src/widgets/PieWidget.js
+++ b/packages/react-widgets/src/widgets/PieWidget.js
@@ -25,7 +25,7 @@ const EMPTY_ARRAY = [];
  * @param  {object} props.labels - Object that maps category name with a chosen label
  * @param  {string} props.height - Height of the chart
  * @param  {boolean} [props.animation] - Enable/disable widget animations on data updates. Enabled by default.
- * @param  {boolean} [props.filterable] - Enable/disable widget filter capabilities. Enabled by default.
+ * @param  {boolean} [props.filterable] - Enable/disable widget filtering capabilities. Enabled by default.
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  * @param  {Object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]()

--- a/packages/react-widgets/src/widgets/PieWidget.js
+++ b/packages/react-widgets/src/widgets/PieWidget.js
@@ -25,6 +25,7 @@ const EMPTY_ARRAY = [];
  * @param  {object} props.labels - Object that maps category name with a chosen label
  * @param  {string} props.height - Height of the chart
  * @param  {boolean} [props.animation] - Enable/disable widget animations on data updates. Enabled by default.
+ * @param  {boolean} [props.filterable] - Enable/disable widget filter capabilities. Enabled by default.
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  * @param  {Object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]()
@@ -41,6 +42,7 @@ function PieWidget({
   tooltipFormatter,
   labels,
   animation,
+  filterable,
   colors,
   onError,
   wrapperProps,
@@ -128,6 +130,7 @@ function PieWidget({
           colors={colors}
           labels={labels}
           animation={animation}
+          filterable={filterable}
           selectedCategories={selectedCategories}
           onSelectedCategoriesChange={handleSelectedCategoriesChange}
         />
@@ -150,6 +153,7 @@ PieWidget.propTypes = {
   tooltipFormatter: PropTypes.func,
   labels: PropTypes.object,
   animation: PropTypes.bool,
+  filterable: PropTypes.bool,
   onError: PropTypes.func,
   colors: PropTypes.arrayOf(PropTypes.string),
   wrapperProps: PropTypes.object,
@@ -158,6 +162,7 @@ PieWidget.propTypes = {
 
 PieWidget.defaultProps = {
   animation: true,
+  filterable: true,
   wrapperProps: {},
   noDataAlertProps: {}
 };


### PR DESCRIPTION
Story details: https://app.shortcut.com/cartoteam/story/193004

Added property `filterable` in every widget with filtering capabilities.

When `filterable` is false, widget's click event is disabled.