### PR TITLE
Use LegendComponent in LegendWidgetUI as JSX component to avoid react errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Use LegendComponent in LegendWidgetUI as JSX component to avoid react errors [#295](https://github.com/CartoDB/carto-react/pull/295)
 - Improve styles for MaterialUI Dialog component [#272](https://github.com/CartoDB/carto-react/pull/272)
 
 ## 1.2

--- a/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
+++ b/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
@@ -202,8 +202,8 @@ function LegendRows({ layers = [], onChangeVisibility }) {
             attr={attr}
             onChangeVisibility={onChangeVisibility}
           >
-            {LegendComponent({
-              legend: {
+            <LegendComponent
+              legend={{
                 type,
                 collapsible,
                 note,
@@ -212,8 +212,8 @@ function LegendRows({ layers = [], onChangeVisibility }) {
                 labels,
                 icons,
                 stats
-              }
-            })}
+              }}
+            />
           </LegendWrapper>
           {!isSingle && !isLast && <Divider />}
         </Fragment>


### PR DESCRIPTION
Story details: https://app.shortcut.com/cartoteam/story/198202

The error happened when you render a legend that uses hooks (icon and proportion) after the first rendering. Because LegendComponent was being called as hook instead of JSX component. Using JSX component, you can change hooks order, but not using a hook.