### PR TITLE
Dynamic tiling integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Dynamic tiling integration [#327](https://github.com/CartoDB/carto-react/pull/327)
 - Fix Switch input width [#323](https://github.com/CartoDB/carto-react/pull/323)
 
 ## 1.2

--- a/packages/react-api/__tests__/hooks/useCartoLayerProps.test.js
+++ b/packages/react-api/__tests__/hooks/useCartoLayerProps.test.js
@@ -38,12 +38,7 @@ describe('useCartoLayerProps', () => {
 
         const { result } = renderHook(() => useCartoLayerProps({ source }));
 
-        expect(Object.keys(result.current)).toEqual([
-          // 'binary',
-          // 'onViewportLoad',
-          // 'fetch',
-          ...COMMON_PROPS
-        ]);
+        expect(Object.keys(result.current)).toEqual([...COMMON_PROPS]);
       });
 
       test('should return correct props when source type is sql', () => {
@@ -56,12 +51,7 @@ describe('useCartoLayerProps', () => {
 
         const { result } = renderHook(() => useCartoLayerProps({ source }));
 
-        expect(Object.keys(result.current)).toEqual([
-          // 'binary',
-          // 'onViewportLoad',
-          // 'fetch',
-          ...COMMON_PROPS
-        ]);
+        expect(Object.keys(result.current)).toEqual([...COMMON_PROPS]);
       });
 
       test('should return correct props when source type is table', () => {
@@ -74,12 +64,7 @@ describe('useCartoLayerProps', () => {
 
         const { result } = renderHook(() => useCartoLayerProps({ source }));
 
-        expect(Object.keys(result.current)).toEqual([
-          // 'binary',
-          // 'onViewportLoad',
-          // 'fetch',
-          ...COMMON_PROPS
-        ]);
+        expect(Object.keys(result.current)).toEqual([...COMMON_PROPS]);
       });
     });
 
@@ -94,12 +79,7 @@ describe('useCartoLayerProps', () => {
 
         const { result } = renderHook(() => useCartoLayerProps({ source }));
 
-        expect(Object.keys(result.current)).toEqual([
-          // 'binary',
-          // 'onViewportLoad',
-          // 'fetch',
-          ...COMMON_PROPS
-        ]);
+        expect(Object.keys(result.current)).toEqual([...COMMON_PROPS]);
       });
 
       test('should return correct props when source type is sql', () => {

--- a/packages/react-api/__tests__/hooks/useCartoLayerProps.test.js
+++ b/packages/react-api/__tests__/hooks/useCartoLayerProps.test.js
@@ -10,6 +10,9 @@ describe('useCartoLayerProps', () => {
 
   describe('return props', () => {
     const COMMON_PROPS = [
+      'binary',
+      'onViewportLoad',
+      'fetch',
       'onDataLoad',
       'uniqueIdProperty',
       'data',
@@ -36,9 +39,9 @@ describe('useCartoLayerProps', () => {
         const { result } = renderHook(() => useCartoLayerProps({ source }));
 
         expect(Object.keys(result.current)).toEqual([
-          'binary',
-          'onViewportLoad',
-          'fetch',
+          // 'binary',
+          // 'onViewportLoad',
+          // 'fetch',
           ...COMMON_PROPS
         ]);
       });
@@ -54,9 +57,9 @@ describe('useCartoLayerProps', () => {
         const { result } = renderHook(() => useCartoLayerProps({ source }));
 
         expect(Object.keys(result.current)).toEqual([
-          'binary',
-          'onViewportLoad',
-          'fetch',
+          // 'binary',
+          // 'onViewportLoad',
+          // 'fetch',
           ...COMMON_PROPS
         ]);
       });
@@ -72,9 +75,9 @@ describe('useCartoLayerProps', () => {
         const { result } = renderHook(() => useCartoLayerProps({ source }));
 
         expect(Object.keys(result.current)).toEqual([
-          'binary',
-          'onViewportLoad',
-          'fetch',
+          // 'binary',
+          // 'onViewportLoad',
+          // 'fetch',
           ...COMMON_PROPS
         ]);
       });
@@ -92,9 +95,9 @@ describe('useCartoLayerProps', () => {
         const { result } = renderHook(() => useCartoLayerProps({ source }));
 
         expect(Object.keys(result.current)).toEqual([
-          'binary',
-          'onViewportLoad',
-          'fetch',
+          // 'binary',
+          // 'onViewportLoad',
+          // 'fetch',
           ...COMMON_PROPS
         ]);
       });

--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -43,6 +43,9 @@ export default function useCartoLayerProps({
     [onDataLoadForGeojson, onDataLoadForTile]
   );
 
+  // Due to dyamic tiling integration we cannot know if we're going to load a geojson or a tileset
+  // until onDataLoad be executed so we return binary, onViewportLoad and fetch that will be ignored
+  // for NOT Tileset layer
   const props = {
     binary: true,
     ...(viewportFeatures && {

--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -43,7 +43,7 @@ export default function useCartoLayerProps({
     [onDataLoadForGeojson, onDataLoadForTile]
   );
 
-  // Due to dyamic tiling integration we cannot know if we're going to load a geojson or a tileset
+  // Due to dynamic tiling integration, we cannot know if we're going to load a geojson or a tileset
   // until onDataLoad be executed so we return binary, onViewportLoad and fetch that will be ignored
   // for NOT Tileset layer
   const props = {

--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { MAP_TYPES, API_VERSIONS } from '@deck.gl/carto';
 import { useSelector } from 'react-redux';
 import { selectSpatialFilter } from '@carto/react-redux';
@@ -31,25 +32,25 @@ export default function useCartoLayerProps({
     debounceTimeout: viewporFeaturesDebounceTimeout
   });
 
-  let props = {};
+  const onDataLoad = useCallback(
+    (data) => {
+      if (data?.tilejson) {
+        return onDataLoadForTile(data);
+      }
 
-  if (
-    source?.credentials.apiVersion === API_VERSIONS.V2 ||
-    source?.type === MAP_TYPES.TILESET
-  ) {
-    props = {
-      binary: true,
-      ...(viewportFeatures && {
-        onViewportLoad,
-        fetch,
-        onDataLoad: onDataLoadForTile
-      })
-    };
-  } else if (source?.type === MAP_TYPES.QUERY || source?.type === MAP_TYPES.TABLE) {
-    props = viewportFeatures && {
-      onDataLoad: onDataLoadForGeojson
-    };
-  }
+      return onDataLoadForGeojson(data);
+    },
+    [onDataLoadForGeojson, onDataLoadForTile]
+  );
+
+  const props = {
+    binary: true,
+    ...(viewportFeatures && {
+      onViewportLoad,
+      fetch,
+      onDataLoad
+    })
+  };
 
   const dataFilterExtensionProps = getDataFilterExtensionProps(source?.filters);
   const maskExtensionProps = getMaskExtensionProps(spatialFilter?.geometry?.coordinates);


### PR DESCRIPTION
# Description

Adapt `useCartoLayerProps` to work with dynamic tiling. Due to dynamic tiling integration, we cannot know if we're going to load a geojson or a tileset until onDataLoad be executed so we always going to return the binary, onViewportLoad, and fetch properties that will be ignored for NOT Tileset layer

## Type of change
- Feature