### PR TITLE
Polish Table Widget styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # CHANGELOG
 
 ## Not released
+
 - Fix how to read format tiles param from Maps API [#321](https://github.com/CartoDB/carto-react/pull/321)
+- Fix Table Widget style issues [#318](https://github.com/CartoDB/carto-react/pull/318)
 
 ## 1.2
 

--- a/packages/react-ui/src/theme/carto-theme.js
+++ b/packages/react-ui/src/theme/carto-theme.js
@@ -1145,6 +1145,52 @@ export const cartoThemeOptions = {
         }
       }
     },
+
+    MuiTablePagination: {
+      select: {
+        paddingRight: spacing(7.5),
+        paddingLeft: spacing(1.5)
+      },
+      input: {
+        height: spacing(4),
+        border: `2px solid ${variables.palette.other.divider}`,
+        borderRadius: spacing(0.5),
+        fontWeight: variables.typography.fontWeightMedium,
+        '& .MuiSelect-icon': {
+          top: '50%',
+          transform: 'translateY(-50%)',
+          width: spacing(2.25),
+          height: spacing(2.25),
+          right: spacing(0.75)
+        }
+      },
+      caption: {
+        ...variables.typography.caption,
+        '&:first-of-type': {
+          color: variables.palette.text.secondary
+        }
+      },
+      toolbar: {
+        minHeight: 0,
+        marginTop: spacing(1)
+      },
+      actions: {
+        '& button:last-child': {
+          marginLeft: spacing(2)
+        }
+      }
+    },
+
+    MuiTableCell: {
+      head: {
+        ...variables.typography.caption,
+        color: variables.palette.text.secondary
+      },
+      stickyHeader: {
+        backgroundColor: variables.palette.common.white
+      }
+    },
+
     // MuiToggleButton
     MuiToggleButton: {
       root: {

--- a/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
+++ b/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
@@ -13,14 +13,9 @@ import {
 } from '@material-ui/core';
 
 const useStyles = makeStyles((theme) => ({
-  tableHead: {
-    '& .MuiTableCell-head, & .MuiTableCell-head span': {
-      ...theme.typography.caption,
-      color: theme.palette.text.secondary
-    },
-    '& th.MuiTableCell-stickyHeader': {
-      backgroundColor: theme.palette.common.white
-    }
+  tableHeadCellLabel: {
+    ...theme.typography.caption,
+    color: theme.palette.text.secondary
   },
   tableRow: {
     maxHeight: theme.spacing(6.5),
@@ -37,19 +32,6 @@ const useStyles = makeStyles((theme) => ({
       whiteSpace: 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis'
-    }
-  },
-  pagination: {
-    '& .MuiTablePagination-caption': {
-      ...theme.typography.caption
-    },
-    '& .MuiTablePagination-caption:first-of-type': {
-      color: theme.palette.text.secondary
-    },
-    '& .MuiTablePagination-input': {
-      minHeight: theme.spacing(4.5),
-      border: `2px solid ${theme.palette.divider}`,
-      borderRadius: theme.spacing(0.5)
     }
   }
 }));
@@ -132,7 +114,7 @@ function TableHeaderComponent({ columns, sorting, sortBy, sortDirection, onSort 
   const classes = useStyles();
 
   return (
-    <TableHead className={classes.tableHead}>
+    <TableHead>
       <TableRow>
         {columns.map(({ field, headerName, align }) => (
           <TableCell key={field} align={align || 'left'}>
@@ -141,6 +123,7 @@ function TableHeaderComponent({ columns, sorting, sortBy, sortDirection, onSort 
                 active={sortBy === field}
                 direction={sortBy === field ? sortDirection : 'asc'}
                 onClick={() => onSort(field)}
+                className={classes.tableHeadCellLabel}
               >
                 {headerName}
               </TableSortLabel>


### PR DESCRIPTION
Story details: https://app.shortcut.com/cartoteam/story/204634

* Move table widget styles into carto theme overrides in order to avoid explicit classname selectors which are not working in Private Builder. 
* Styles polishing