### PR TITLE
Refactor tiles processing

### DIFF
--- a/packages/react-core/src/filters/geojsonFeatures.js
+++ b/packages/react-core/src/filters/geojsonFeatures.js
@@ -1,11 +1,15 @@
 import intersects from '@turf/boolean-intersects';
-import { getGeometryToIntersect } from './tileFeatures';
+import bboxPolygon from '@turf/bbox-polygon';
+import { flatGeometries } from '../utils/geometryUtils';
 
 export function geojsonFeatures({ geojson, viewport, geometry, uniqueIdProperty }) {
   let uniqueIdx = 0;
   // Map is used to cache multi geometries. Only a sucessfull intersect by multipolygon
   const map = new Map();
-  const geometryToIntersect = getGeometryToIntersect(viewport, geometry);
+
+  const viewportPolygon = viewport && bboxPolygon(viewport);
+
+  const geometryToIntersect = flatGeometries(viewportPolygon, geometry);
 
   if (!geometryToIntersect) {
     return [];
@@ -20,5 +24,5 @@ export function geojsonFeatures({ geojson, viewport, geometry, uniqueIdProperty 
     }
   }
 
-  return Array.from(map.values());
+  return map.values();
 }

--- a/packages/react-core/src/filters/geojsonFeatures.js
+++ b/packages/react-core/src/filters/geojsonFeatures.js
@@ -19,7 +19,7 @@ export function geojsonFeatures({ geojson, viewport, geometry, uniqueIdProperty 
     const uniqueId = uniqueIdProperty
       ? feature.properties[uniqueIdProperty]
       : ++uniqueIdx;
-    if (!map.has(uniqueId) && intersects(geometryToIntersect, feature)) {
+    if (!map.has(uniqueId) && intersects(geometryToIntersect, feature.geometry)) {
       map.set(uniqueId, feature.properties);
     }
   }

--- a/packages/react-core/src/filters/tileFeatures.d.ts
+++ b/packages/react-core/src/filters/tileFeatures.d.ts
@@ -2,4 +2,4 @@ import { TileFeatures, TileFeaturesResponse } from '../types';
 import { Geometry, Feature, Polygon, MultiPolygon } from 'geojson';
 
 export function getGeometryToIntersect(viewport: number[], geometry: Geometry | null): Feature<Polygon | MultiPolygon> | null;
-export function tileFeatures(arg: TileFeatures): TileFeaturesResponse;
+export function processTiles(arg: TileFeatures): TileFeaturesResponse;

--- a/packages/react-core/src/filters/tileFeatures.js
+++ b/packages/react-core/src/filters/tileFeatures.js
@@ -1,6 +1,6 @@
 import { buildGeoJson, GEOMETRY_TYPES } from '../utils/geometryUtils';
 
-export function processTiles({ tiles, uniqueIdProperty }) {
+export function tileFeatures({ tiles, uniqueIdProperty }) {
   const map = new Map();
 
   for (let tile of tiles) {

--- a/packages/react-core/src/index.d.ts
+++ b/packages/react-core/src/index.d.ts
@@ -21,7 +21,7 @@ export { scatterPlot } from './operations/scatterPlot';
 
 export { FilterTypes as _FilterTypes } from './filters/FilterTypes';
 
-export { tileFeatures } from './filters/tileFeatures';
+export { tileFeatures, filterProcessedTilesSpatially } from './filters/tileFeatures';
 export { geojsonFeatures } from './filters/geojsonFeatures';
 
 export { AggregationFunctions, GroupByFeature, HistogramFeature, Viewport, TileFeatures } from './types';

--- a/packages/react-core/src/index.d.ts
+++ b/packages/react-core/src/index.d.ts
@@ -21,7 +21,7 @@ export { scatterPlot } from './operations/scatterPlot';
 
 export { FilterTypes as _FilterTypes } from './filters/FilterTypes';
 
-export { processTiles } from './filters/tileFeatures';
+export { tileFeatures } from './filters/tileFeatures';
 export { geojsonFeatures } from './filters/geojsonFeatures';
 
 export { AggregationFunctions, GroupByFeature, HistogramFeature, Viewport, TileFeatures } from './types';

--- a/packages/react-core/src/index.d.ts
+++ b/packages/react-core/src/index.d.ts
@@ -21,7 +21,7 @@ export { scatterPlot } from './operations/scatterPlot';
 
 export { FilterTypes as _FilterTypes } from './filters/FilterTypes';
 
-export { tileFeatures } from './filters/tileFeatures';
+export { processTiles } from './filters/tileFeatures';
 export { geojsonFeatures } from './filters/geojsonFeatures';
 
 export { AggregationFunctions, GroupByFeature, HistogramFeature, Viewport, TileFeatures } from './types';

--- a/packages/react-core/src/index.js
+++ b/packages/react-core/src/index.js
@@ -30,7 +30,7 @@ export {
   applyFilters as _applyFilters
 } from './filters/Filter';
 
-export { tileFeatures } from './filters/tileFeatures';
+export { tileFeatures, filterProcessedTilesSpatially } from './filters/tileFeatures';
 export { geojsonFeatures } from './filters/geojsonFeatures';
 
 export { GroupDateTypes } from './operations/GroupDateTypes';
@@ -41,5 +41,3 @@ export {
   EDIT_MODES,
   MASK_ID
 } from './utils/featureSelectionConstants';
-
-export { transformToTileCoords } from './utils/transformToTileCoords';

--- a/packages/react-core/src/index.js
+++ b/packages/react-core/src/index.js
@@ -30,7 +30,7 @@ export {
   applyFilters as _applyFilters
 } from './filters/Filter';
 
-export { processTiles } from './filters/tileFeatures';
+export { tileFeatures } from './filters/tileFeatures';
 export { geojsonFeatures } from './filters/geojsonFeatures';
 
 export { GroupDateTypes } from './operations/GroupDateTypes';

--- a/packages/react-core/src/index.js
+++ b/packages/react-core/src/index.js
@@ -30,7 +30,7 @@ export {
   applyFilters as _applyFilters
 } from './filters/Filter';
 
-export { tileFeatures } from './filters/tileFeatures';
+export { processTiles } from './filters/tileFeatures';
 export { geojsonFeatures } from './filters/geojsonFeatures';
 
 export { GroupDateTypes } from './operations/GroupDateTypes';
@@ -41,3 +41,5 @@ export {
   EDIT_MODES,
   MASK_ID
 } from './utils/featureSelectionConstants';
+
+export { transformToTileCoords } from './utils/transformToTileCoords';

--- a/packages/react-core/src/utils/geometryUtils.js
+++ b/packages/react-core/src/utils/geometryUtils.js
@@ -1,10 +1,10 @@
 import intersect from '@turf/intersect';
 
-export function flatGeometries(...geometries) {
-  const validGeometries = geometries.filter(Boolean);
+export function flatGeometries(geometry1, geometry2) {
+  const validGeometries = [geometry1, geometry2].filter(Boolean);
   return validGeometries.length === 2
-    ? intersect(geometries[0], geometries[1])
-    : geometries[0];
+    ? intersect(validGeometries[0], validGeometries[1])
+    : validGeometries[0];
 }
 
 export const GEOMETRY_TYPES = Object.freeze({

--- a/packages/react-core/src/utils/geometryUtils.js
+++ b/packages/react-core/src/utils/geometryUtils.js
@@ -1,0 +1,27 @@
+import intersect from '@turf/intersect';
+
+export function flatGeometries(...geometries) {
+  const validGeometries = geometries.filter(Boolean);
+  return validGeometries.length === 2
+    ? intersect(geometries[0], geometries[1])
+    : geometries[0];
+}
+
+export const GEOMETRY_TYPES = Object.freeze({
+  Point: 0,
+  LineString: 1,
+  Polygon: 2
+});
+
+export function buildGeoJson(coordinates, type) {
+  switch (type) {
+    case GEOMETRY_TYPES['Polygon']:
+      return { type: 'Polygon', coordinates: [coordinates] };
+    case GEOMETRY_TYPES['LineString']:
+      return { type: 'LineString', coordinates };
+    case GEOMETRY_TYPES['Point']:
+      return { type: 'Point', coordinates: coordinates[0] };
+    default:
+      throw new Error('Invalid geometry type');
+  }
+}

--- a/packages/react-core/src/utils/transformToTileCoords.js
+++ b/packages/react-core/src/utils/transformToTileCoords.js
@@ -8,7 +8,7 @@ import { lngLatToWorld } from '@math.gl/web-mercator';
  * @param {{ west: number, east: number, north: number, south: number }} bbox - tile bbox as used in deck.gl
  * @returns {GeoJSON}
  */
-export function transformToTileCoords(geometry, bbox) {
+export default function transformToTileCoords(geometry, bbox) {
   const nw = projectFlat([bbox.west, bbox.north]);
   const se = projectFlat([bbox.east, bbox.south]);
   const projectedBbox = [nw, se];

--- a/packages/react-core/src/utils/transformToTileCoords.js
+++ b/packages/react-core/src/utils/transformToTileCoords.js
@@ -8,7 +8,7 @@ import { lngLatToWorld } from '@math.gl/web-mercator';
  * @param {{ west: number, east: number, north: number, south: number }} bbox - tile bbox as used in deck.gl
  * @returns {GeoJSON}
  */
-export default function transformToTileCoords(geometry, bbox) {
+export function transformToTileCoords(geometry, bbox) {
   const nw = projectFlat([bbox.west, bbox.north]);
   const se = projectFlat([bbox.east, bbox.south]);
   const projectedBbox = [nw, se];

--- a/packages/react-workers/src/workers/features.worker.js
+++ b/packages/react-workers/src/workers/features.worker.js
@@ -58,7 +58,7 @@ onmessage = ({ data: { method, ...params } }) => {
 };
 
 function getTileFeatures({ viewport, geometry, tileFormat }) {
-  let t0 = performance.now();
+  // let t0 = performance.now();
   const viewportPolygon = bboxPolygon(viewport);
   const geometryToIntersect = flatGeometries(viewportPolygon, geometry);
   currentFeatures = [];
@@ -97,17 +97,17 @@ function getTileFeatures({ viewport, geometry, tileFormat }) {
     currentFeatures = currentFeatures.concat(foundFeatures);
   }
 
-  let t1 = performance.now();
-  console.log('Process tiles by viewport', t1 - t0);
+  // let t1 = performance.now();
+  // console.log('Process tiles by viewport', t1 - t0);
 
   postMessage({ result: true });
 }
 
 function loadTiles({ tiles, uniqueIdProperty }) {
-  let t0 = performance.now();
+  // let t0 = performance.now();
   currentTiles = processTiles({ tiles, uniqueIdProperty });
-  let t1 = performance.now();
-  console.log('Load tiles', t1 - t0);
+  // let t1 = performance.now();
+  // console.log('Load tiles', t1 - t0);
   postMessage({ result: true });
 }
 

--- a/packages/react-workers/src/workers/features.worker.js
+++ b/packages/react-workers/src/workers/features.worker.js
@@ -1,5 +1,5 @@
 import {
-  processTiles,
+  tileFeatures,
   geojsonFeatures,
   aggregationFunctions,
   _applyFilters,
@@ -105,7 +105,7 @@ function getTileFeatures({ viewport, geometry, tileFormat }) {
 
 function loadTiles({ tiles, uniqueIdProperty }) {
   // let t0 = performance.now();
-  currentTiles = processTiles({ tiles, uniqueIdProperty });
+  currentTiles = tileFeatures({ tiles, uniqueIdProperty });
   // let t1 = performance.now();
   // console.log('Load tiles', t1 - t0);
   postMessage({ result: true });


### PR DESCRIPTION
Refactor tiles processing to improve performance and readability.

### Why?
Meanwhile I was preparing the implementation of optional viewport and spatial filter I thought that there are too much logic in tileFeature fn. That's why I decided to prepare a refactor that can improve this.

### Ideas of the refactor
Currently, each time the viewport changes, the tiles are processed. It means that if the viewport changes but the tiles not, we're repeating the process of extracting the coordinates and properties from the binary data. Also, we're making the filtering process in that fn, mixing it with the binary processing which makes it more complicated when it grows.

After this refactor:
- tileFeatures fn is exclusively for tile data processing. That fn transform binary-to-geojson. To avoid processing data that it isn't needed (for example the coordinates in a fully visible tile or the properties if the feature isn't visible) the feature props (geometry and properties) are set as getters, it means that that info will be processed when it's needed and only once. Thanks to that, when the viewport changes and the tiles not, the spatial filtering is ~50% faster.
- Due to tileFeature output is a geojson, we can use geojsonFeatures fn and reuse that code. Currently, in this PR code, the spatial filtering code is in the worker, but I can move it to a specific fn for better organisation. I just want you to catch the idea.
- I've made some modifications in tileFeature fn to improve performance avoiding converting the iterables to array. It means a ~5% performance improvement.

Using this refactor, the stores view first load is ~5ms faster (25ms to 20ms).