### PR TITLE
Add optional slider to modify layer opacity in Legend widget

### DIFF
--- a/packages/react-ui/__tests__/widgets/LegendWidgetUI.test.js
+++ b/packages/react-ui/__tests__/widgets/LegendWidgetUI.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { getMaterialUIContext } from './testUtils';
 import LegendWidgetUI from '../../src/widgets/legend/LegendWidgetUI';
-import { render, screen } from '@testing-library/react';
-import { Typography } from '@material-ui/core';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { TextField, Typography } from '@material-ui/core';
 
 const CUSTOM_CHILDREN = <Typography>Legend custom</Typography>;
 
@@ -69,6 +69,16 @@ describe('LegendWidgetUI', () => {
       legend: {
         children: CUSTOM_CHILDREN
       }
+    },
+    {
+      id: 'custom',
+      title: 'Single Layer',
+      visible: true,
+      showOpacityControl: true,
+      opacity: 0.6,
+      legend: {
+        children: CUSTOM_CHILDREN
+      }
     }
   ];
   const Widget = (props) => getMaterialUIContext(<LegendWidgetUI {...props} />);
@@ -114,9 +124,28 @@ describe('LegendWidgetUI', () => {
     render(<Widget layers={[DATA[4]]}></Widget>);
     expect(screen.getByTestId('proportion-legend')).toBeInTheDocument();
   });
-
+  
   test('Custom legend', () => {
     render(<Widget layers={[DATA[5]]}></Widget>);
     expect(screen.getByText('Legend custom')).toBeInTheDocument();
+  });
+  
+  test('legend with opacity control', () => {
+    const legendConfig = DATA[6];
+    const onChangeOpacity = jest.fn();
+    const container = render(<Widget layers={[legendConfig]} onChangeOpacity={onChangeOpacity}></Widget>);
+    const layerOptionsBtn = screen.getByTitle('Layer options')
+    expect(layerOptionsBtn).toBeInTheDocument();
+    layerOptionsBtn.click()
+    expect(screen.getByText('Opacity')).toBeInTheDocument();
+
+    const opacitySelectorInput = container.getByTestId('opacity-slider')
+    expect(opacitySelectorInput.value).toBe('' + (legendConfig.opacity * 100));
+    
+    fireEvent.change(opacitySelectorInput, { target: { value: '50' } })
+  
+
+    expect(onChangeOpacity).toHaveBeenCalledTimes(1)
+    expect(onChangeOpacity).toHaveBeenCalledWith({ id: legendConfig.id, opacity: 0.5 })
   });
 });

--- a/packages/react-ui/src/assets/LayerIcon.js
+++ b/packages/react-ui/src/assets/LayerIcon.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { SvgIcon } from '@material-ui/core';
+
+export default function LayerIcon(props) {
+  return (
+    <SvgIcon {...props}>
+      <path
+        d='M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14z'
+        fillOpacity='.6'
+      />
+      <path
+        d='M9 15h2v2H9v-2zm0-4h2v2H9v-2zm0-4h2v2H9V7zm-4 8h2v2H5v-2zm0-4h2v2H5v-2zm0-4h2v2H5V7zm12 8h2v2h-2v-2zm0-4h2v2h-2v-2zm0-4h2v2h-2V7zm-2 10h2v2h-2v-2zm0-4h2v2h-2v-2zm0-4h2v2h-2V9zm0-4h2v2h-2V5zM7 17h2v2H7v-2zm0-4h2v2H7v-2zm0-4h2v2H7V9zm0-4h2v2H7V5zm6 10h2v2h-2v-2zm0-4h2v2h-2v-2zm0-4h2v2h-2V7zm-2 10h2v2h-2v-2zm0-4h2v2h-2v-2zm0-4h2v2h-2V9zm0-4h2v2h-2V5z'
+        fillOpacity='.36'
+      />
+    </SvgIcon>
+  );
+}

