### PR TITLE
Use multiple operationColumn in widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Implement multiple operationColumn in core functions [#347](https://github.com/CartoDB/carto-react/pull/347)
 - Add RegExp string filtering capabilities [#362](https://github.com/CartoDB/carto-react/pull/362)
+- Use multiple operationColumn in widgets [#361](https://github.com/CartoDB/carto-react/pull/361)
 
 ## 1.2
 

--- a/packages/react-core/__tests__/operations/aggregation.test.js
+++ b/packages/react-core/__tests__/operations/aggregation.test.js
@@ -1,4 +1,4 @@
-import { aggregationFunctions } from '../../src/operations/aggregation';
+import { aggregate, aggregationFunctions } from '../../src/operations/aggregation';
 import { AggregationTypes } from '../../src/operations/constants/AggregationTypes';
 
 const VALUES = [1, 2, 3, 4, 5];
@@ -11,49 +11,86 @@ const features = [...Array(VALUES.length)].map((_, idx) => ({
   [COLUMN_2]: VALUES[idx] - 1
 }));
 
-describe('aggregationFunctions', () => {
-  const RESULTS = {
-    [AggregationTypes.COUNT]: VALUES.length,
-    [AggregationTypes.AVG]: 3,
-    [AggregationTypes.MIN]: 1,
-    [AggregationTypes.MAX]: 5,
-    [AggregationTypes.SUM]: 15
-  };
+describe('aggregation', () => {
+  describe('aggregationFunctions', () => {
+    const RESULTS = {
+      [AggregationTypes.COUNT]: VALUES.length,
+      [AggregationTypes.AVG]: 3,
+      [AggregationTypes.MIN]: 1,
+      [AggregationTypes.MAX]: 5,
+      [AggregationTypes.SUM]: 15
+    };
 
-  describe('by values', () => {
-    Object.entries(RESULTS).forEach(([operation, result]) => {
-      test(operation, () => {
-        const func = aggregationFunctions[operation];
-        expect(func(VALUES)).toEqual(result);
+    describe('by values', () => {
+      Object.entries(RESULTS).forEach(([operation, result]) => {
+        test(operation, () => {
+          const func = aggregationFunctions[operation];
+          expect(func(VALUES)).toEqual(result);
+        });
+      });
+    });
+
+    describe('by features', () => {
+      describe('unique key', () => {
+        Object.entries(RESULTS).forEach(([operation, result], idx) => {
+          test(operation, () => {
+            const func = aggregationFunctions[operation];
+            expect(func(features, COLUMN)).toEqual(result);
+          });
+        });
+      });
+
+      describe('multiple keys', () => {
+        const RESULTS_FOR_MULTIPLE_KEYS = {
+          [AggregationTypes.COUNT]: VALUES.length,
+          [AggregationTypes.AVG]: 2.5,
+          [AggregationTypes.MIN]: 0,
+          [AggregationTypes.MAX]: 5,
+          [AggregationTypes.SUM]: 25
+        };
+
+        Object.entries(RESULTS_FOR_MULTIPLE_KEYS).forEach(([operation, result]) => {
+          test(operation, () => {
+            const func = aggregationFunctions[operation];
+            expect(func(features, [COLUMN, COLUMN_2], operation)).toEqual(result);
+          });
+        });
       });
     });
   });
 
-  describe('by features', () => {
-    describe('unique key', () => {
-      Object.entries(RESULTS).forEach(([operation, result], idx) => {
-        test(operation, () => {
-          const func = aggregationFunctions[operation];
-          expect(func(features, COLUMN)).toEqual(result);
-        });
+  describe("aggregate feature's properties", () => {
+    // It should only access the feature's property
+    test('should work correctly with one column', () => {
+      features.forEach((feature) => {
+        const aggregatedValue = aggregate(feature, [COLUMN]);
+        expect(aggregatedValue).toEqual(feature[COLUMN]);
       });
     });
 
-    describe('multiple keys', () => {
-      const RESULTS_FOR_MULTIPLE_KEYS = {
-        [AggregationTypes.COUNT]: VALUES.length,
-        [AggregationTypes.AVG]: 2.5,
-        [AggregationTypes.MIN]: 0,
-        [AggregationTypes.MAX]: 5,
-        [AggregationTypes.SUM]: 25
-      };
-
-      Object.entries(RESULTS_FOR_MULTIPLE_KEYS).forEach(([operation, result]) => {
-        test(operation, () => {
-          const func = aggregationFunctions[operation];
-          expect(func(features, [COLUMN, COLUMN_2], operation)).toEqual(result);
-        });
+    test('should aggregate two columns correctly', () => {
+      features.forEach((feature) => {
+        const aggregatedValue = aggregate(
+          feature,
+          [COLUMN, COLUMN_2],
+          AggregationTypes.SUM
+        );
+        expect(aggregatedValue).toEqual(feature[COLUMN] + feature[COLUMN_2]);
       });
+    });
+
+    test("throws an error if joinOperation isn't valid", () => {
+      const feature = features[0];
+      // @ts-ignore
+      expect(() => aggregate(feature, [COLUMN, COLUMN_2], '__unknown__')).toThrowError();
+    });
+
+    test("throws an error if passed keys aren't valid", () => {
+      const feature = features[0];
+      // @ts-ignore
+      expect(() => aggregate(feature, [], '__unknown__')).toThrowError();
+      // @ts-ignore
+      expect(() => aggregate(feature, null, '__unknown__')).toThrowError();
     });
   });
 });

--- a/packages/react-core/__tests__/operations/scatterPlot.test.js
+++ b/packages/react-core/__tests__/operations/scatterPlot.test.js
@@ -32,8 +32,9 @@ describe('scatterPlot', () => {
       scatterPlot({
         data,
         xAxisColumns: ['x', 'y'],
+        xAxisJoinOperation: AggregationTypes.SUM,
         yAxisColumns: ['x', 'y'],
-        joinOperation: AggregationTypes.SUM
+        yAxisJoinOperation: AggregationTypes.SUM
       })
     ).toEqual([
       [0, 0],

--- a/packages/react-core/src/operations/aggregation.d.ts
+++ b/packages/react-core/src/operations/aggregation.d.ts
@@ -5,6 +5,6 @@ export const aggregationFunctions: AggregationFunctions;
 
 export function aggregate(
   feature: Record<string, unknown>,
-  keys?: string | string[],
+  keys?: string[],
   joinOperation?: AggregationTypes
 );

--- a/packages/react-core/src/operations/aggregation.js
+++ b/packages/react-core/src/operations/aggregation.js
@@ -66,8 +66,8 @@ function max(values, keys, joinOperation) {
 
 // Aux
 
-// Keys can come as a string (one column) or a string array (multiple column)
+// Keys can come as a string (one column) or a strings array (multiple column)
 // Use always an array to make the code easier
 function normalizeKeys(keys) {
-  return keys?.length ? [keys].flat() : undefined;
+  return Array.isArray(keys) ? keys : typeof keys === 'string' ? [keys] : undefined;
 }

--- a/packages/react-core/src/operations/aggregation.js
+++ b/packages/react-core/src/operations/aggregation.js
@@ -1,7 +1,5 @@
 import { AggregationTypes } from './constants/AggregationTypes';
 
-const dummyFn = ([value]) => value;
-
 export const aggregationFunctions = {
   [AggregationTypes.COUNT]: (values) => values.length,
   [AggregationTypes.MIN]: min,
@@ -11,15 +9,19 @@ export const aggregationFunctions = {
 };
 
 export function aggregate(feature, keys, operation) {
-  const normalizedKeys = normalizeKeys(keys);
-
-  if (!normalizedKeys?.length) {
+  if (!keys?.length) {
     throw new Error('Cannot aggregate a feature without having keys');
+  } else if (keys.length === 1) {
+    return feature[keys[0]];
   }
 
-  const aggregationFn = aggregationFunctions[operation] || dummyFn;
+  const aggregationFn = aggregationFunctions[operation];
 
-  return aggregationFn(normalizedKeys.map((column) => feature[column]));
+  if (!aggregationFn) {
+    throw new Error(`${operation} isn't a valid aggregation function`);
+  }
+
+  return aggregationFn(keys.map((column) => feature[column]));
 }
 
 // Aggregation functions

--- a/packages/react-core/src/operations/scatterPlot.d.ts
+++ b/packages/react-core/src/operations/scatterPlot.d.ts
@@ -4,6 +4,7 @@ import { ScatterPlotFeature } from '../types';
 export function scatterPlot(args: {
   data: Record<string, unknown>[];
   xAxisColumns: string[];
+  xAxisJoinOperation?: AggregationTypes;
   yAxisColumns: string[];
-  joinOperation?: AggregationTypes;
+  yAxisJoinOperation?: AggregationTypes;
 }): ScatterPlotFeature;

--- a/packages/react-core/src/operations/scatterPlot.js
+++ b/packages/react-core/src/operations/scatterPlot.js
@@ -1,11 +1,17 @@
 import { aggregate } from './aggregation';
 
 // Filters invalid features and formats  data
-export function scatterPlot({ data, xAxisColumns, yAxisColumns, joinOperation }) {
+export function scatterPlot({
+  data,
+  xAxisColumns,
+  xAxisJoinOperation,
+  yAxisColumns,
+  yAxisJoinOperation
+}) {
   return data.reduce((acc, feature) => {
-    const xValue = aggregate(feature, xAxisColumns, joinOperation);
+    const xValue = aggregate(feature, xAxisColumns, xAxisJoinOperation);
     const xIsValid = xValue !== null && xValue !== undefined;
-    const yValue = aggregate(feature, yAxisColumns, joinOperation);
+    const yValue = aggregate(feature, yAxisColumns, yAxisJoinOperation);
     const yIsValid = yValue !== null && yValue !== undefined;
 
     if (xIsValid && yIsValid) {

--- a/packages/react-widgets/src/models/CategoryModel.js
+++ b/packages/react-widgets/src/models/CategoryModel.js
@@ -1,10 +1,14 @@
 import { Methods, executeTask } from '@carto/react-workers';
+import checkParams from './utils/checkParams';
 
 export const getCategories = async (props) => {
-  const { column, operationColumn, operation, filters, dataSource } = props;
+  const { column, operationColumn, joinOperation, operation, filters, dataSource } = props;
+
+  checkParams({ joinOperation, operationColumn });
 
   return executeTask(dataSource, Methods.FEATURES_CATEGORY, {
     filters,
+    joinOperation,
     operation,
     column,
     operationColumn: operationColumn || column

--- a/packages/react-widgets/src/models/CategoryModel.js
+++ b/packages/react-widgets/src/models/CategoryModel.js
@@ -1,10 +1,7 @@
 import { Methods, executeTask } from '@carto/react-workers';
-import checkParams from './utils/checkParams';
 
 export const getCategories = async (props) => {
   const { column, operationColumn, joinOperation, operation, filters, dataSource } = props;
-
-  checkParams({ joinOperation, operationColumn });
 
   return executeTask(dataSource, Methods.FEATURES_CATEGORY, {
     filters,

--- a/packages/react-widgets/src/models/FormulaModel.js
+++ b/packages/react-widgets/src/models/FormulaModel.js
@@ -1,10 +1,7 @@
 import { Methods, executeTask } from '@carto/react-workers';
-import checkParams from './utils/checkParams';
 
 export const getFormula = async (props) => {
   const { operation, column, joinOperation, filters, dataSource } = props;
-
-  checkParams({ joinOperation, operationColumn: column });
 
   return executeTask(dataSource, Methods.FEATURES_FORMULA, {
     filters,

--- a/packages/react-widgets/src/models/FormulaModel.js
+++ b/packages/react-widgets/src/models/FormulaModel.js
@@ -1,11 +1,15 @@
 import { Methods, executeTask } from '@carto/react-workers';
+import checkParams from './utils/checkParams';
 
 export const getFormula = async (props) => {
-  const { operation, column, filters, dataSource } = props;
+  const { operation, column, joinOperation, filters, dataSource } = props;
+
+  checkParams({ joinOperation, operationColumn: column });
 
   return executeTask(dataSource, Methods.FEATURES_FORMULA, {
     filters,
     operation,
+    joinOperation,
     column
   });
 };

--- a/packages/react-widgets/src/models/ScatterPlotModel.js
+++ b/packages/react-widgets/src/models/ScatterPlotModel.js
@@ -1,11 +1,24 @@
 import { Methods, executeTask } from '@carto/react-workers';
+import checkParams from './utils/checkParams';
 
 export const getScatter = async (props) => {
-  const { xAxisColumn, yAxisColumn, filters, dataSource } = props;
+  const {
+    xAxisColumn,
+    xAxisJoinOperation,
+    yAxisColumn,
+    yAxisJoinOperation,
+    filters,
+    dataSource
+  } = props;
+
+  checkParams({ joinOperation: xAxisJoinOperation, operationColumn: xAxisColumn });
+  checkParams({ joinOperation: yAxisJoinOperation, operationColumn: yAxisColumn });
 
   return executeTask(dataSource, Methods.FEATURES_SCATTERPLOT, {
     filters,
     xAxisColumn,
-    yAxisColumn
+    xAxisJoinOperation,
+    yAxisColumn,
+    yAxisJoinOperation
   });
 };

--- a/packages/react-widgets/src/models/ScatterPlotModel.js
+++ b/packages/react-widgets/src/models/ScatterPlotModel.js
@@ -1,5 +1,4 @@
 import { Methods, executeTask } from '@carto/react-workers';
-import checkParams from './utils/checkParams';
 
 export const getScatter = async (props) => {
   const {
@@ -10,9 +9,6 @@ export const getScatter = async (props) => {
     filters,
     dataSource
   } = props;
-
-  checkParams({ joinOperation: xAxisJoinOperation, operationColumn: xAxisColumn });
-  checkParams({ joinOperation: yAxisJoinOperation, operationColumn: yAxisColumn });
 
   return executeTask(dataSource, Methods.FEATURES_SCATTERPLOT, {
     filters,

--- a/packages/react-widgets/src/models/TimeSeriesModel.js
+++ b/packages/react-widgets/src/models/TimeSeriesModel.js
@@ -1,13 +1,25 @@
 import { Methods, executeTask } from '@carto/react-workers';
+import checkParams from './utils/checkParams';
 
 export const getTimeSeries = async (props) => {
-  const { filters, dataSource, column, operationColumn, operation, stepSize } = props;
+  const {
+    filters,
+    dataSource,
+    column,
+    operationColumn,
+    joinOperation,
+    operation,
+    stepSize
+  } = props;
+
+  checkParams({ joinOperation, operationColumn });
 
   return executeTask(dataSource, Methods.FEATURES_TIME_SERIES, {
     filters,
     column,
     stepSize,
     operationColumn: operationColumn || column,
+    joinOperation,
     operation
   });
 };

--- a/packages/react-widgets/src/models/TimeSeriesModel.js
+++ b/packages/react-widgets/src/models/TimeSeriesModel.js
@@ -1,5 +1,4 @@
 import { Methods, executeTask } from '@carto/react-workers';
-import checkParams from './utils/checkParams';
 
 export const getTimeSeries = async (props) => {
   const {
@@ -11,8 +10,6 @@ export const getTimeSeries = async (props) => {
     operation,
     stepSize
   } = props;
-
-  checkParams({ joinOperation, operationColumn });
 
   return executeTask(dataSource, Methods.FEATURES_TIME_SERIES, {
     filters,

--- a/packages/react-widgets/src/models/utils/checkParams.js
+++ b/packages/react-widgets/src/models/utils/checkParams.js
@@ -1,0 +1,7 @@
+export default function checkParams ({ joinOperation, operationColumn }) {
+    if (Array.isArray(operationColumn)) {
+        if (!joinOperation) {
+            throw new Error('Must indicate a join operation when providing multiple operation columns.')
+        }
+    }
+}

--- a/packages/react-widgets/src/models/utils/checkParams.js
+++ b/packages/react-widgets/src/models/utils/checkParams.js
@@ -1,7 +1,0 @@
-export default function checkParams ({ joinOperation, operationColumn }) {
-    if (Array.isArray(operationColumn)) {
-        if (!joinOperation) {
-            throw new Error('Must indicate a join operation when providing multiple operation columns.')
-        }
-    }
-}

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -18,7 +18,8 @@ const EMPTY_ARRAY = [];
  * @param  {string} props.title - Title to show in the widget header.
  * @param  {string} props.dataSource - ID of the data source to get the data from.
  * @param  {string} props.column - Name of the data source's column to get the data from.
- * @param  {string} [props.operationColumn] - Name of the data source's column to operate with. If not defined it will default to the one defined in `column`.
+ * @param  {string | string[]} [props.operationColumn] - Name of the data source's column to operate with. If not defined it will default to the one defined in `column`. If multiples are provided, they will be merged into a single one using joinOperation property.
+ * @param  {AggregationTypes} [props.joinOperation] - Operation applied to aggregate multiple operation columns into a single one.
  * @param  {string} props.operation - Operation to apply to the operationColumn. Must be one of those defined in `AggregationTypes` object.
  * @param  {Function} [props.formatter] - Function to format each value returned.
  * @param  {Object} [props.labels] - Overwrite category labels.
@@ -36,6 +37,7 @@ function CategoryWidget(props) {
     dataSource,
     column,
     operationColumn,
+    joinOperation,
     operation,
     formatter,
     labels,
@@ -68,6 +70,7 @@ function CategoryWidget(props) {
       getCategories({
         column,
         operationColumn,
+        joinOperation,
         operation,
         filters,
         dataSource
@@ -87,6 +90,7 @@ function CategoryWidget(props) {
     id,
     column,
     operationColumn,
+    joinOperation,
     operation,
     filters,
     dataSource,
@@ -144,7 +148,11 @@ CategoryWidget.propTypes = {
   title: PropTypes.string.isRequired,
   dataSource: PropTypes.string.isRequired,
   column: PropTypes.string.isRequired,
-  operationColumn: PropTypes.string,
+  operationColumn: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ]),
+  joinOperation: PropTypes.oneOf(Object.values(AggregationTypes)),
   operation: PropTypes.oneOf(Object.values(AggregationTypes)).isRequired,
   formatter: PropTypes.func,
   labels: PropTypes.object,

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -8,6 +8,7 @@ import { getCategories } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
 import { selectAreFeaturesReadyForSource } from '@carto/react-redux/';
 import { useWidgetFilterValues } from '../hooks/useWidgetFilterValues';
+import { columnAggregationOn } from './utils/propTypesFns';
 
 const EMPTY_ARRAY = [];
 
@@ -152,7 +153,7 @@ CategoryWidget.propTypes = {
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string)
   ]),
-  joinOperation: PropTypes.oneOf(Object.values(AggregationTypes)),
+  joinOperation: columnAggregationOn('operationColumn'),
   operation: PropTypes.oneOf(Object.values(AggregationTypes)).isRequired,
   formatter: PropTypes.func,
   labels: PropTypes.object,

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -6,6 +6,7 @@ import { getFormula } from '../models';
 import { AggregationTypes } from '@carto/react-core';
 import useSourceFilters from '../hooks/useSourceFilters';
 import { selectAreFeaturesReadyForSource } from '@carto/react-redux';
+import { columnAggregationOn } from './utils/propTypesFns';
 
 /**
  * Renders a <FormulaWidget /> component
@@ -83,8 +84,8 @@ FormulaWidget.propTypes = {
   dataSource: PropTypes.string.isRequired,
   column: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)])
     .isRequired,
+  joinOperation: columnAggregationOn('column'),
   operation: PropTypes.oneOf(Object.values(AggregationTypes)).isRequired,
-  joinOperation: PropTypes.oneOf(Object.values(AggregationTypes)),
   formatter: PropTypes.func,
   animation: PropTypes.bool,
   onError: PropTypes.func,

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -13,25 +13,26 @@ import { selectAreFeaturesReadyForSource } from '@carto/react-redux';
  * @param  {string} props.id - ID for the widget instance.
  * @param  {string} props.title - Title to show in the widget header.
  * @param  {string} props.dataSource - ID of the data source to get the data from.
- * @param  {string} props.column - Name of the data source's column to get the data from.
- * @param  {string} props.operation - Operation to apply to the operationColumn. Must be one of those defined in `AggregationTypes` object.
+ * @param  {string | string[]} props.column - Name of the data source's column(s) to get the data from. If multiples are provided, they will be merged into a single one using joinOperation property.
+ * @param  {AggregationTypes} [props.joinOperation] - Operation applied to aggregate multiple columns into a single one.
+ * @param  {AggregationTypes} props.operation - Operation to apply to the operationColumn. Must be one of those defined in `AggregationTypes` object.
  * @param  {Function} [props.formatter] - Function to format each value returned.
  * @param  {boolean} [props.animation] - Enable/disable widget animations on data updates. Enabled by default.
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  */
-function FormulaWidget(props) {
-  const {
-    id,
-    title,
-    dataSource,
-    column,
-    operation,
-    formatter,
-    animation,
-    onError,
-    wrapperProps
-  } = props;
+function FormulaWidget({
+  id,
+  title,
+  dataSource,
+  column,
+  operation,
+  joinOperation,
+  formatter,
+  animation,
+  onError,
+  wrapperProps
+}) {
   const isSourceReady = useSelector((state) =>
     selectAreFeaturesReadyForSource(state, dataSource)
   );
@@ -47,6 +48,7 @@ function FormulaWidget(props) {
       getFormula({
         operation,
         column,
+        joinOperation,
         filters,
         dataSource
       })
@@ -61,7 +63,7 @@ function FormulaWidget(props) {
           if (onError) onError(error);
         });
     }
-  }, [operation, column, filters, dataSource, setIsLoading, onError, isSourceReady]);
+  }, [operation, column, joinOperation, filters, dataSource, setIsLoading, onError, isSourceReady]);
 
   return (
     <WrapperWidgetUI title={title} isLoading={isLoading} {...wrapperProps}>
@@ -79,8 +81,10 @@ FormulaWidget.propTypes = {
   id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   dataSource: PropTypes.string.isRequired,
-  column: PropTypes.string.isRequired,
+  column: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)])
+    .isRequired,
   operation: PropTypes.oneOf(Object.values(AggregationTypes)).isRequired,
+  joinOperation: PropTypes.oneOf(Object.values(AggregationTypes)),
   formatter: PropTypes.func,
   animation: PropTypes.bool,
   onError: PropTypes.func,

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -18,7 +18,7 @@ const EMPTY_ARRAY = [];
  * @param  {string} props.title - Title to show in the widget header.
  * @param  {string} props.dataSource - ID of the data source to get the data from.
  * @param  {string} props.column - Name of the data source's column to get the data from.
- * @param  {string} props.operation - Operation to apply to the operationColumn. Must be one of those defined in `AggregationTypes` object.
+ * @param  {string} props.operation - Operation to apply to the column. Must be one of those defined in `AggregationTypes` object.
  * @param  {number[]} props.ticks - Array of thresholds for the X axis.
  * @param  {Function} [props.xAxisformatter] - Function to format X axis values.
  * @param  {Function} [props.formatter] - Function to format Y axis values.

--- a/packages/react-widgets/src/widgets/PieWidget.js
+++ b/packages/react-widgets/src/widgets/PieWidget.js
@@ -18,7 +18,8 @@ const EMPTY_ARRAY = [];
  * @param  {string} props.title - Title to show in the widget header.
  * @param  {string} props.dataSource - ID of the data source to get the data from.
  * @param  {string} props.column - Name of the data source's column to get the data from.
- * @param  {string} [props.operationColumn] - Name of the data source's column to operate with. If not defined it will default to the one defined in `column`.
+ * @param  {string | string[]} [props.operationColumn] - Name of the data source's column to operate with. If not defined it will default to the one defined in `column`. If multiples are provided, they will be merged into a single one using joinOperation property.
+ * @param  {AggregationTypes} [props.joinOperation] - Operation applied to aggregate multiple operation columns into a single one.
  * @param  {string} props.operation - Operation to apply to the operationColumn. Must be one of those defined in `AggregationTypes` object.
  * @param  {Function} [props.formatter] - Function to format the value that appears in the tooltip.
  * @param  {Function} [props.tooltipFormatter] - Function to return the HTML of the tooltip.
@@ -37,6 +38,7 @@ function PieWidget({
   dataSource,
   column,
   operationColumn,
+  joinOperation,
   operation,
   formatter,
   tooltipFormatter,
@@ -69,6 +71,7 @@ function PieWidget({
         column,
         operation,
         operationColumn,
+        joinOperation,
         filters,
         dataSource
       })
@@ -87,6 +90,7 @@ function PieWidget({
     id,
     column,
     operationColumn,
+    joinOperation,
     operation,
     filters,
     dataSource,
@@ -147,7 +151,11 @@ PieWidget.propTypes = {
   height: PropTypes.number,
   dataSource: PropTypes.string.isRequired,
   column: PropTypes.string.isRequired,
-  operationColumn: PropTypes.string,
+  operationColumn: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ]),
+  joinOperation: PropTypes.oneOf(Object.values(AggregationTypes)),
   operation: PropTypes.oneOf(Object.values(AggregationTypes)).isRequired,
   formatter: PropTypes.func,
   tooltipFormatter: PropTypes.func,

--- a/packages/react-widgets/src/widgets/PieWidget.js
+++ b/packages/react-widgets/src/widgets/PieWidget.js
@@ -8,6 +8,7 @@ import { getCategories } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
 import { selectAreFeaturesReadyForSource } from '@carto/react-redux/';
 import { useWidgetFilterValues } from '../hooks/useWidgetFilterValues';
+import { columnAggregationOn } from './utils/propTypesFns';
 
 const EMPTY_ARRAY = [];
 
@@ -155,7 +156,7 @@ PieWidget.propTypes = {
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string)
   ]),
-  joinOperation: PropTypes.oneOf(Object.values(AggregationTypes)),
+  joinOperation: columnAggregationOn('operationColumn'),
   operation: PropTypes.oneOf(Object.values(AggregationTypes)).isRequired,
   formatter: PropTypes.func,
   tooltipFormatter: PropTypes.func,

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -5,7 +5,6 @@ import { selectAreFeaturesReadyForSource } from '@carto/react-redux';
 import { WrapperWidgetUI, ScatterPlotWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { getScatter } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
-import { AggregationTypes } from '@carto/react-core';
 import { columnAggregationOn } from './utils/propTypesFns';
 
 /**

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -16,7 +16,7 @@ import { columnAggregationOn } from './utils/propTypesFns';
  * @param  {string} props.dataSource - ID of the data source to get the data from.
  * @param  {string | string[]} props.xAxisColumn - Name of the data source's column to get the x axis from. If multiples are provided, they will be merged into a single one using xAxisJoinOperation property.
  * @param  {AggregationTypes} [props.xAxisJoinOperation] - Operation applied to aggregate multiple xAxis columns into a single one.
- * @param  {string} props.yAxisColumn - Name of the data source's column to get the y axis from. If multiples are provided, they will be merged into a single one using yAxisJoinOperation property.
+ * @param  {string | string[]} props.yAxisColumn - Name of the data source's column to get the y axis from. If multiples are provided, they will be merged into a single one using yAxisJoinOperation property.
  * @param  {AggregationTypes} [props.yAxisJoinOperation] - Operation applied to aggregate multiple yAxis columns into a single one.
  * @param  {boolean} [props.animation] - Enable/disable widget animations on data updates. Enabled by default.
  * @param  {formatterCallback} [props.xAxisFormatter] - Function to format X axis values.

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -6,6 +6,7 @@ import { WrapperWidgetUI, ScatterPlotWidgetUI, NoDataAlert } from '@carto/react-
 import { getScatter } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
 import { AggregationTypes } from '@carto/react-core';
+import { columnAggregationOn } from './utils/propTypesFns';
 
 /**
  * Renders a <ScatterPlotWidget /> component
@@ -112,12 +113,12 @@ ScatterPlotWidget.propTypes = {
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string)
   ]).isRequired,
-  xAxisJoinOperation: PropTypes.oneOf(Object.values(AggregationTypes)),
+  xAxisJoinOperation: columnAggregationOn('xAxisColumn'),
   yAxisColumn: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string)
   ]).isRequired,
-  yAxisJoinOperation: PropTypes.oneOf(Object.values(AggregationTypes)),
+  yAxisJoinOperation: columnAggregationOn('yAxisColumn'),
   animation: PropTypes.bool,
   xAxisFormatter: PropTypes.func,
   yAxisFormatter: PropTypes.func,

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -5,6 +5,7 @@ import { selectAreFeaturesReadyForSource } from '@carto/react-redux';
 import { WrapperWidgetUI, ScatterPlotWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { getScatter } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
+import { AggregationTypes } from '@carto/react-core';
 
 /**
  * Renders a <ScatterPlotWidget /> component
@@ -12,8 +13,10 @@ import useSourceFilters from '../hooks/useSourceFilters';
  * @param  {string} props.id - ID for the widget instance.
  * @param  {string} props.title - Title to show in the widget header.
  * @param  {string} props.dataSource - ID of the data source to get the data from.
- * @param  {string} props.xAxisColumn - Name of the data source's column to get the x axis from.
- * @param  {string} props.yAxisColumn - Name of the data source's column to get the y axis from.
+ * @param  {string | string[]} props.xAxisColumn - Name of the data source's column to get the x axis from. If multiples are provided, they will be merged into a single one using xAxisJoinOperation property.
+ * @param  {AggregationTypes} [props.xAxisJoinOperation] - Operation applied to aggregate multiple xAxis columns into a single one.
+ * @param  {string} props.yAxisColumn - Name of the data source's column to get the y axis from. If multiples are provided, they will be merged into a single one using yAxisJoinOperation property.
+ * @param  {AggregationTypes} [props.yAxisJoinOperation] - Operation applied to aggregate multiple yAxis columns into a single one.
  * @param  {boolean} [props.animation] - Enable/disable widget animations on data updates. Enabled by default.
  * @param  {formatterCallback} [props.xAxisFormatter] - Function to format X axis values.
  * @param  {formatterCallback} [props.yAxisFormatter] - Function to format Y axis values.
@@ -28,7 +31,9 @@ function ScatterPlotWidget(props) {
     title,
     dataSource,
     xAxisColumn,
+    xAxisJoinOperation,
     yAxisColumn,
+    yAxisJoinOperation,
     animation,
     yAxisFormatter,
     xAxisFormatter,
@@ -52,7 +57,9 @@ function ScatterPlotWidget(props) {
     if (isSourceReady) {
       getScatter({
         xAxisColumn,
+        xAxisJoinOperation,
         yAxisColumn,
+        yAxisJoinOperation,
         filters,
         dataSource
       })
@@ -70,7 +77,9 @@ function ScatterPlotWidget(props) {
   }, [
     id,
     xAxisColumn,
+    xAxisJoinOperation,
     yAxisColumn,
+    yAxisJoinOperation,
     dataSource,
     filters,
     setIsLoading,
@@ -99,8 +108,16 @@ ScatterPlotWidget.propTypes = {
   id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   dataSource: PropTypes.string.isRequired,
-  xAxisColumn: PropTypes.string.isRequired,
-  yAxisColumn: PropTypes.string.isRequired,
+  xAxisColumn: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ]).isRequired,
+  xAxisJoinOperation: PropTypes.oneOf(Object.values(AggregationTypes)),
+  yAxisColumn: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ]).isRequired,
+  yAxisJoinOperation: PropTypes.oneOf(Object.values(AggregationTypes)),
   animation: PropTypes.bool,
   xAxisFormatter: PropTypes.func,
   yAxisFormatter: PropTypes.func,

--- a/packages/react-widgets/src/widgets/TimeSeriesWidget.js
+++ b/packages/react-widgets/src/widgets/TimeSeriesWidget.js
@@ -20,6 +20,7 @@ import {
 import { capitalize, Menu, MenuItem, SvgIcon, Typography } from '@material-ui/core';
 import { PropTypes } from 'prop-types';
 import useSourceFilters from '../hooks/useSourceFilters';
+import { columnAggregationOn } from './utils/propTypesFns';
 
 // Due to the widget groups the data by a certain stepSize, when filtering
 // the filter applied must be a range that represent the grouping range.
@@ -312,7 +313,7 @@ TimeSeriesWidget.propTypes = {
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string)
   ]),
-  joinOperation: PropTypes.oneOf(Object.values(AggregationTypes)),
+  joinOperation: columnAggregationOn('operationColumn'),
   operation: PropTypes.oneOf(Object.values(AggregationTypes)).isRequired,
   stepSizeOptions: PropTypes.arrayOf(PropTypes.oneOf(Object.values(GroupDateTypes))),
   onError: PropTypes.func,

--- a/packages/react-widgets/src/widgets/TimeSeriesWidget.js
+++ b/packages/react-widgets/src/widgets/TimeSeriesWidget.js
@@ -41,7 +41,8 @@ const STEP_SIZE_RANGE_MAPPING = {
  * @param  {string} props.title - Title to show in the widget header.
  * @param  {string} props.dataSource - ID of the data source to get the data from.
  * @param  {string} props.column - Name of the data source's date column for grouping the data.
- * @param  {string} [props.operationColumn] - Name of the data source's column to operate with. If not defined it will default to the one defined in `column`.
+ * @param  {string | string[]} [props.operationColumn] - Name of the data source's column to operate with. If not defined it will default to the one defined in `column`. If multiples are provided, they will be merged into a single one using joinOperation property.
+ * @param  {AggregationTypes} [props.joinOperation] - Operation applied to aggregate multiple operation columns into a single one.
  * @param  {string} [props.operation] - Operation to apply to the operationColumn. Operation used by default is COUNT. Must be one of those defined in `AggregationTypes` object.
  * @param  {string} props.stepSize - Step applied to group the data. Must be one of those defined in `GroupDateTypes` object.
  * @param  {string[]} [props.stepSizeOptions] - Different steps that can be applied to group the data. If filled, an icon with a menu appears to change between steps. Every value must be one of those defined in `AggregationTypes` object.
@@ -73,6 +74,7 @@ function TimeSeriesWidget({
   dataSource,
   column,
   operationColumn,
+  joinOperation,
   operation,
   stepSizeOptions,
   onError,
@@ -124,6 +126,7 @@ function TimeSeriesWidget({
         filters,
         dataSource,
         column,
+        joinOperation,
         stepSize: selectedStepSize,
         operationColumn,
         operation
@@ -148,6 +151,7 @@ function TimeSeriesWidget({
     isSourceReady,
     setIsLoading,
     operationColumn,
+    joinOperation,
     operation,
     onError
   ]);
@@ -304,7 +308,11 @@ TimeSeriesWidget.propTypes = {
   title: PropTypes.string.isRequired,
   dataSource: PropTypes.string.isRequired,
   column: PropTypes.string.isRequired,
-  operationColumn: PropTypes.string,
+  operationColumn: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
+  ]),
+  joinOperation: PropTypes.oneOf(Object.values(AggregationTypes)),
   operation: PropTypes.oneOf(Object.values(AggregationTypes)).isRequired,
   stepSizeOptions: PropTypes.arrayOf(PropTypes.oneOf(Object.values(GroupDateTypes))),
   onError: PropTypes.func,

--- a/packages/react-widgets/src/widgets/utils/propTypesFns.js
+++ b/packages/react-widgets/src/widgets/utils/propTypesFns.js
@@ -1,0 +1,14 @@
+import { AggregationTypes } from '@carto/react-core';
+
+export const columnAggregationOn = (columnPropName) => (props, propName) => {
+  if (Array.isArray(props[columnPropName])) {
+    if (!props[propName]) {
+      return new Error(
+        `Prop ${propName} must be defined if ${columnPropName} is an array`
+      );
+    }
+    if (Object.values(AggregationTypes).indexOf(props[propName]) === -1) {
+      return new Error(`Prop ${propName} must be a valid aggregation operator`);
+    }
+  }
+};

--- a/packages/react-widgets/src/widgets/utils/propTypesFns.js
+++ b/packages/react-widgets/src/widgets/utils/propTypesFns.js
@@ -1,7 +1,7 @@
 import { AggregationTypes } from '@carto/react-core';
 
 export const columnAggregationOn = (columnPropName) => (props, propName) => {
-  if (Array.isArray(props[columnPropName])) {
+  if (Array.isArray(props[columnPropName]) && props[columnPropName].length >= 2) {
     if (!props[propName]) {
       return new Error(
         `Prop ${propName} must be defined if ${columnPropName} is an array`

--- a/packages/react-workers/src/workers/features.worker.js
+++ b/packages/react-workers/src/workers/features.worker.js
@@ -137,15 +137,22 @@ function getCategories({ filters, operation, column, operationColumn, joinOperat
   postMessage({ result });
 }
 
-function getScatterPlot({ filters, xAxisColumn, yAxisColumn, joinOperation }) {
+function getScatterPlot({
+  filters,
+  xAxisColumn,
+  yAxisColumn,
+  xAxisJoinOperation,
+  yAxisJoinOperation
+}) {
   let result = [];
   if (currentFeatures) {
     const filteredFeatures = getFilteredFeatures(filters);
     result = scatterPlot({
       data: filteredFeatures,
       xAxisColumns: [xAxisColumn].flat(),
+      xAxisJoinOperation,
       yAxisColumns: [yAxisColumn].flat(),
-      joinOperation
+      yAxisJoinOperation
     });
   }
 


### PR DESCRIPTION
Documentation PR: https://github.com/CartoDB/documentation/pull/271

**Widgets affected**

- FormulaWidget
- CategoryWidget
- PieWidget
- ScatterPlotWidget
- TimeSeriesWidget

**Example from documentation**

In case you have the `population` disaggregated by gender: `population_m` and `population_f`, you can use an array in `operationColumn` and sum them into a single column using `joinOperation`. By this way, you avoid to have duplicated data in your dataset and you can compose widgets using multiple columns.
  
  ```js
  import { PieWidget } from "@carto/react-widgets";
  
  return (
    <PieWidget
      id="populationByContinent"
      title="Population by continent"
      dataSource="countriesSourceId"
      column="continent"
      operationColumn={["population_m", "population_f"]}
      joinOperation={AggregationTypes.SUM}
      operation={AggregationTypes.SUM}
    />
  );
  ```