### PR TITLE
The basemap prop in the initialStateSlice for template base-3-typescript only accepts CARTO base maps names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Typings fix: Include GMapsBasemaps in InitialCarto2State [#354](https://github.com/CartoDB/carto-react/pull/354)
 
 ## 1.2
 

--- a/packages/react-redux/src/types.d.ts
+++ b/packages/react-redux/src/types.d.ts
@@ -1,6 +1,6 @@
 import { Credentials } from '@carto/react-api';
 import { OauthApp } from '@carto/react-auth';
-import { CartoBasemapsNames } from '@carto/react-basemaps';
+import { CartoBasemapsNames, GMapsBasemaps } from '@carto/react-basemaps';
 import { Viewport } from '@carto/react-core';
 import { Geometry } from 'geojson';
 
@@ -17,7 +17,7 @@ export type ViewState = {
 
 type InitialCarto2State = {
   viewState: ViewState,
-  basemap: CartoBasemapsNames,
+  basemap: CartoBasemapsNames | GMapsBasemaps,
   credentials: Credentials,
   googleApiKey: string,
   googleMapId: string,


### PR DESCRIPTION
Story details: https://app.shortcut.com/cartoteam/story/211802