### PR TITLE
Fix Timeseries wrong filtering with time window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not released
 
 - Upgrade storybook and fix custom-component stories [#303](https://github.com/CartoDB/carto-react/pull/303)
+- Fix Timeseries wrong filtering with time window [#306](https://github.com/CartoDB/carto-react/pull/306)
 
 ## 1.2
 

--- a/packages/react-ui/src/widgets/TimeSeriesWidgetUI/hooks/TimeSeriesContext.js
+++ b/packages/react-ui/src/widgets/TimeSeriesWidgetUI/hooks/TimeSeriesContext.js
@@ -48,7 +48,9 @@ export function TimeSeriesProvider({
 
   useEffect(() => {
     if (_timeWindow.length === 2 && onTimeWindowUpdate) {
-      onTimeWindowUpdate(_timeWindow.sort().map(getDate));
+      onTimeWindowUpdate(
+        _timeWindow.sort((timeA, timeB) => (timeA < timeB ? -1 : 1)).map(getDate)
+      );
     }
     // Only executed when timeWindow changes
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
# Description

Shortcut: [(link)](https://app.shortcut.com/cartoteam/story/205677/redshift-public-map-histogram-breaks-when-filtering-with-timeseries)

Timeseries filter was not working properly, array of **time** was not correctly sorted. Why?
`Array.sort()` sort array of number from least to greatest if numbers are > 0 but not with negatives values.
Instead we have to implement a specific callback to sort array of numbers:
`Array.sort((timeA, timeB) => (timeA < timeB ? -1 : 1))`


## Type of change

- Fix
