### PR TITLE
Fix size default value in ToggleButton storybook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Fix size default value in ToggleButton storybook [#292](https://github.com/CartoDB/carto-react/pull/292)
 - Add missing filterable default value [#291](https://github.com/CartoDB/carto-react/pull/291)
 - Remove custom ToggleButtonGroup and ToggleButton default size value [#289](https://github.com/CartoDB/carto-react/pull/289)
 - Improve styles for for MaterialUI CircularProgress component [#270](https://github.com/CartoDB/carto-react/pull/270)

--- a/packages/react-ui/storybook/stories/common/ToggleButton.stories.js
+++ b/packages/react-ui/storybook/stories/common/ToggleButton.stories.js
@@ -10,7 +10,7 @@ const options = {
   component: ToggleButtonGroup,
   argTypes: {
     size: {
-      defaultValue: 'small',
+      defaultValue: 'medium',
       control: {
         type: 'select',
         options: ['small', 'medium', 'large']
@@ -72,7 +72,6 @@ const DefaultPropsTemplate = () => {
 
   return (
     <ToggleButtonGroup
-      size='small'
       orientation='horizontal'
       exclusive={false}
       value={selected}


### PR DESCRIPTION
Use medium as default value in ToggleButton storybook

![image](https://user-images.githubusercontent.com/9151432/150316815-c1c42a68-dbc0-4667-8bb5-2e53c6a60320.png)
