### PR TITLE
Table widget UI tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- Allow table body scrolling in TableWidget [#279](https://github.com/CartoDB/carto-react/pull/279)
+- Expose height and dense prop in TableWidget [#279](https://github.com/CartoDB/carto-react/pull/279)
 - Expose initialPageSize prop in TableWidget [#281](https://github.com/CartoDB/carto-react/pull/281)
 - Fix filtersToSQL output when IN filter has numeric values [#277](https://github.com/CartoDB/carto-react/pull/277)
 - Remove uniqueIdProperty default value in useGeojsonFeatures [#273](https://github.com/CartoDB/carto-react/pull/273)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Allow table body scrolling in TableWidget [#279](https://github.com/CartoDB/carto-react/pull/279)
+- Expose initialPageSize prop in TableWidget [#281](https://github.com/CartoDB/carto-react/pull/281)
 - Fix filtersToSQL output when IN filter has numeric values [#277](https://github.com/CartoDB/carto-react/pull/277)
 - Remove uniqueIdProperty default value in useGeojsonFeatures [#273](https://github.com/CartoDB/carto-react/pull/273)
 - Allow disable widgets filtering [#268](https://github.com/CartoDB/carto-react/pull/268)

--- a/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
+++ b/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
@@ -74,7 +74,8 @@ function TableWidgetUI({
   rowsPerPageOptions,
   onSetRowsPerPage,
   onRowClick,
-  height
+  height,
+  dense
 }) {
   const classes = useStyles();
   const paginationRef = useRef(null);
@@ -103,7 +104,7 @@ function TableWidgetUI({
   return (
     <>
       <TableContainer style={fixedHeightStyle}>
-        <Table stickyHeader size='small'>
+        <Table stickyHeader size={dense ? 'small' : 'medium'}>
           <TableHeaderComponent
             columns={columns}
             sorting={sorting}
@@ -197,7 +198,8 @@ TableWidgetUI.defaultProps = {
   sortDirection: 'asc',
   pagination: false,
   rowsPerPage: 10,
-  rowsPerPageOptions: [5, 10, 25]
+  rowsPerPageOptions: [5, 10, 25],
+  dense: false
 };
 
 TableWidgetUI.propTypes = {
@@ -216,7 +218,8 @@ TableWidgetUI.propTypes = {
   rowsPerPageOptions: PropTypes.array,
   onSetRowsPerPage: PropTypes.func,
   onRowClick: PropTypes.func,
-  height: PropTypes.string
+  height: PropTypes.string,
+  dense: PropTypes.bool
 };
 
 export default TableWidgetUI;

--- a/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
+++ b/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
@@ -103,7 +103,7 @@ function TableWidgetUI({
   return (
     <>
       <TableContainer style={fixedHeightStyle}>
-        <Table stickyHeader>
+        <Table stickyHeader size='small'>
           <TableHeaderComponent
             columns={columns}
             sorting={sorting}

--- a/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
+++ b/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
@@ -97,7 +97,7 @@ function TableWidgetUI({
   const fixedHeightStyle = {};
   if (height) {
     const paginationHeight = paginationRef?.current?.clientHeight || 0;
-    fixedHeightStyle.height = `${height - paginationHeight}px`;
+    fixedHeightStyle.height = `calc(${height} - ${paginationHeight}px)`;
   }
 
   return (
@@ -216,7 +216,7 @@ TableWidgetUI.propTypes = {
   rowsPerPageOptions: PropTypes.array,
   onSetRowsPerPage: PropTypes.func,
   onRowClick: PropTypes.func,
-  height: PropTypes.number
+  height: PropTypes.string
 };
 
 export default TableWidgetUI;

--- a/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
+++ b/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   Table,
@@ -91,11 +91,15 @@ function TableWidgetUI({
     onSetPage(0);
   };
 
-  const fixedHeightStyle = {};
-  if (height) {
+  const fixedHeightStyle = useMemo(() => {
+    if (!height) {
+      return {};
+    }
     const paginationHeight = paginationRef?.current?.clientHeight || 0;
-    fixedHeightStyle.height = `calc(${height} - ${paginationHeight}px)`;
-  }
+    return {
+      height: `calc(${height} - ${paginationHeight}px)`
+    };
+  }, [height, paginationRef]);
 
   return (
     <>

--- a/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
+++ b/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
@@ -14,10 +14,6 @@ import {
 
 const useStyles = makeStyles((theme) => ({
   tableHead: {
-    backgroundColor: theme.palette.common.white,
-    '& .MuiTableCell-head': {
-      border: 'none'
-    },
     '& .MuiTableCell-head, & .MuiTableCell-head span': {
       ...theme.typography.caption,
       color: theme.palette.text.secondary

--- a/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
+++ b/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import {
   Table,
@@ -21,6 +21,9 @@ const useStyles = makeStyles((theme) => ({
     '& .MuiTableCell-head, & .MuiTableCell-head span': {
       ...theme.typography.caption,
       color: theme.palette.text.secondary
+    },
+    '& th.MuiTableCell-stickyHeader': {
+      backgroundColor: theme.palette.common.white
     }
   },
   tableRow: {
@@ -70,9 +73,11 @@ function TableWidgetUI({
   rowsPerPage,
   rowsPerPageOptions,
   onSetRowsPerPage,
-  onRowClick
+  onRowClick,
+  height
 }) {
   const classes = useStyles();
+  const paginationRef = useRef(null);
 
   const handleSort = (sortField) => {
     const isAsc = sortBy === sortField && sortDirection === 'asc';
@@ -89,10 +94,16 @@ function TableWidgetUI({
     onSetPage(0);
   };
 
+  const fixedHeightStyle = {};
+  if (height) {
+    const paginationHeight = paginationRef?.current?.clientHeight || 0;
+    fixedHeightStyle.height = `${height - paginationHeight}px`;
+  }
+
   return (
     <>
-      <TableContainer>
-        <Table>
+      <TableContainer style={fixedHeightStyle}>
+        <Table stickyHeader>
           <TableHeaderComponent
             columns={columns}
             sorting={sorting}
@@ -105,6 +116,7 @@ function TableWidgetUI({
       </TableContainer>
       {pagination && (
         <TablePagination
+          ref={paginationRef}
           className={classes.pagination}
           rowsPerPageOptions={rowsPerPageOptions}
           component='div'
@@ -203,7 +215,8 @@ TableWidgetUI.propTypes = {
   rowsPerPage: PropTypes.number,
   rowsPerPageOptions: PropTypes.array,
   onSetRowsPerPage: PropTypes.func,
-  onRowClick: PropTypes.func
+  onRowClick: PropTypes.func,
+  height: PropTypes.number
 };
 
 export default TableWidgetUI;

--- a/packages/react-ui/storybook/stories/widgetsUI/TableWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/TableWidgetUI.stories.js
@@ -20,6 +20,13 @@ const DefaultProps = { columns, rows };
 export const Playground = Template.bind({});
 Playground.args = { ...DefaultProps, rows: rows.slice(0, 5) };
 
+export const DenseLayout = Template.bind({});
+DenseLayout.args = {
+  ...DefaultProps,
+  rows: rows.slice(0, 5),
+  dense: true
+};
+
 export const Pagination = Template.bind({});
 Pagination.args = {
   ...DefaultProps,

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -17,6 +17,7 @@ import { selectAreFeaturesReadyForSource } from '@carto/react-redux/';
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  * @param  {Object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]()
  * @param  {number} [props.initialPageSize] - Initial number of rows per page
+ * @param  {number} [props.height] - Static widget height, required for scrollable table content
  */
 function TableWidget({
   id,
@@ -26,7 +27,8 @@ function TableWidget({
   wrapperProps,
   noDataAlertProps,
   onError,
-  initialPageSize = 10
+  initialPageSize = 10,
+  height
 }) {
   const [rowsPerPage, setRowsPerPage] = useState(initialPageSize);
   const [page, setPage] = useState(0);
@@ -100,6 +102,7 @@ function TableWidget({
           sortDirection={sortDirection}
           onSetSortBy={setSortBy}
           onSetSortDirection={setSortDirection}
+          height={height}
         />
       ) : (
         <NoDataAlert {...noDataAlertProps} />
@@ -122,7 +125,8 @@ TableWidget.propTypes = {
   onError: PropTypes.func,
   wrapperProps: PropTypes.object,
   noDataAlertProps: PropTypes.object,
-  initialPageSize: PropTypes.number
+  initialPageSize: PropTypes.number,
+  height: PropTypes.number
 };
 
 export default TableWidget;

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -17,7 +17,7 @@ import { selectAreFeaturesReadyForSource } from '@carto/react-redux/';
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  * @param  {Object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]()
  * @param  {number} [props.initialPageSize] - Initial number of rows per page
- * @param  {number} [props.height] - Static widget height, required for scrollable table content
+ * @param  {string} [props.height] - Static widget height, required for scrollable table content
  */
 function TableWidget({
   id,
@@ -126,7 +126,7 @@ TableWidget.propTypes = {
   wrapperProps: PropTypes.object,
   noDataAlertProps: PropTypes.object,
   initialPageSize: PropTypes.number,
-  height: PropTypes.number
+  height: PropTypes.string
 };
 
 export default TableWidget;

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -18,6 +18,7 @@ import { selectAreFeaturesReadyForSource } from '@carto/react-redux/';
  * @param  {Object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]()
  * @param  {number} [props.initialPageSize] - Initial number of rows per page
  * @param  {string} [props.height] - Static widget height, required for scrollable table content
+ * @param  {boolean} [props.dense] - Whether the table should use a compact layout with smaller cell paddings
  */
 function TableWidget({
   id,
@@ -28,7 +29,8 @@ function TableWidget({
   noDataAlertProps,
   onError,
   initialPageSize = 10,
-  height
+  height,
+  dense
 }) {
   const [rowsPerPage, setRowsPerPage] = useState(initialPageSize);
   const [page, setPage] = useState(0);
@@ -103,6 +105,7 @@ function TableWidget({
           onSetSortBy={setSortBy}
           onSetSortDirection={setSortDirection}
           height={height}
+          dense={dense}
         />
       ) : (
         <NoDataAlert {...noDataAlertProps} />
@@ -126,7 +129,8 @@ TableWidget.propTypes = {
   wrapperProps: PropTypes.object,
   noDataAlertProps: PropTypes.object,
   initialPageSize: PropTypes.number,
-  height: PropTypes.string
+  height: PropTypes.string,
+  dense: PropTypes.bool
 };
 
 export default TableWidget;


### PR DESCRIPTION
Tweaks to the TableWidget to improve its usability:
 - allow to specify a fixed pixel `height` prop, necessary to make the table content scrollable in case of overflow
 - make the header "sticky", so it doesn't scroll with the content
 - use the `size="small"` variant, which reduces cell padding for a denser layout