### PR TITLE
Fix opacity selector input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix opacity selector input [#350](https://github.com/CartoDB/carto-react/pull/350)
+
 ## 1.2
 
 ### 1.2.1-beta.8 (2022-02-22)

--- a/packages/react-ui/src/widgets/OpacityControl.js
+++ b/packages/react-ui/src/widgets/OpacityControl.js
@@ -31,10 +31,10 @@ const useOpacityControlStyles = makeStyles(({ spacing }) => ({
         appearance: 'none',
         margin: 0
       }
-    },
-    '& .MuiInputAdornment-positionEnd': {
-      margin: 0
     }
+  },
+  noMargin: {
+    margin: 0
   }
 }));
 
@@ -73,7 +73,14 @@ export default function OpacityControl({ opacity, onChangeOpacity }) {
                 type: 'number',
                 inputProps: { 'data-testid': 'opacity-slider' },
                 'aria-labelledby': 'opacity-slider',
-                endAdornment: <InputAdornment position='end'>%</InputAdornment>
+                endAdornment: (
+                  <InputAdornment
+                    classes={{ positionEnd: classes.noMargin }}
+                    position='end'
+                  >
+                    %
+                  </InputAdornment>
+                )
               }}
             />
           </Grid>


### PR DESCRIPTION
Instead of using css selector with class name, it's better to use MUI classes prop. In SS we have a number suffix in the classes and the styles modification wasn't being applied.