### PR TITLE
Widgets - Export getTable method for TableWidget model

### DIFF
--- a/packages/react-widgets/src/index.d.ts
+++ b/packages/react-widgets/src/index.d.ts
@@ -11,7 +11,8 @@ export {
   getHistogram,
   getCategories,
   geocodeStreetPoint,
-  getScatter
+  getScatter,
+  getTable
 } from './models';
 export { default as TimeSeriesWidget } from './widgets/TimeSeriesWidget';
 export { default as useSourceFilters } from './hooks/useSourceFilters';

--- a/packages/react-widgets/src/index.js
+++ b/packages/react-widgets/src/index.js
@@ -13,7 +13,8 @@ export {
   getHistogram,
   getCategories,
   geocodeStreetPoint,
-  getScatter
+  getScatter,
+  getTable
 } from './models';
 export { default as useSourceFilters } from './hooks/useSourceFilters';
 export { default as DrawingToolLayer } from './layers/DrawingToolLayer';


### PR DESCRIPTION
# Widgets - Export getTable method for TableWidgets model

As we do with other widgets, we should export the models method `getTable` for `TableWidget` too 