### PR TITLE
fix duplicated logic for category selection in HistogramWidgetUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix duplicated logic for category selection in HistogramWidgetUI [#345](https://github.com/CartoDB/carto-react/pull/345)
+
 ## 1.2
 
 ### 1.2.1-beta.7 (2022-02-18)

--- a/packages/react-ui/src/widgets/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import ReactEcharts from '../custom-components/echarts-for-react';
 import { Grid, Link, Typography, useTheme, makeStyles } from '@material-ui/core';
 import {
-  applyChartFilter,
   clearFilter,
   areChartPropsEqual,
   disableSerie,
@@ -311,23 +310,29 @@ function HistogramWidgetUI(props) {
     (params) => {
       if (onSelectedBarsChange) {
         const echart = chartInstance.current.getEchartsInstance();
-
         const { serie } = getChartSerie(echart, params.seriesIndex);
-        applyChartFilter(serie, params.dataIndex, theme);
+        let newSelectedCategories = serie.data
+          .filter((category) => !category.disabled)
+          .map((d, i) => i);
 
-        const activeBars = [];
-        serie.data.forEach((d, index) => {
-          if (!d.disabled) {
-            activeBars.push(index);
-          }
-        });
+        if (newSelectedCategories.length === serie.data.length) {
+          newSelectedCategories = [];
+        }
+
+        const selectedCategoryIdx = newSelectedCategories.indexOf(params.dataIndex);
+        if (selectedCategoryIdx === -1) {
+          newSelectedCategories.push(params.dataIndex);
+        } else {
+          newSelectedCategories.splice(selectedCategoryIdx, 1);
+        }
+
         onSelectedBarsChange({
-          bars: activeBars.length === serie.data.length ? [] : activeBars,
+          bars: newSelectedCategories,
           chartInstance
         });
       }
     },
-    [onSelectedBarsChange, theme]
+    [onSelectedBarsChange]
   );
 
   const onEvents = useMemo(

--- a/packages/react-ui/src/widgets/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI.js
@@ -313,7 +313,7 @@ function HistogramWidgetUI(props) {
         const { serie } = getChartSerie(echart, params.seriesIndex);
         let newSelectedCategories = serie.data
           .filter((category) => !category.disabled)
-          .map((d, i) => i);
+          .map((d) => serie.data.indexOf(d));
 
         if (newSelectedCategories.length === serie.data.length) {
           newSelectedCategories = [];

--- a/packages/react-ui/src/widgets/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI.js
@@ -312,9 +312,8 @@ function HistogramWidgetUI(props) {
       if (onSelectedBarsChange) {
         const echart = chartInstance.current.getEchartsInstance();
 
-        const { option, serie } = getChartSerie(echart, params.seriesIndex);
+        const { serie } = getChartSerie(echart, params.seriesIndex);
         applyChartFilter(serie, params.dataIndex, theme);
-        echart.setOption(option);
 
         const activeBars = [];
         serie.data.forEach((d, index) => {

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -70,7 +70,7 @@ function HistogramWidget(props) {
         if (typeof from === 'undefined' || from === null) {
           return 0;
         } else if (typeof to === 'undefined' || to === null) {
-          return ticks.length - 1;
+          return ticks.length;
         } else {
           const idx = ticks.indexOf(from);
           return idx !== -1 ? idx + 1 : null;


### PR DESCRIPTION
# Description

As with PR #332, this PR fixes the behaviour of HistogramWidgetUI `clickEvent`, removing duplicated logic that was re-appliying UI changes already applied in other `useEffect` calls. Before this changes, you couldn't recieve the `onSelectedBarsChange` event without affecting the UI of the chart. This change makes it so you can better control if the component is controlled or uncontrolled. 

## Type of change
- Fix

# Acceptance
Acceptance is described here in terms of the component API

1. create a constant array with `const categories = useRef([])`
2. Render a `<HistogramWidgetUI />`
3. Pass as props `selectedBars={categories.current}` and `onSelectedBarsChange={(value) => console.log(value)}`
4. When clicked, the UI of the chart should not be modified (the clicked part should not be highlighted)

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
