### PR TITLE
Legend improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Add option in LegendCategories to draw color strokes [#311](https://github.com/CartoDB/carto-react/pull/311)
+- Expose individual legend type components [#311](https://github.com/CartoDB/carto-react/pull/311)
 - Fix how to read format tiles param from Maps API [#321](https://github.com/CartoDB/carto-react/pull/321)
 - Fix Table Widget style issues [#318](https://github.com/CartoDB/carto-react/pull/318)
 

--- a/packages/react-ui/src/index.d.ts
+++ b/packages/react-ui/src/index.d.ts
@@ -5,6 +5,10 @@ import FormulaWidgetUI from './widgets/FormulaWidgetUI';
 import HistogramWidgetUI from './widgets/HistogramWidgetUI';
 import PieWidgetUI from './widgets/PieWidgetUI';
 import LegendWidgetUI, { LEGEND_TYPES } from './widgets/legend/LegendWidgetUI';
+import LegendCategories from './widgets/legend/LegendCategories';
+import LegendIcon from './widgets/legend/LegendIcon';
+import LegendProportion from './widgets/legend/LegendProportion';
+import LegendRamp from './widgets/legend/LegendRamp';
 import ScatterPlotWidgetUI from './widgets/ScatterPlotWidgetUI';
 import TimeSeriesWidgetUI from './widgets/TimeSeriesWidgetUI/TimeSeriesWidgetUI';
 import {
@@ -35,6 +39,10 @@ export {
   TableWidgetUI,
   LegendWidgetUI,
   LEGEND_TYPES,
-  NoDataAlert
+  NoDataAlert,
+  // undocumented components
+  LegendCategories as _LegendCategories,
+  LegendIcon as _LegendIcon,
+  LegendProportion as _LegendProportion,
+  LegendRamp as _LegendRamp
 };
-

--- a/packages/react-ui/src/index.js
+++ b/packages/react-ui/src/index.js
@@ -5,6 +5,10 @@ import FormulaWidgetUI from './widgets/FormulaWidgetUI';
 import HistogramWidgetUI from './widgets/HistogramWidgetUI';
 import PieWidgetUI from './widgets/PieWidgetUI';
 import LegendWidgetUI, { LEGEND_TYPES } from './widgets/legend/LegendWidgetUI';
+import LegendCategories from './widgets/legend/LegendCategories';
+import LegendIcon from './widgets/legend/LegendIcon';
+import LegendProportion from './widgets/legend/LegendProportion';
+import LegendRamp from './widgets/legend/LegendRamp';
 import ScatterPlotWidgetUI from './widgets/ScatterPlotWidgetUI';
 import TimeSeriesWidgetUI from './widgets/TimeSeriesWidgetUI/TimeSeriesWidgetUI';
 import FeatureSelectionWidgetUI from './widgets/FeatureSelectionWidgetUI';
@@ -40,5 +44,10 @@ export {
   LegendWidgetUI,
   LEGEND_TYPES,
   NoDataAlert,
-  featureSelectionIcons
+  featureSelectionIcons,
+  // undocumented components
+  LegendCategories as _LegendCategories,
+  LegendIcon as _LegendIcon,
+  LegendProportion as _LegendProportion,
+  LegendRamp as _LegendRamp
 };

--- a/packages/react-ui/src/widgets/legend/LegendCategories.js
+++ b/packages/react-ui/src/widgets/legend/LegendCategories.js
@@ -7,12 +7,18 @@ export default function LegendCategories({ legend }) {
     return null;
   }
 
-  const { labels = [], colors = [] } = legend;
+  const { labels = [], colors = [], isStrokeColor = false } = legend;
 
   const palette = getPalette(colors, labels.length);
 
   const Rows = labels.map((label, idx) => (
-    <Row key={label + idx} isMax={false} label={label} color={palette[idx]} />
+    <Row
+      key={label + idx}
+      isMax={false}
+      label={label}
+      color={palette[idx]}
+      isStrokeColor={isStrokeColor}
+    />
   ));
 
   return (
@@ -31,10 +37,11 @@ const useStyles = makeStyles((theme) => ({
   },
   circle: {
     display: 'block',
-    width: '8px',
-    height: '8px',
+    width: '12px',
+    height: '12px',
     borderRadius: '50%',
     position: 'relative',
+    border: '2px solid transparent',
     '&::after': {
       position: 'absolute',
       display: ({ isMax }) => (isMax ? 'block' : 'none'),
@@ -49,7 +56,7 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-function Row({ label, isMax, color = '#000' }) {
+function Row({ label, isMax, isStrokeColor, color = '#000' }) {
   const classes = useStyles({ isMax });
 
   return (
@@ -59,7 +66,7 @@ function Row({ label, isMax, color = '#000' }) {
           mr={1.5}
           component='span'
           className={classes.circle}
-          style={{ backgroundColor: color }}
+          style={isStrokeColor ? { borderColor: color } : { backgroundColor: color }}
         />
       </Tooltip>
       <Typography variant='overline'>{label}</Typography>

--- a/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
+++ b/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
@@ -165,59 +165,35 @@ const LEGEND_COMPONENT_BY_TYPE = {
 function LegendRows({ layers = [], onChangeVisibility }) {
   const isSingle = layers.length === 1;
 
-  return layers.map(
-    (
-      {
-        id,
-        title,
-        switchable,
-        visible,
-        legend: {
-          children = null,
-          type = '',
-          collapsible = true,
-          note = '',
-          attr = '',
-          colors = [],
-          labels = [],
-          icons = [],
-          stats = undefined
-        } = {}
-      },
-      index
-    ) => {
-      const isLast = layers.length - 1 === index;
-      // TODO: Add validation for layer.type
-      const hasChildren = LEGEND_COMPONENT_BY_TYPE[type] || children;
-      const LegendComponent = LEGEND_COMPONENT_BY_TYPE[type] || (() => children);
-      return (
-        <Fragment key={id}>
-          <LegendWrapper
-            id={id}
-            title={title}
-            collapsible={!!(collapsible && hasChildren)}
-            switchable={switchable}
-            visible={visible}
-            note={note}
-            attr={attr}
-            onChangeVisibility={onChangeVisibility}
-          >
-            <LegendComponent
-              legend={{
-                type,
-                collapsible,
-                note,
-                attr,
-                colors,
-                labels,
-                icons,
-                stats
-              }}
-            />
-          </LegendWrapper>
-          {!isSingle && !isLast && <Divider />}
-        </Fragment>
-      );
-    }
-  );
+  return layers.map(({ id, title, switchable, visible, legend = {} }, index) => {
+    const {
+      children = null,
+      type = '',
+      collapsible = true,
+      note = '',
+      attr = ''
+    } = legend;
+
+    const isLast = layers.length - 1 === index;
+    // TODO: Add validation for layer.type
+    const hasChildren = LEGEND_COMPONENT_BY_TYPE[type] || children;
+    const LegendComponent = LEGEND_COMPONENT_BY_TYPE[type] || (() => children);
+    return (
+      <Fragment key={id}>
+        <LegendWrapper
+          id={id}
+          title={title}
+          collapsible={!!(collapsible && hasChildren)}
+          switchable={switchable}
+          visible={visible}
+          note={note}
+          attr={attr}
+          onChangeVisibility={onChangeVisibility}
+        >
+          <LegendComponent legend={legend} />
+        </LegendWrapper>
+        {!isSingle && !isLast && <Divider />}
+      </Fragment>
+    );
+  });
 }

--- a/packages/react-ui/storybook/stories/widgetsUI/LegendWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/LegendWidgetUI.stories.js
@@ -121,17 +121,34 @@ const LegendMultiTemplateCollapsed = () => {
   );
 };
 
+const categoryLegend = {
+  type: 'category',
+  note: 'lorem',
+  colors: ['#000', '#00F', '#0F0'],
+  labels: ['Category 1', 'Category 2', 'Category 3']
+};
+
 const LegendCategoriesTemplate = () => {
   const layers = [
     {
       id: 0,
       title: 'Category Layer',
       visible: true,
+      legend: categoryLegend
+    }
+  ];
+  return <LegendWidgetUI layers={layers}></LegendWidgetUI>;
+};
+
+const LegendCategoriesStrokeTemplate = () => {
+  const layers = [
+    {
+      id: 0,
+      title: 'Category Layer as stroke',
+      visible: true,
       legend: {
-        type: 'category',
-        note: 'lorem',
-        colors: ['#000', '#00F', '#0F0'],
-        labels: ['Category 1', 'Category 2', 'Category 3']
+        ...categoryLegend,
+        isStrokeColor: true
       }
     }
   ];
@@ -242,6 +259,7 @@ export const MultiLayer = LegendMultiTemplate.bind({});
 export const MultiLayerCollapsed = LegendMultiTemplateCollapsed.bind({});
 export const NotFound = LegendNotFoundTemplate.bind({});
 export const Categories = LegendCategoriesTemplate.bind({});
+export const CategoriesAsStroke = LegendCategoriesStrokeTemplate.bind({});
 export const Icon = LegendIconTemplate.bind({});
 export const Ramp = LegendRampTemplate.bind({});
 export const Proportion = LegendProportionTemplate.bind({});


### PR DESCRIPTION
 - Expose internal legend types components (`LegendCategories`, `LegendIcon`, `LegendRamp`, & `LegendProportion`) to allow re-use outside the high-level `LegendWidget`
 - Add `isStrokeColor` prop to `LegendCategories` to draw colors as circles instead of disks
![Capture d’écran de 2022-02-07 15-37-32](https://user-images.githubusercontent.com/243653/152809059-905e6ea7-34b1-481b-9576-a7df2e8fc3a6.png)

