### PR TITLE
Fix: tablewidget fixed height with pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Fix: TableWidget fixed height with pagination [#286](https://github.com/CartoDB/carto-react/pull/286)
 - Add initialCollapsed prop to LegendWidget [#282](https://github.com/CartoDB/carto-react/pull/282)
 - Fix executeSQL typing [#280](https://github.com/CartoDB/carto-react/pull/280)
 - Fix widget long name going out of the frame [#266](https://github.com/CartoDB/carto-react/pull/266)

--- a/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
+++ b/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
@@ -1,4 +1,4 @@
-import React, { useRef, useMemo } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import {
   Table,
@@ -91,15 +91,11 @@ function TableWidgetUI({
     onSetPage(0);
   };
 
-  const fixedHeightStyle = useMemo(() => {
-    if (!height) {
-      return {};
-    }
+  const fixedHeightStyle = {};
+  if (height) {
     const paginationHeight = paginationRef?.current?.clientHeight || 0;
-    return {
-      height: `calc(${height} - ${paginationHeight}px)`
-    };
-  }, [height, paginationRef]);
+    fixedHeightStyle.height = `calc(${height} - ${paginationHeight}px)`;
+  }
 
   return (
     <>


### PR DESCRIPTION
I've removed a `useMemo` which caused a rendering bug when updating the component props after first render.
When the `paginationRef` ref is set, the pagination control itself isn't fully rendered, so its height is zero. As it's memoized and `paginationRef` never changes after that, the height isn't refreshed at all.

Just doing the computation on each render is enough to solve the problem and doesn't seem problematic to me, but there may be other ways to fix that.

cc @Clebal 
