### PR TITLE
Use layerConfig in useCartoLayerProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Use layerConfig in useCartoLayerProps [#336](https://github.com/CartoDB/carto-react/pull/336)
 - Fix legends typings [#335](https://github.com/CartoDB/carto-react/pull/335)
 - Fix legends export [#334](https://github.com/CartoDB/carto-react/pull/334)
 - Fix duplicated logic for category selection in PieWidgetUI [#332](https://github.com/CartoDB/carto-react/pull/332)

--- a/packages/react-api/__tests__/hooks/useCartoLayerProps.test.js
+++ b/packages/react-api/__tests__/hooks/useCartoLayerProps.test.js
@@ -14,6 +14,9 @@ describe('useCartoLayerProps', () => {
       'onViewportLoad',
       'fetch',
       'onDataLoad',
+      'id',
+      'visible',
+      'opacity',
       'uniqueIdProperty',
       'data',
       'type',
@@ -26,6 +29,20 @@ describe('useCartoLayerProps', () => {
       'extensions',
       'maskId'
     ];
+
+    test('should return correct props when layerConfig is passed', () => {
+      const layerConfig = {
+        id: '__test__',
+        visible: true,
+        opacity: 0.5
+      };
+
+      const { result } = renderHook(() => useCartoLayerProps({ layerConfig }));
+
+      expect(result.current.id).toBe(layerConfig.id);
+      expect(result.current.visible).toBe(layerConfig.visible);
+      expect(result.current.opacity).toBe(layerConfig.opacity);
+    });
 
     describe('when maps_api_version is V2', () => {
       test('should return correct props when source type is tileset', () => {

--- a/packages/react-api/src/hooks/useCartoLayerProps.d.ts
+++ b/packages/react-api/src/hooks/useCartoLayerProps.d.ts
@@ -1,9 +1,12 @@
-import { SourceProps, UseCartoLayerFilterProps } from '../types';
+import { SourceProps, LayerConfig, UseCartoLayerFilterProps } from '../types';
 
 interface UseCartoLayerProps {
-  source: SourceProps & { id: string },
-  uniqueIdProperty?: string
-  viewportFeatures?: boolean
+  source: SourceProps & { id: string };
+  layerConfig?: LayerConfig;
+  uniqueIdProperty?: string;
+  viewportFeatures?: boolean;
 }
 
-export default function useCartoLayerProps(props: UseCartoLayerProps): UseCartoLayerFilterProps
+export default function useCartoLayerProps(
+  props: UseCartoLayerProps
+): UseCartoLayerFilterProps;

--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -65,7 +65,7 @@ export default function useCartoLayerProps({
   return {
     ...props,
     id: layerConfig?.id,
-    visible: layerConfig?.visible ?? false,
+    visible: layerConfig?.visible !== undefined ? layerConfig.visible : true,
     opacity: layerConfig?.opacity ?? 1,
     uniqueIdProperty,
     data: source?.data,

--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -8,6 +8,7 @@ import { getMaskExtensionProps } from './maskExtensionUtil';
 
 export default function useCartoLayerProps({
   source,
+  layerConfig,
   uniqueIdProperty,
   viewportFeatures = true,
   viewporFeaturesDebounceTimeout = 250
@@ -63,6 +64,9 @@ export default function useCartoLayerProps({
 
   return {
     ...props,
+    id: layerConfig?.id,
+    visible: layerConfig?.visible ?? false,
+    opacity: layerConfig?.opacity ?? 1,
     uniqueIdProperty,
     data: source?.data,
     type: source?.type,

--- a/packages/react-api/src/types.d.ts
+++ b/packages/react-api/src/types.d.ts
@@ -26,6 +26,14 @@ export type SourceProps = {
   credentials: Credentials;
 };
 
+export type LayerConfig = {
+  id: string;
+  source?: string;
+  visible?: boolean;
+  opacity?: number;
+  [key: string]: unknown;
+};
+
 export type UseCartoLayerFilterProps = {
   binary?: boolean;
   uniqueIdProperty?: string;


### PR DESCRIPTION
This feature was a proposal by @borja-munoz, so it's already approved by him.

Now you can optionally pass `layerConfig` object to useCartoLayerProps to automatically get `id`, `visible` and `opacity` props.

By default `visible` is true and `opacity` is 1.

Example:

```javascript
const layerConfig = {
  title: 'Store types',
  visible: true,
  showOpacityControl: true,
  opacity: 0.4,
  legend: {
    ...
  },
};
```

```javascript
function StoresLayer() {
  const { storesLayer } = useSelector((state) => state.carto.layers);
  const source = useSelector((state) => selectSourceById(state, storesLayer?.source));
  const cartoLayerProps = useCartoLayerProps({ source, layerConfig: storesLayer });

  ...
}
```

`cartoLayerProps` contains:

```javascript
...
id: 'storesLayer',
visible: true,
opacity: 0.4
...
```