### PR TITLE
Fix executeSQL typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Fix executeSQL typing [#280](https://github.com/CartoDB/carto-react/pull/280)
 - Fix filtersToSQL output when IN filter has numeric values [#277](https://github.com/CartoDB/carto-react/pull/277)
 - Remove uniqueIdProperty default value in useGeojsonFeatures [#273](https://github.com/CartoDB/carto-react/pull/273)
 - Allow disable widgets filtering [#268](https://github.com/CartoDB/carto-react/pull/268)

--- a/packages/react-api/src/api/SQL.d.ts
+++ b/packages/react-api/src/api/SQL.d.ts
@@ -1,6 +1,9 @@
-import { Credentials, ExecuteSQLResponse } from '../types';
+import { Credentials } from '../types';
+import { FeatureCollection } from 'geojson';
 
-export function executeSQL({
+export type ExecuteSQLResponse<Response = FeatureCollection | {}[]> = Promise<Response>;
+
+export function executeSQL<Response = FeatureCollection | {}[]>({
   credentials,
   query,
   connection,
@@ -10,4 +13,4 @@ export function executeSQL({
   query: string;
   connection?: string;
   opts?: unknown;
-}): ExecuteSQLResponse;
+}): ExecuteSQLResponse<Response>;

--- a/packages/react-api/src/api/SQL.d.ts
+++ b/packages/react-api/src/api/SQL.d.ts
@@ -1,7 +1,5 @@
-import { Credentials } from '../types';
+import { Credentials, ExecuteSQLResponse } from '../types';
 import { FeatureCollection } from 'geojson';
-
-export type ExecuteSQLResponse<Response = FeatureCollection | {}[]> = Promise<Response>;
 
 export function executeSQL<Response = FeatureCollection | {}[]>({
   credentials,

--- a/packages/react-api/src/api/SQL.js
+++ b/packages/react-api/src/api/SQL.js
@@ -9,13 +9,14 @@ const CLIENT = 'carto-react';
 /**
  * Executes a SQL query
  *
- * @param { Object } credentials - CARTO user credentials
- * @param { string } credentials.username - CARTO username
- * @param { string } credentials.apiKey - CARTO API Key
- * @param { string } credentials.serverUrlTemplate - CARTO server URL template
- * @param { string } query - SQL query to be executed
- * @param { string } connection - connection name required for CARTO cloud native
- * @param { Object } opts - Additional options for the HTTP request
+ * @param { object } props
+ * @param { Object } props.credentials - CARTO user credentials
+ * @param { string } props.credentials.username - CARTO username
+ * @param { string } props.credentials.apiKey - CARTO API Key
+ * @param { string } props.credentials.serverUrlTemplate - CARTO server URL template
+ * @param { string } props.query - SQL query to be executed
+ * @param { string } props.connection - connection name required for CARTO cloud native
+ * @param { Object } props.opts - Additional options for the HTTP request
  */
 export const executeSQL = async ({ credentials, query, connection, opts }) => {
   let response;

--- a/packages/react-api/src/types.d.ts
+++ b/packages/react-api/src/types.d.ts
@@ -1,5 +1,6 @@
 import { DataFilterExtension } from '@deck.gl/extensions';
 import { MAP_TYPES, API_VERSIONS } from '@deck.gl/carto';
+import { FeatureCollection } from 'geojson';
 
 interface CredentialsCarto2 {
   apiVersion: API_VERSIONS.V1 | API_VERSIONS.V2;
@@ -38,3 +39,4 @@ export type UseCartoLayerFilterProps = {
   };
 } & SourceProps;
 
+export type ExecuteSQLResponse<Response = FeatureCollection | {}[]> = Promise<Response>;

--- a/packages/react-api/src/types.d.ts
+++ b/packages/react-api/src/types.d.ts
@@ -1,6 +1,5 @@
 import { DataFilterExtension } from '@deck.gl/extensions';
 import { MAP_TYPES, API_VERSIONS } from '@deck.gl/carto';
-import { FeatureCollection } from 'geojson';
 
 interface CredentialsCarto2 {
   apiVersion: API_VERSIONS.V1 | API_VERSIONS.V2;
@@ -39,4 +38,3 @@ export type UseCartoLayerFilterProps = {
   };
 } & SourceProps;
 
-export type ExecuteSQLResponse = Promise<FeatureCollection | {}[]>;


### PR DESCRIPTION
Changes made:

- Added a generic to customise executeSQL output type.
- Fixed executeSQL JSDoc: it had the old description of the fn.

I have some doubts about the need of ExecuteSQLResponse type, because it just adds the promise. But it didn't want to remove it to avoid a breaking change. What do you think?