### PR TITLE
Fix react-redux FilterBasic typing

### DIFF
--- a/packages/react-core/src/index.d.ts
+++ b/packages/react-core/src/index.d.ts
@@ -1,3 +1,7 @@
+import {
+  FilterTypes
+} from './filters/FilterQueryBuilder';
+
 export {
   getRequest,
   postRequest,
@@ -28,3 +32,5 @@ export { GroupDateTypes } from './operations/GroupDateTypes';
 export { groupValuesByDateColumn } from './operations/groupByDate';
 
 export { DRAW_MODES, EDIT_MODES } from './utils/drawingToolConstants';
+
+export type _FilterTypes = typeof FilterTypes;

--- a/packages/react-core/src/index.d.ts
+++ b/packages/react-core/src/index.d.ts
@@ -1,7 +1,3 @@
-import {
-  FilterTypes
-} from './filters/FilterQueryBuilder';
-
 export {
   getRequest,
   postRequest,
@@ -32,5 +28,3 @@ export { GroupDateTypes } from './operations/GroupDateTypes';
 export { groupValuesByDateColumn } from './operations/groupByDate';
 
 export { DRAW_MODES, EDIT_MODES } from './utils/drawingToolConstants';
-
-export type _FilterTypes = typeof FilterTypes;

--- a/packages/react-core/src/types.d.ts
+++ b/packages/react-core/src/types.d.ts
@@ -1,33 +1,33 @@
 import { AggregationTypes } from './operations/aggregation/AggregationTypes';
 import { Geometry } from 'geojson';
-import { FilterTypes } from './filters/FilterQueryBuilder';
+import {
+  FilterTypes
+} from './filters/FilterQueryBuilder';
 
 export type AggregationFunctions = {
-  [AggregationTypes.COUNT]: Function;
-  [AggregationTypes.MIN]: Function;
-  [AggregationTypes.MAX]: Function;
-  [AggregationTypes.SUM]: Function;
-  [AggregationTypes.AVG]: Function;
-};
+  [AggregationTypes.COUNT]: Function,
+  [AggregationTypes.MIN]: Function,
+  [AggregationTypes.MAX]: Function,
+  [AggregationTypes.SUM]: Function,
+  [AggregationTypes.AVG]: Function
+}
 
-export type GroupByFeature =
-  | {
-      name: string;
-      value: number;
-    }[]
-  | [];
+export type GroupByFeature = {
+  name: string,
+  value: number
+}[] | [];
 
 export type HistogramFeature = number[] | [];
 
 export type Viewport = [number, number, number, number];
 
 export type TileFeatures = {
-  tiles: any; // TODO: add proper deck.gl type
-  viewport: Viewport;
-  geometry?: Geometry;
-  uniqueIdProperty?: string;
-};
+  tiles: any, // TODO: add proper deck.gl type
+  viewport: Viewport,
+  geometry?: Geometry,
+  uniqueIdProperty?: string
+}
 
-export type TileFeaturesResponse = Record<string, unknown>[] | [];
+export type TileFeaturesResponse = Record<string, unknown>[] | []
 
 export type _FilterTypes = typeof FilterTypes;

--- a/packages/react-core/src/types.d.ts
+++ b/packages/react-core/src/types.d.ts
@@ -1,28 +1,33 @@
 import { AggregationTypes } from './operations/aggregation/AggregationTypes';
 import { Geometry } from 'geojson';
+import { FilterTypes } from './filters/FilterQueryBuilder';
 
 export type AggregationFunctions = {
-  [AggregationTypes.COUNT]: Function,
-  [AggregationTypes.MIN]: Function,
-  [AggregationTypes.MAX]: Function,
-  [AggregationTypes.SUM]: Function,
-  [AggregationTypes.AVG]: Function
-}
+  [AggregationTypes.COUNT]: Function;
+  [AggregationTypes.MIN]: Function;
+  [AggregationTypes.MAX]: Function;
+  [AggregationTypes.SUM]: Function;
+  [AggregationTypes.AVG]: Function;
+};
 
-export type GroupByFeature = {
-  name: string,
-  value: number
-}[] | [];
+export type GroupByFeature =
+  | {
+      name: string;
+      value: number;
+    }[]
+  | [];
 
 export type HistogramFeature = number[] | [];
 
 export type Viewport = [number, number, number, number];
 
 export type TileFeatures = {
-  tiles: any, // TODO: add proper deck.gl type
-  viewport: Viewport,
-  geometry?: Geometry,
-  uniqueIdProperty?: string
-}
+  tiles: any; // TODO: add proper deck.gl type
+  viewport: Viewport;
+  geometry?: Geometry;
+  uniqueIdProperty?: string;
+};
 