--- a/packages/react-ui/src/widgets/OpacityControl.js
+++ b/packages/react-ui/src/widgets/OpacityControl.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import {
+  Box,
+  Grid,
+  InputAdornment,
+  makeStyles,
+  Slider,
+  TextField
+} from '@material-ui/core';
+import LayerOptionWrapper from './legend/LayerOptionWrapper';
+
+const useOpacityControlStyles = makeStyles(({ spacing }) => ({
+  content: {
+    height: 'auto',
+    flex: 1
+  },
+  slider: {
+    marginTop: spacing(1)
+  },
+  input: {
+    width: spacing(8),
+    '& input': {
+      '&[type=number]': {
+        appearance: 'textfield'
+      },
+      '&::-webkit-outer-spin-button': {
+        appearance: 'none',
+        margin: 0
+      },
+      '&::-webkit-inner-spin-button': {
+        appearance: 'none',
+        margin: 0
+      }
+    },
+    '& .MuiInputAdornment-positionEnd': {
+      margin: 0
+    }
+  }
+}));
+
+export default function OpacityControl({ opacity, onChangeOpacity }) {
+  const classes = useOpacityControlStyles();
+  const handleTextFieldChange = (e) => {
+    const newOpacity = parseInt(e.target.value || '0');
+    onChangeOpacity(Math.max(0, Math.min(100, newOpacity)) / 100);
+  };
+
+  return (
+    <LayerOptionWrapper label='Opacity'>
+      <Box className={classes.content}>
+        <Grid container spacing={2} direction='row' alignItems='center'>
+          <Grid item xs>
+            <Slider
+              value={Math.round(opacity * 100)}
+              min={0}
+              max={100}
+              step={1}
+              onChange={(_, value) => onChangeOpacity(value / 100)}
+              aria-labelledby='input-slider'
+              className={classes.slider}
+            />
+          </Grid>
+          <Grid item>
+            <TextField
+              className={classes.input}
+              value={Math.round(opacity * 100)}
+              margin='dense'
+              onChange={handleTextFieldChange}
+              InputProps={{
+                step: 1,
+                min: 0,
+                max: 100,
+                type: 'number',
+                inputProps: { 'data-testid': 'opacity-slider' },
+                'aria-labelledby': 'opacity-slider',
+                endAdornment: <InputAdornment position='end'>%</InputAdornment>
+              }}
+            />
+          </Grid>
+        </Grid>
+      </Box>
+    </LayerOptionWrapper>
+  );
+}

--- a/packages/react-ui/src/widgets/legend/LayerOptionWrapper.js
+++ b/packages/react-ui/src/widgets/legend/LayerOptionWrapper.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Box, Typography } from '@material-ui/core';
+
+export default function LayerOptionWrapper({ className = '', label, children }) {
+  return (
+    <Box className={className} px={2} py={1.5}>
+      <Typography variant='caption' color='textPrimary'>{label}</Typography>
+      <Box>{children}</Box>
+    </Box>
+  );
+}

