### PR TITLE
Add initialCollapsed prop to LegendWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Add initialCollapsed prop to LegendWidget [#282](https://github.com/CartoDB/carto-react/pull/282)
 - Expose height and dense prop in TableWidget [#279](https://github.com/CartoDB/carto-react/pull/279)
 - Expose initialPageSize prop in TableWidget [#281](https://github.com/CartoDB/carto-react/pull/281)
 - Fix filtersToSQL output when IN filter has numeric values [#277](https://github.com/CartoDB/carto-react/pull/277)

--- a/packages/react-ui/__tests__/widgets/LegendWidgetUI.test.js
+++ b/packages/react-ui/__tests__/widgets/LegendWidgetUI.test.js
@@ -81,6 +81,13 @@ describe('LegendWidgetUI', () => {
   test('multiple legends', () => {
     render(<Widget layers={DATA}></Widget>);
     expect(screen.queryByText('Layers')).toBeInTheDocument();
+    expect(screen.queryByTestId('categories-legend')).toBeInTheDocument();
+  });
+
+  test('multiple legends with collapsed as true', () => {
+    render(<Widget layers={DATA} collapsed={true}></Widget>);
+    expect(screen.queryByText('Layers')).toBeInTheDocument();
+    expect(screen.queryByTestId('categories-legend')).not.toBeInTheDocument();
   });
 
   test('Category legend', () => {

--- a/packages/react-ui/src/types.d.ts
+++ b/packages/react-ui/src/types.d.ts
@@ -80,8 +80,11 @@ export type LegendWidgetUIData = {
 };
 
 export type LegendWidgetUI = {
-  layers: LegendWidgetUIData[];
-  onChangeVisibility: ({ id: string, visible: boolean }) => void;
+  className?: string;
+  layers?: LegendWidgetUIData[];
+  collapsed?: boolean;
+  onCollapsedChange?: (value: boolean) => void;
+  onChangeVisibility?: ({ id: string, visible: boolean }) => void;
 };
 
 export type ScatterPlotWidgetUIData = number[][];

--- a/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
+++ b/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
@@ -1,4 +1,4 @@
-import React, { createRef, Fragment, useState } from 'react';
+import React, { createRef, Fragment } from 'react';
 import {
   Box,
   Button,
@@ -14,6 +14,7 @@ import LegendCategories from './LegendCategories';
 import LegendIcon from './LegendIcon';
 import LegendRamp from './LegendRamp';
 import LegendProportion from './LegendProportion';
+import PropTypes from 'prop-types';
 
 const LayersIcon = () => (
   <SvgIcon width='24' height='24' viewBox='0 0 24 24'>
@@ -43,18 +44,43 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-export default function LegendWidgetUI({ className, layers = [], onChangeVisibility }) {
+function LegendWidgetUI({
+  className,
+  layers = [],
+  collapsed,
+  onCollapsedChange,
+  onChangeVisibility
+}) {
   const classes = useStyles();
   const isSingle = layers.length === 1;
 
   return (
     <Box className={`${classes.legend} ${className}`}>
-      <LegendContainer isSingle={isSingle}>
+      <LegendContainer
+        isSingle={isSingle}
+        collapsed={collapsed}
+        onCollapsedChange={onCollapsedChange}
+      >
         <LegendRows layers={layers} onChangeVisibility={onChangeVisibility} />
       </LegendContainer>
     </Box>
   );
 }
+
+LegendWidgetUI.defaultProps = {
+  layers: [],
+  collapsed: false
+};
+
+LegendWidgetUI.propTypes = {
+  className: PropTypes.string,
+  layers: PropTypes.array,
+  collapsed: PropTypes.bool,
+  onCollapsedChange: PropTypes.func,
+  onChangeVisibility: PropTypes.func
+};
+
+export default LegendWidgetUI;
 
 const useStylesLegendContainer = makeStyles((theme) => ({
   header: {
@@ -67,8 +93,8 @@ const useStylesLegendContainer = makeStyles((theme) => ({
     flex: '1 1 auto',
     justifyContent: 'space-between',
     padding: theme.spacing(0.75, 1.25, 0.75, 3),
-    borderTop: ({ expanded }) =>
-      !expanded ? 'none' : `1px solid ${theme.palette.divider}`,
+    borderTop: ({ collapsed }) =>
+      collapsed ? 'none' : `1px solid ${theme.palette.divider}`,
     cursor: 'pointer',
     '& .MuiButton-label': {
       ...theme.typography.body1
@@ -81,15 +107,14 @@ const useStylesLegendContainer = makeStyles((theme) => ({
   }
 }));
 
-function LegendContainer({ isSingle, children }) {
+function LegendContainer({ isSingle, children, collapsed, onCollapsedChange }) {
   const wrapper = createRef();
-  const [expanded, setExpanded] = useState(true);
   const classes = useStylesLegendContainer({
-    expanded
+    collapsed
   });
 
   const handleExpandClick = () => {
-    setExpanded(!expanded);
+    onCollapsedChange(!collapsed);
   };
 
   return isSingle ? (
@@ -98,7 +123,7 @@ function LegendContainer({ isSingle, children }) {
     <>
       <Collapse
         ref={wrapper}
-        in={expanded}
+        in={!collapsed}
         timeout='auto'
         unmountOnExit
         classes={{

--- a/packages/react-ui/storybook/stories/widgetsUI/LegendWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/LegendWidgetUI.stories.js
@@ -1,33 +1,26 @@
 import { Typography } from '@material-ui/core';
-import React from 'react';
+import React, { useState } from 'react';
 import LegendWidgetUI from '../../../src/widgets/legend/LegendWidgetUI';
 
 const options = {
   title: 'Widgets UI/LegendWidgetUI',
   component: LegendWidgetUI,
   argTypes: {
-    title: {
-      defaultValue: 'Legend title',
+    className: {
       control: {
         type: 'text'
-      }
-    },
-    switchable: {
-      defaultValue: true,
-      control: {
-        type: 'boolean'
-      }
-    },
-    visible: {
-      defaultValue: true,
-      control: {
-        type: 'boolean'
       }
     },
     layers: {
       defaultValue: [],
       control: {
         type: 'array'
+      }
+    },
+    collapsed: {
+      defaultValue: false,
+      control: {
+        type: 'boolean'
       }
     }
   }
@@ -88,6 +81,32 @@ const LegendMultiTemplate = () => {
     }
   ];
   return <LegendWidgetUI layers={layers}></LegendWidgetUI>;
+};
+
+const LegendMultiTemplateCollapsed = () => {
+  const [collapsed, setCollapsed] = useState(true);
+  
+  const layers = [
+    {
+      id: 0,
+      title: 'Multi Layer',
+      visible: true,
+      legend: {
+        children: <Typography>Your Content</Typography>
+      }
+    },
+    {
+      id: 1,
+      title: 'Multi Layer',
+      visible: false,
+      collapsible: false,
+      legend: {
+        children: <Typography>Your Content</Typography>
+      }
+    }
+  ];
+
+  return <LegendWidgetUI layers={layers} collapsed={collapsed} onCollapsedChange={setCollapsed} />;
 };
 
 const LegendCategoriesTemplate = () => {
@@ -208,6 +227,7 @@ export const Playground = Template.bind({});
 
 export const SingleLayer = LegendTemplate.bind({});
 export const MultiLayer = LegendMultiTemplate.bind({});
+export const MultiLayerCollapsed = LegendMultiTemplateCollapsed.bind({});
 export const NotFound = LegendNotFoundTemplate.bind({});
 export const Categories = LegendCategoriesTemplate.bind({});
 export const Icon = LegendIconTemplate.bind({});

--- a/packages/react-widgets/src/types.d.ts
+++ b/packages/react-widgets/src/types.d.ts
@@ -72,3 +72,8 @@ export type TimeSeriesWidget = {
   onTimelineUpdate?: Function,
   onTimeWindowUpdate?: Function
 } & CommonWidgetProps & MonoColumnWidgetProps;
+
+export type LegendWidget = {
+  className?: string;
+  initialCollapsed?: boolean;
+}

--- a/packages/react-widgets/src/widgets/LegendWidget.js
+++ b/packages/react-widgets/src/widgets/LegendWidget.js
@@ -1,19 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { updateLayer } from '@carto/react-redux/';
 import { LegendWidgetUI } from '@carto/react-ui';
 import { useDispatch, useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
 
-export default function LegendWidget({ className }) {
+/**
+ * Renders a <LegendWidget /> component
+ * @param  {object} props
+ * @param  {string} props.className - CSS class name
+ * @param  {string} props.initialCollapsed - Define initial collapsed value. false by default.
+ */
+function LegendWidget({ className, initialCollapsed }) {
   const dispatch = useDispatch();
   const layers = useSelector((state) =>
-    Object.values(state.carto.layers).filter((layer) => !!layer.legend)
+    [...Object.values(state.carto.layers), ...Object.values(state.carto.layers)].filter(
+      (layer) => !!layer.legend
+    )
   );
+  const [collapsed, setCollapsed] = useState(initialCollapsed);
 
   if (!layers.length) {
     return null;
   }
 
-  const onChangeVisibility = ({ id, visible }) => {
+  const handleChangeVisibility = ({ id, visible }) => {
     dispatch(
       updateLayer({
         id,
@@ -22,11 +32,28 @@ export default function LegendWidget({ className }) {
     );
   };
 
+  const handleCollapsedChange = (newCollapsedValue) => {
+    setCollapsed(newCollapsedValue);
+  };
+
   return (
     <LegendWidgetUI
       className={className}
       layers={layers}
-      onChangeVisibility={onChangeVisibility}
+      onChangeVisibility={handleChangeVisibility}
+      collapsed={collapsed}
+      onCollapsedChange={handleCollapsedChange}
     />
   );
 }
+
+LegendWidget.propTypes = {
+  className: PropTypes.string,
+  initialCollapsed: PropTypes.bool
+};
+
+LegendWidget.defaultProps = {
+  initialCollapsed: false
+};
+
+export default LegendWidget;

--- a/packages/react-widgets/src/widgets/LegendWidget.js
+++ b/packages/react-widgets/src/widgets/LegendWidget.js
@@ -32,9 +32,6 @@ function LegendWidget({ className, initialCollapsed }) {
     );
   };
 
-  const handleCollapsedChange = (newCollapsedValue) => {
-    setCollapsed(newCollapsedValue);
-  };
 
   return (
     <LegendWidgetUI
@@ -42,7 +39,7 @@ function LegendWidget({ className, initialCollapsed }) {
       layers={layers}
       onChangeVisibility={handleChangeVisibility}
       collapsed={collapsed}
-      onCollapsedChange={handleCollapsedChange}
+      onCollapsedChange={setCollapsed}
     />
   );
 }

--- a/packages/react-widgets/src/widgets/LegendWidget.js
+++ b/packages/react-widgets/src/widgets/LegendWidget.js
@@ -13,9 +13,7 @@ import PropTypes from 'prop-types';
 function LegendWidget({ className, initialCollapsed }) {
   const dispatch = useDispatch();
   const layers = useSelector((state) =>
-    [...Object.values(state.carto.layers), ...Object.values(state.carto.layers)].filter(
-      (layer) => !!layer.legend
-    )
+    Object.values(state.carto.layers).filter((layer) => !!layer.legend)
   );
   const [collapsed, setCollapsed] = useState(initialCollapsed);
 
@@ -31,7 +29,6 @@ function LegendWidget({ className, initialCollapsed }) {
       })
     );
   };
-
 
   return (
     <LegendWidgetUI


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9151432/149807942-5f69502e-45ce-450e-8281-18d7e14792e8.png)

Changes made:

- Allow to render LegendWidget initially collapsed.
- Added TS types, prop types and JSDocs.

Breaking change:
- LegendWidgetUI is now dummy.