### PR TITLE
Remove custom ToggleButtonGroup and ToggleButton default size value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Remove custom ToggleButtonGroup and ToggleButton default size value [#289](https://github.com/CartoDB/carto-react/pull/289)
 - Improve styles for for MaterialUI CircularProgress component [#270](https://github.com/CartoDB/carto-react/pull/270)
 - Improve styles for MaterialUI Slider component [#274](https://github.com/CartoDB/carto-react/pull/274)
 - Improve styles for MaterialUI Chip component [#275](https://github.com/CartoDB/carto-react/pull/275)

--- a/packages/react-ui/src/theme/carto-theme.js
+++ b/packages/react-ui/src/theme/carto-theme.js
@@ -1317,12 +1317,8 @@ export const cartoThemeOptions = {
       variant: 'body2'
     },
     MuiToggleButtonGroup: {
-      size: 'small',
       orientation: 'horizontal',
       exclusive: true
-    },
-    MuiToggleButton: {
-      size: 'small'
     },
     CircularProgress: {
       size: 40,


### PR DESCRIPTION
In the PR #269, Edgar modified the default size value for ToggleButtonGroup and ToggleButton components.

In Material UI, both components have medium `size` as default value, instead of `small`.

That change made the projects styles to break:

Using small:
![image](https://user-images.githubusercontent.com/9151432/150307118-20a39c33-35d5-4b12-866c-1368a8f78b15.png)

Using medium:
![image](https://user-images.githubusercontent.com/9151432/150307134-b6f4b3a5-2568-4964-ab4e-5308a1dd74e4.png)

This PR is to remove small size, and leave the default Material UI value as our default value.