### PR TITLE
Add missing property 'googleMapId'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Align legend icon with its label [#300](https://github.com/CartoDB/carto-react/pull/300)
 - Align legend expand icon with title [#299](https://github.com/CartoDB/carto-react/pull/299)
 - Use LegendComponent in LegendWidgetUI as JSX component to avoid react errors [#295](https://github.com/CartoDB/carto-react/pull/295)
+- Add missing property (`googleMapId`) to `InitialCarto2State` [#294](https://github.com/CartoDB/carto-react/pull/294)
 - Improve styles for MaterialUI Dialog component [#272](https://github.com/CartoDB/carto-react/pull/272)
 
 ## 1.2

--- a/packages/react-redux/src/index.d.ts
+++ b/packages/react-redux/src/index.d.ts
@@ -7,4 +7,5 @@ export {
   InitialOauthState,
   OauthState,
   ViewState,
+  InitialCarto3State,
 } from './types';

--- a/packages/react-redux/src/types.d.ts
+++ b/packages/react-redux/src/types.d.ts
@@ -20,6 +20,7 @@ type InitialCarto2State = {
   basemap: CartoBasemapsNames,
   credentials: Credentials,
   googleApiKey: string,
+  googleMapId: string,
 }
 
 type OauthCarto3 = {


### PR DESCRIPTION
# Description

Shortcut: [(link)](https://app.shortcut.com/cartoteam/story/196602/error-removing-oauth-section-from-typescript-template)

Removing `oauth` section from `initialStateSlice`, in **@carto/cra-template-base-3-typescript**, cause an error in `ProtectedRoute`. We have to update template adding properly type to `initialStateSlice` but first we need to update the `InitialCarto2State` to include `googleMapId`.


## Type of change

- Fix