-export type TileFeaturesResponse = Record<string, unknown>[] | []
+export type TileFeaturesResponse = Record<string, unknown>[] | [];
+
+export type _FilterTypes = typeof FilterTypes;

--- a/packages/react-redux/src/slices/cartoSlice.d.ts
+++ b/packages/react-redux/src/slices/cartoSlice.d.ts
@@ -1,5 +1,6 @@
 import { Credentials } from '@carto/react-api/';
 import { SourceProps } from '@carto/react-api/types';
+import { _FilterTypes } from '@carto/react-core'
 import { CartoBasemapsNames, GMapsBasemapsNames } from '@carto/react-basemaps/';
 import { InitialCartoState, CartoState, ViewState } from '../types';
 import { AnyAction, Reducer } from 'redux';
@@ -15,9 +16,9 @@ type Layer = {
 type BasemapName = CartoBasemapsNames | GMapsBasemapsNames;
 
 type FilterBasic = {
-  type: '';
+  type: _FilterTypes;
   values: string[] | number[];
-  owner: string;
+  owner?: string;
 };
 
 type FilterCommonProps = {

--- a/packages/react-redux/src/slices/cartoSlice.d.ts
+++ b/packages/react-redux/src/slices/cartoSlice.d.ts
@@ -1,6 +1,6 @@
 import { Credentials } from '@carto/react-api/';
 import { SourceProps } from '@carto/react-api/types';
-import { _FilterTypes } from '@carto/react-core/types'
+import { _FilterTypes } from '@carto/react-core/types';
 import { CartoBasemapsNames, GMapsBasemapsNames } from '@carto/react-basemaps/';
 import { InitialCartoState, CartoState, ViewState } from '../types';
 import { AnyAction, Reducer } from 'redux';
@@ -63,10 +63,12 @@ declare enum CartoActions {
   SET_FEATURES_READY = 'carto/setFeaturesReady',
   SET_CREDENTIALS = 'carto/setCredentials',
   SET_DRAWING_TOOL_MODE = 'carto/setDrawingToolMode',
-  SET_DRAWING_TOOL_ENABLED = 'carto/setDrawingToolEnabled',
+  SET_DRAWING_TOOL_ENABLED = 'carto/setDrawingToolEnabled'
 }
 
-export function createCartoSlice(initialState: InitialCartoState): Reducer<CartoState, AnyAction>;
+export function createCartoSlice(
+  initialState: InitialCartoState
+): Reducer<CartoState, AnyAction>;
 
 export function addSource(source: Source): {
   type: CartoActions.ADD_SOURCE;

--- a/packages/react-redux/src/slices/cartoSlice.d.ts
+++ b/packages/react-redux/src/slices/cartoSlice.d.ts
@@ -1,6 +1,6 @@
 import { Credentials } from '@carto/react-api/';
 import { SourceProps } from '@carto/react-api/types';
-import { _FilterTypes } from '@carto/react-core'
+import { _FilterTypes } from '@carto/react-core/types'
 import { CartoBasemapsNames, GMapsBasemapsNames } from '@carto/react-basemaps/';
 import { InitialCartoState, CartoState, ViewState } from '../types';
 import { AnyAction, Reducer } from 'redux';

--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -252,7 +252,7 @@ export const removeSpatialFilter = (sourceId) => ({
  * Action to add a filter on a given source and column
  * @param {string} id - sourceId of the source to apply the filter on
  * @param {string} column - column to use by the filter at the source
- * @param {FilterType} type - FilterTypes.IN and FilterTypes.BETWEEN
+ * @param {FilterTypes} type - FilterTypes.IN, FilterTypes.BETWEEN, FilterTypes.CLOSED_OPEN and FilterTypes.TIME
  * @param {array} values -  Values for the filter (eg: ['a', 'b'] for IN or [10, 20] for BETWEEN)
  * @param {string} owner - (optional) id of the widget triggering the filter (to be excluded)
  */


### PR DESCRIPTION
# Description

Fix react-redux FilterBasic typing:

- filter property now uses _FilterTypes type based in the FilterTypes constant of react-core package, solving the problems related with the '' type.
- _FilterTypes now is exported in the types.d.ts file, solving the problems related with the import of this type.
- owner now is optional.

## Type of change
- Fix