### PR TITLE
Export new CartoTheme type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not released
 
 - Improve styles for MaterialUI Dialog component [#272](https://github.com/CartoDB/carto-react/pull/272)
+- Add and export CartoTheme type that describe our custom theme [#298](https://github.com/CartoDB/carto-react/pull/298)
 
 ## 1.2
 

--- a/packages/react-ui/src/index.d.ts
+++ b/packages/react-ui/src/index.d.ts
@@ -1,4 +1,4 @@
-import { cartoThemeOptions } from './theme/carto-theme';
+import { cartoThemeOptions, CartoTheme } from './theme/carto-theme';
 import WrapperWidgetUI from './widgets/WrapperWidgetUI';
 import CategoryWidgetUI from './widgets/CategoryWidgetUI';
 import FormulaWidgetUI from './widgets/FormulaWidgetUI';
@@ -19,6 +19,7 @@ import FeatureSelectionWidgetUI from './widgets/FeatureSelectionWidgetUI';
 
 export {
   cartoThemeOptions,
+  CartoTheme,
   WrapperWidgetUI,
   CategoryWidgetUI,
   FormulaWidgetUI,

--- a/packages/react-ui/src/theme/carto-theme.d.ts
+++ b/packages/react-ui/src/theme/carto-theme.d.ts
@@ -1,3 +1,19 @@
-import { ThemeOptions } from '@material-ui/core';
+import { Theme, ThemeOptions } from '@material-ui/core';
+import { Palette, PaletteColor } from '@material-ui/core/styles/createPalette';
 
 export const cartoThemeOptions: ThemeOptions;
+
+type Modify<T, R> = Omit<T, keyof R> & R
+type CustomPaletteColor = Modify<PaletteColor, { relatedLight: string }>
+type CustomPalette = Modify<Palette, {
+  primary: CustomPaletteColor,
+  secondary: CustomPaletteColor,
+  error: CustomPaletteColor,
+  warning: CustomPaletteColor,
+  info: CustomPaletteColor,
+  success: CustomPaletteColor,
+}>
+
+export type CartoTheme = Modify<Theme, {
+  palette: CustomPalette
+}>


### PR DESCRIPTION
# Description

Shortcut: [(link)](https://app.shortcut.com/cartoteam/story/191390/theme-include-custom-props-in-exported-type)

Create and export a new type, `CartoTheme` to be used in other projects, as `cloud-native`

When this feature is released, we have to upgrade other projects and remove workarounds. 

Usage:
![image](https://user-images.githubusercontent.com/7818205/150749300-b9d46166-96f2-4d56-aaaa-227a22cd5f55.png)


```ts
// We have to indicate in *makeStyles* that theme is CartoTheme
const useStyle = makeStyles<CartoTheme>((theme) => ({
  root: {
    marginBottom: theme.spacing(3)
  },
  banner: {
    position: 'relative',
    display: 'flex',
    backgroundColor: theme.palette.primary.relatedLight, // <--- Now we don't need cast to any before access relatedLight
    minHeight: '100%',
    padding: theme.spacing(3),
    borderRadius: theme.spacing(0.5),
    [theme.breakpoints.down('sm')]: {
      paddingBottom: theme.spacing(10)
    }
  }
}
```

## Type of change

- Refactor
