### PR TITLE
Fix Wrong word break in widgets title, fix JS error in category label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Improve styles for for MaterialUI CircularProgress component [#270](https://github.com/CartoDB/carto-react/pull/270)
 - Improve styles for MaterialUI Slider component [#274](https://github.com/CartoDB/carto-react/pull/274)
 - Improve styles for MaterialUI Chip component [#275](https://github.com/CartoDB/carto-react/pull/275)
+- Fix wrong word break in widgets title [#290](https://github.com/CartoDB/carto-react/pull/290)
+- Fix JS error in category label [#290](https://github.com/CartoDB/carto-react/pull/290)
 
 ## 1.2
 

--- a/packages/react-ui/src/widgets/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI.js
@@ -429,7 +429,6 @@ function CategoryWidgetUI(props) {
                 variant='body2'
                 className={classes.label}
                 noWrap
-                zeroMinWidth
                 ref={textElementRef}
               >
                 {getCategoryLabel(data.name)}

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.js
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.js
@@ -75,7 +75,7 @@ const useStyles = makeStyles((theme) => ({
     }
   },
   buttonText: ({ expanded }) => ({
-    wordBreak: 'break-all',
+    wordBreak: 'break-word',
     overflow: 'hidden',
     ...(expanded && {
       display: '-webkit-box',


### PR DESCRIPTION
Story details: https://app.shortcut.com/cartoteam/story/203899

- Wrong word break in widgets title
- JS error in category label