### PR TITLE
Adaptation to the new parameters returned by the MAPS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Not released
 
+## 1.2
+
+### 1.2.1-beta.3 (2022-02-09)
+
+- Read formatTile from MAPS API tile url param instead of format to know the tiles format
 - TimeSeriesWidget applying received formatter to yAxis [#315](https://github.com/CartoDB/carto-react/pull/315)
 - Export FilterTypes enum [#314](https://github.com/CartoDB/carto-react/pull/314)
 - Improve lasso tool copies [#313](https://github.com/CartoDB/carto-react/pull/313)
-
-## 1.2
 
 ### 1.2.1-beta.2 (2022-02-08)
 

--- a/packages/react-api/src/hooks/useTileFeatures.js
+++ b/packages/react-api/src/hooks/useTileFeatures.js
@@ -120,7 +120,7 @@ export default function useTileFeatures({
   );
 
   const onDataLoad = useCallback(({ tiles: [tile] }) => {
-    const tilesFormat = new URLSearchParams(tile).get('format');
+    const tilesFormat = new URLSearchParams(tile).get('formatTiles');
     setTileFormat(tilesFormat || TILE_FORMATS.MVT);
   }, []);
 


### PR DESCRIPTION
# Description
The tile format is returned in the `formatTiles` URL  tile param instead of `format`

## Type of change
- Feature