--- a/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
+++ b/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
@@ -49,7 +49,8 @@ function LegendWidgetUI({
   layers = [],
   collapsed,
   onCollapsedChange,
-  onChangeVisibility
+  onChangeVisibility,
+  onChangeOpacity,
 }) {
   const classes = useStyles();
   const isSingle = layers.length === 1;
@@ -61,7 +62,7 @@ function LegendWidgetUI({
         collapsed={collapsed}
         onCollapsedChange={onCollapsedChange}
       >
-        <LegendRows layers={layers} onChangeVisibility={onChangeVisibility} />
+        <LegendRows layers={layers} onChangeVisibility={onChangeVisibility} onChangeOpacity={onChangeOpacity} />
       </LegendContainer>
     </Box>
   );
@@ -77,7 +78,8 @@ LegendWidgetUI.propTypes = {
   layers: PropTypes.array,
   collapsed: PropTypes.bool,
   onCollapsedChange: PropTypes.func,
-  onChangeVisibility: PropTypes.func
+  onChangeVisibility: PropTypes.func,
+  onChangeOpacity: PropTypes.func
 };
 
 export default LegendWidgetUI;
@@ -157,15 +159,15 @@ export const LEGEND_TYPES = {
 const LEGEND_COMPONENT_BY_TYPE = {
   [LEGEND_TYPES.CATEGORY]: LegendCategories,
   [LEGEND_TYPES.ICON]: LegendIcon,
-  [LEGEND_TYPES.CONTINUOUS_RAMP]: (args) => LegendRamp({ ...args, isContinuous: true }),
-  [LEGEND_TYPES.BINS]: (args) => LegendRamp({ ...args, isContinuous: false }),
+  [LEGEND_TYPES.CONTINUOUS_RAMP]: (args) => <LegendRamp {...args} isContinuous={true} />,
+  [LEGEND_TYPES.BINS]: (args) => <LegendRamp {...args} isContinuous={false} />,
   [LEGEND_TYPES.PROPORTION]: LegendProportion
 };
 
-function LegendRows({ layers = [], onChangeVisibility }) {
+function LegendRows({ layers = [], onChangeVisibility, onChangeOpacity }) {
   const isSingle = layers.length === 1;
 
-  return layers.map(({ id, title, switchable, visible, legend = {} }, index) => {
+  return layers.map(({ id, title, switchable, visible, showOpacityControl = false, opacity = 1, legend = {} }, index) => {
     const {
       children = null,
       type = '',
@@ -188,6 +190,9 @@ function LegendRows({ layers = [], onChangeVisibility }) {
           visible={visible}
           note={note}
           attr={attr}
+          showOpacityControl={showOpacityControl}
+          opacity={opacity}
+          onChangeOpacity={onChangeOpacity}
           onChangeVisibility={onChangeVisibility}
         >
           <LegendComponent legend={legend} />

--- a/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
+++ b/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
@@ -50,7 +50,7 @@ function LegendWidgetUI({
   collapsed,
   onCollapsedChange,
   onChangeVisibility,
-  onChangeOpacity,
+  onChangeOpacity
 }) {
   const classes = useStyles();
   const isSingle = layers.length === 1;
@@ -62,7 +62,11 @@ function LegendWidgetUI({
         collapsed={collapsed}
         onCollapsedChange={onCollapsedChange}
       >
-        <LegendRows layers={layers} onChangeVisibility={onChangeVisibility} onChangeOpacity={onChangeOpacity} />
+        <LegendRows
+          layers={layers}
+          onChangeVisibility={onChangeVisibility}
+          onChangeOpacity={onChangeOpacity}
+        />
       </LegendContainer>
     </Box>
   );
@@ -167,38 +171,55 @@ const LEGEND_COMPONENT_BY_TYPE = {
 function LegendRows({ layers = [], onChangeVisibility, onChangeOpacity }) {
   const isSingle = layers.length === 1;
 
-  return layers.map(({ id, title, switchable, visible, showOpacityControl = false, opacity = 1, legend = {} }, index) => {
-    const {
-      children = null,
-      type = '',
-      collapsible = true,
-      note = '',
-      attr = ''
-    } = legend;
+  return (
+    <>
+      {layers.map(
+        (
+          {
+            id,
+            title,
+            switchable,
+            visible,
+            showOpacityControl = false,
+            opacity = 1,
+            legend = {}
+          },
+          index
+        ) => {
+          const {
+            children = null,
+            type = '',
+            collapsible = true,
+            note = '',
+            attr = ''
+          } = legend;
 
-    const isLast = layers.length - 1 === index;
-    // TODO: Add validation for layer.type
-    const hasChildren = LEGEND_COMPONENT_BY_TYPE[type] || children;
-    const LegendComponent = LEGEND_COMPONENT_BY_TYPE[type] || (() => children);
-    return (
-      <Fragment key={id}>
-        <LegendWrapper
-          id={id}
-          title={title}
-          collapsible={!!(collapsible && hasChildren)}
-          switchable={switchable}
-          visible={visible}
-          note={note}
-          attr={attr}
-          showOpacityControl={showOpacityControl}
-          opacity={opacity}
-          onChangeOpacity={onChangeOpacity}
-          onChangeVisibility={onChangeVisibility}
-        >
-          <LegendComponent legend={legend} />
-        </LegendWrapper>
-        {!isSingle && !isLast && <Divider />}
-      </Fragment>
-    );
-  });
+          const isLast = layers.length - 1 === index;
+          // TODO: Add validation for layer.type
+          const hasChildren = LEGEND_COMPONENT_BY_TYPE[type] || children;
+          const LegendComponent = LEGEND_COMPONENT_BY_TYPE[type] || (() => children);
+          return (
+            <Fragment key={id}>
+              <LegendWrapper
+                id={id}
+                title={title}
+                collapsible={!!(collapsible && hasChildren)}
+                switchable={switchable}
+                visible={visible}
+                note={note}
+                attr={attr}
+                showOpacityControl={showOpacityControl}
+                opacity={opacity}
+                onChangeOpacity={onChangeOpacity}
+                onChangeVisibility={onChangeVisibility}
+              >
+                <LegendComponent legend={legend} />
+              </LegendWrapper>
+              {!isSingle && !isLast && <Divider />}
+            </Fragment>
+          );
+        }
+      )}
+    </>
+  );
 }

--- a/packages/react-ui/src/widgets/legend/LegendWrapper.js
+++ b/packages/react-ui/src/widgets/legend/LegendWrapper.js
@@ -262,35 +262,6 @@ function OpacityControl({ opacity, onChangeOpacity }) {
           </Grid>
         </Grid>
       </Box>
-      {/* <Grid
-        container
-        wrap='nowrap'
-        direction='row'
-        alignItems='center'
-        justifyContent='space-between'
-      >
-        <Grid item xs={6}>
-          <Slider
-            value={Math.round(opacity * 100)}
-            aria-labelledby='opacity-slider'
-            min={0}
-            max={100}
-            step={1}
-            onChange={(_, value) => onChangeOpacity(value / 100)}
-          />
-        </Grid>
-        <Grid item xs={4}>
-          <TextField
-            size='small'
-            id='opacity-text'
-            value={Math.round(opacity * 100)}
-            onChange={handleTextFieldChange}
-            InputProps={{
-              endAdornment: <InputAdornment position='end'>%</InputAdornment>
-            }}
-          />
-        </Grid>
-      </Grid>*/}
     </LayerOptionWrapper>
   );
 }

--- a/packages/react-ui/src/widgets/legend/LegendWrapper.js
+++ b/packages/react-ui/src/widgets/legend/LegendWrapper.js
@@ -5,20 +5,16 @@ import {
   Collapse,
   Grid,
   Icon,
-  Input,
-  InputAdornment,
   makeStyles,
-  Slider,
   Switch,
-  TextField,
   Tooltip,
   Typography
 } from '@material-ui/core';
 import { ExpandLess, ExpandMore } from '@material-ui/icons';
 import Note from './Note';
 import LayerIcon from '../../assets/LayerIcon';
-import LayerOptionWrapper from './LayerOptionWrapper';
 import { ToggleButton } from '@material-ui/lab';
+import OpacityControl from '../OpacityControl';
 
 const useStyles = makeStyles((theme) => ({
   legendWrapper: {
@@ -190,79 +186,5 @@ function Header({
         </Tooltip>
       )}
     </Grid>
-  );
-}
-
-const useOpacityControlStyles = makeStyles(({ spacing }) => ({
-  content: {
-    height: 'auto',
-    flex: 1
-  },
-  slider: {
-    marginTop: spacing(1)
-  },
-  input: {
-    width: spacing(8),
-    '& input': {
-      '&[type=number]': {
-        appearance: 'textfield'
-      },
-      '&::-webkit-outer-spin-button': {
-        appearance: 'none',
-        margin: 0
-      },
-      '&::-webkit-inner-spin-button': {
-        appearance: 'none',
-        margin: 0
-      }
-    },
-    '& .MuiInputAdornment-positionEnd': {
-      margin: 0
-    }
-  }
-}));
-
-function OpacityControl({ opacity, onChangeOpacity }) {
-  const classes = useOpacityControlStyles();
-  const handleTextFieldChange = (e) => {
-    const newOpacity = parseInt(e.target.value || '0');
-    onChangeOpacity(Math.max(0, Math.min(100, newOpacity)) / 100);
-  };
-
-  return (
-    <LayerOptionWrapper label='Opacity'>
-      <Box className={classes.content}>
-        <Grid container spacing={2} direction='row' alignItems='center'>
-          <Grid item xs>
-            <Slider
-              value={Math.round(opacity * 100)}
-              min={0}
-              max={100}
-              step={1}
-              onChange={(_, value) => onChangeOpacity(value / 100)}
-              aria-labelledby='input-slider'
-              className={classes.slider}
-            />
-          </Grid>
-          <Grid item>
-            <TextField
-              className={classes.input}
-              value={Math.round(opacity * 100)}
-              margin='dense'
-              onChange={handleTextFieldChange}
-              InputProps={{
-                step: 1,
-                min: 0,
-                max: 100,
-                type: 'number',
-                inputProps: { 'data-testid': 'opacity-slider' },
-                'aria-labelledby': 'opacity-slider',
-                endAdornment: <InputAdornment position='end'>%</InputAdornment>
-              }}
-            />
-          </Grid>
-        </Grid>
-      </Box>
-    </LayerOptionWrapper>
   );
 }

--- a/packages/react-ui/src/widgets/legend/LegendWrapper.js
+++ b/packages/react-ui/src/widgets/legend/LegendWrapper.js
@@ -255,7 +255,8 @@ function OpacityControl({ opacity, onChangeOpacity }) {
                 min: 0,
                 max: 100,
                 type: 'number',
-                'aria-labelledby': 'input-slider',
+                inputProps: { 'data-testid': 'opacity-slider' },
+                'aria-labelledby': 'opacity-slider',
                 endAdornment: <InputAdornment position='end'>%</InputAdornment>
               }}
             />

--- a/packages/react-ui/storybook/stories/widgetsUI/LegendWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/LegendWidgetUI.stories.js
@@ -41,22 +41,6 @@ const Template = ({ ...args }) => {
   );
 };
 
-const LegendWithOpacityTemplate = () => {
-  const layers = [
-    {
-      id: 0,
-      title: 'Single Layer',
-      visible: true,
-      showOpacityControl: true,
-      opacity: 0.5,
-      legend: {
-        children: <div>Your Content</div>,
-      }
-    }
-  ];
-  return <LegendWidgetUI layers={layers}></LegendWidgetUI>;
-};
-
 
 const LegendTemplate = () => {
   const layers = [
@@ -78,6 +62,22 @@ const LegendNotFoundTemplate = () => {
       id: 0,
       title: 'Single Layer',
       visible: true
+    }
+  ];
+  return <LegendWidgetUI layers={layers}></LegendWidgetUI>;
+};
+
+const LegendWithOpacityTemplate = () => {
+  const layers = [
+    {
+      id: 0,
+      title: 'Single Layer',
+      visible: true,
+      showOpacityControl: true,
+      opacity: 0.5,
+      legend: {
+        children: <div>Your Content</div>,
+      }
     }
   ];
   return <LegendWidgetUI layers={layers}></LegendWidgetUI>;
@@ -272,10 +272,10 @@ const LegendNoChildrenTemplate = () => {
 export const Playground = Template.bind({});
 
 export const SingleLayer = LegendTemplate.bind({});
-export const LegendWithOpacityControl = LegendWithOpacityTemplate.bind({});
 export const MultiLayer = LegendMultiTemplate.bind({});
 export const MultiLayerCollapsed = LegendMultiTemplateCollapsed.bind({});
 export const NotFound = LegendNotFoundTemplate.bind({});
+export const LegendWithOpacityControl = LegendWithOpacityTemplate.bind({});
 export const Categories = LegendCategoriesTemplate.bind({});
 export const CategoriesAsStroke = LegendCategoriesStrokeTemplate.bind({});
 export const Icon = LegendIconTemplate.bind({});

--- a/packages/react-ui/storybook/stories/widgetsUI/LegendWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/LegendWidgetUI.stories.js
@@ -41,6 +41,23 @@ const Template = ({ ...args }) => {
   );
 };
 
+const LegendWithOpacityTemplate = () => {
+  const layers = [
+    {
+      id: 0,
+      title: 'Single Layer',
+      visible: true,
+      showOpacityControl: true,
+      opacity: 0.5,
+      legend: {
+        children: <div>Your Content</div>,
+      }
+    }
+  ];
+  return <LegendWidgetUI layers={layers}></LegendWidgetUI>;
+};
+
+
 const LegendTemplate = () => {
   const layers = [
     {
@@ -255,6 +272,7 @@ const LegendNoChildrenTemplate = () => {
 export const Playground = Template.bind({});
 
 export const SingleLayer = LegendTemplate.bind({});
+export const LegendWithOpacityControl = LegendWithOpacityTemplate.bind({});
 export const MultiLayer = LegendMultiTemplate.bind({});
 export const MultiLayerCollapsed = LegendMultiTemplateCollapsed.bind({});
 export const NotFound = LegendNotFoundTemplate.bind({});

--- a/packages/react-widgets/src/widgets/LegendWidget.js
+++ b/packages/react-widgets/src/widgets/LegendWidget.js
@@ -30,11 +30,21 @@ function LegendWidget({ className, initialCollapsed }) {
     );
   };
 
+  const handleChangeOpacity = ({ id, opacity }) => {
+    dispatch(
+      updateLayer({
+        id,
+        layerAttributes: { opacity }
+      })
+    );
+  };
+
   return (
     <LegendWidgetUI
       className={className}
       layers={layers}
       onChangeVisibility={handleChangeVisibility}
+      onChangeOpacity={handleChangeOpacity}
       collapsed={collapsed}
       onCollapsedChange={setCollapsed}
     />


### PR DESCRIPTION
Template branch for testing: https://github.com/CartoDB/carto-react-template/tree/feature/sc-208745/add-slider-to-modify-layer-opacity-in-legend

![image](https://user-images.githubusercontent.com/9151432/153579498-7065acdc-e6b1-4f39-9800-d7ad028a97b9.png)

![image](https://user-images.githubusercontent.com/9151432/153579554-fa293fb8-da70-4e38-90f8-609b4f0e12c6.png)

Story:
![image](https://user-images.githubusercontent.com/9151432/153580472-69e36adc-afbd-4e03-8e42-5e7abcb9e778.png)
