### PR TITLE
Remove uniqueIdProperty default value in useGeojsonFeatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- Remove uniqueIdProperty by default value in useGeojsonFeatures [#273](https://github.com/CartoDB/carto-react/pull/273)
+- Remove uniqueIdProperty default value in useGeojsonFeatures [#273](https://github.com/CartoDB/carto-react/pull/273)
 - Allow disable widgets filtering [#268](https://github.com/CartoDB/carto-react/pull/268)
 - Fix: use 0-based pagination in raw feature access and TableWidget [#265](https://github.com/CartoDB/carto-react/pull/265)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Remove uniqueIdProperty by default value in useGeojsonFeatures [#273](https://github.com/CartoDB/carto-react/pull/273)
 - Allow disable widgets filtering [#268](https://github.com/CartoDB/carto-react/pull/268)
 - Fix: use 0-based pagination in raw feature access and TableWidget [#265](https://github.com/CartoDB/carto-react/pull/265)
 

--- a/packages/react-api/src/hooks/useGeojsonFeatures.js
+++ b/packages/react-api/src/hooks/useGeojsonFeatures.js
@@ -8,7 +8,7 @@ export default function useGeojsonFeatures({
   source,
   viewport,
   spatialFilter,
-  uniqueIdProperty = 'cartodb_id',
+  uniqueIdProperty,
   debounceTimeout = 250
 }) {
   const [


### PR DESCRIPTION
We cannot asume that every layer has cartodb_id since it's not mandatory in Carto 3. Users are facing a problem when cartodb_id is not defined.
This is a wrong behavior added when the useViewportFeatures were refactored, because before the refactor we didn't have a default value for uniqueIdProperty.