### PR TITLE
Fix changelog entries + nesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - Fix widget long name going out of the frame [#266](https://github.com/CartoDB/carto-react/pull/266)
 - Fix too long labels in CategoryWidget [#267](https://github.com/CartoDB/carto-react/pull/267)
 
-## 1.2.1-alpha.3 (2022-01-18)
+## 1.2
+
+### 1.2.1-alpha.3 (2022-01-18)
 
 - Export getTable method for TableWidget model [#283](https://github.com/CartoDB/carto-react/pull/283)
 - Expose height and dense prop in TableWidget [#279](https://github.com/CartoDB/carto-react/pull/279)
@@ -17,17 +19,17 @@
 - Allow disable widgets filtering [#268](https://github.com/CartoDB/carto-react/pull/268)
 - Fix: use 0-based pagination in raw feature access and TableWidget [#265](https://github.com/CartoDB/carto-react/pull/265)
 
-## 1.2.1-alpha.2 (2022-01-03)
+### 1.2.1-alpha.2 (2022-01-03)
 
 - Fix: DrawingToolLayer disables interactivity of the layers behind it [#263](https://github.com/CartoDB/carto-react/pull/263)
 - Add TableWidget [#154](https://github.com/CartoDB/carto-react/pull/154)
 
-## 1.2.0-alpha.1 (2021-12-30)
+### 1.2.1-alpha.1 (2021-12-30)
 
 - Track clientId for tracing purposes [#261](https://github.com/CartoDB/carto-react/pull/261)
 - Update deck.gl version to 8.7.0-alpha.11 [#254](https://github.com/CartoDB/carto-react/pull/254)
 
-## 1.2.0-alpha.0 (2021-12-29)
+### 1.2.1-alpha.0 (2021-12-29)
 
 - WRAPPER WIDGET Configurable margin in widgets [#251](https://github.com/CartoDB/carto-react/pull/251)
 - Add spatial filter to allow ramdom geometry filters in widgets[#250](https://github.com/CartoDB/carto-react/pull/250)
@@ -35,7 +37,9 @@
 - Fix: remove sortBy prop default value [#252](https://github.com/CartoDB/carto-react/pull/252)
 - Fix TS type declarations for BasemapName and CartoSlice [#248](https://github.com/CartoDB/carto-react/pull/248)
 
-## 1.1.4 (2021-12-16)
+## 1.1
+
+### 1.1.4 (2021-12-16)
 
 - Implement C4R filtering using binary data [#228](https://github.com/CartoDB/carto-react/pull/228)
 - Fix build adding peerDependecy of @carto/react-core to @carto/react-ui [#237](https://github.com/CartoDB/carto-react/pull/237)
@@ -44,23 +48,23 @@
 - Improve timeseries animation performance [#243](https://github.com/CartoDB/carto-react/pull/243)
 - Fix TS type declarations for BasemapName and CartoSlice [#248](https://github.com/CartoDB/carto-react/pull/248)
 
-## 1.1.3 (2021-12-04)
+### 1.1.3 (2021-12-04)
 
 - Histogram takes into account null values in filters for selected bars [#234](https://github.com/CartoDB/carto-react/pull/234)
 - Return raw feature data from workers [#225](https://github.com/CartoDB/carto-react/pull/225)
 
-## 1.1.2 (2021-12-01)
+### 1.1.2 (2021-12-01)
 
 - Fix CategoryWidget values during animation [#230](https://github.com/CartoDB/carto-react/pull/230)
 - Remove lock in CategoryWidget if selected categories change [#231](https://github.com/CartoDB/carto-react/pull/231)
 - Refresh charts widgets when changing tooltip functions [#232](https://github.com/CartoDB/carto-react/pull/232)
 
-## 1.1.1 (2021-11-23)
+### 1.1.1 (2021-11-23)
 
 - Improve Widgets calculations sync with tiles [#223](https://github.com/CartoDB/carto-react/pull/223)
 - `CategoryWidget`, `HistogramWidget`, `PieWidget` use filters in datasource to derive selecteditems (categories, bars) instead of local react state [224](https://github.com/CartoDB/carto-react/pull/224)
 
-## 1.1.0 (2021-10-29)
+### 1.1.0 (2021-10-29)
 
 - Histogram tooltip formatter receiving dataIndex and ticks [#220](https://github.com/CartoDB/carto-react/pull/220)
 - Histogram yAxis max value should always be shown [#221](https://github.com/CartoDB/carto-react/pull/221)
@@ -146,12 +150,14 @@
 - Update to latest 8.5.0-alpha.10 deck.gl version [#149](https://github.com/CartoDB/carto-react/pull/149)
 - Add support to Cloud Native SQL API [#150](https://github.com/CartoDB/carto-react/pull/150)
 
-## 1.0.1 (2021-04-12)
+## 1.0
+
+### 1.0.1 (2021-04-12)
 
 - Add basic Typescript typings [#136](https://github.com/CartoDB/carto-react/pull/136)
 - Remove debugger in googlemap and clean code [#137](https://github.com/CartoDB/carto-react/pull/137)
 
-## 1.0.0 (2021-03-23)
+### 1.0.0 (2021-03-23)
 
 ### 1.0.0-rc.3 (2021-03-22)
 


### PR DESCRIPTION
Fix a couple of wrong naming in changelog alphas (1.2.1 instead of 1.2.0) + some nesting, to better see the structure & minors:

![image](https://user-images.githubusercontent.com/458196/149969207-2ba68f71-81df-41c7-a8da-dbd60cee93f7.png)

