### PR TITLE
Fix Switch input width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix Switch input width [#323](https://github.com/CartoDB/carto-react/pull/323)
+
 ## 1.2
 
 ### 1.2.1-beta.4 (2022-02-10)

--- a/packages/react-ui/src/theme/carto-theme.js
+++ b/packages/react-ui/src/theme/carto-theme.js
@@ -926,6 +926,11 @@ export const cartoThemeOptions = {
         boxShadow: 'none'
       },
 
+      input: {
+        width: spacing(6),
+        left: spacing(-1.5)
+      },
+
       track: {
         height: 'auto',
         border: `2px solid ${variables.palette.text.secondary}`,


### PR DESCRIPTION
By default the Switch input takes too much space.
![image](https://user-images.githubusercontent.com/9151432/153558090-b9c9646f-7b13-46e2-920a-f5134fd58f62.png)

After these changes, the Switch input takes the necessary space.
![image](https://user-images.githubusercontent.com/9151432/153558273-250c83ca-f668-48f9-901d-fcfa9882df5d.png)
