### PR TITLE
Add RegExp string filtering capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not released
 
 - Implement multiple operationColumn in core functions [#347](https://github.com/CartoDB/carto-react/pull/347)
+- Add regex string filtering capabilities [#362](https://github.com/CartoDB/carto-react/pull/362)
 
 ## 1.2
 

--- a/packages/react-core/__tests__/filters/FilterTypes.test.js
+++ b/packages/react-core/__tests__/filters/FilterTypes.test.js
@@ -91,6 +91,11 @@ describe('FilterTypes', () => {
 
       // Multiples filter values (OR)
       expect(stringSearchFilter(['_test_', 'carto'], featureValue)).toBe(true);
+
+      // Regexp filtering
+      expect(stringSearchFilter(['\\w+RT\\w'], featureValue, { useRegExp: true })).toBe(
+        true
+      );
     });
   });
 });

--- a/packages/react-core/src/filters/FilterTypes.js
+++ b/packages/react-core/src/filters/FilterTypes.js
@@ -50,8 +50,9 @@ function stringSearch(filterValues, featureValue, params = {}) {
   const normalizedFeatureValue = normalize(featureValue, params);
   const stringRegExp = filterValues
     .map((filterValue) => {
-      let stringRegExp = escapeRegExp(normalize(filterValue, params));
+      let stringRegExp = normalize(filterValue, params);
 
+      if (!params.useRegExp) stringRegExp = escapeRegExp(stringRegExp);
       if (params.mustStart) stringRegExp = `^${stringRegExp}`;
       if (params.mustEnd) stringRegExp = `${stringRegExp}$`;
 

--- a/packages/react-core/src/filters/FilterTypes.js
+++ b/packages/react-core/src/filters/FilterTypes.js
@@ -50,15 +50,15 @@ function stringSearch(filterValues, featureValue, params = {}) {
   const normalizedFeatureValue = normalize(featureValue, params);
   const stringRegExp = filterValues
     .map((filterValue) => {
-      let stringRegExp = normalize(filterValue, params);
+      let formattedValue = filterValue;
 
       if (!params.useRegExp) {
-        stringRegExp = escapeRegExp(stringRegExp);
-        if (params.mustStart) stringRegExp = `^${stringRegExp}`;
-        if (params.mustEnd) stringRegExp = `${stringRegExp}$`;
+        formattedValue = escapeRegExp(normalize(filterValue, params));
+        if (params.mustStart) formattedValue = `^${formattedValue}`;
+        if (params.mustEnd) formattedValue = `${formattedValue}$`;
       }
 
-      return stringRegExp;
+      return formattedValue;
     })
     .join('|');
 

--- a/packages/react-core/src/filters/FilterTypes.js
+++ b/packages/react-core/src/filters/FilterTypes.js
@@ -48,21 +48,18 @@ function closedOpen(filterValues, featureValue) {
 // FilterTypes.STRING_SEARCH
 function stringSearch(filterValues, featureValue, params = {}) {
   const normalizedFeatureValue = normalize(featureValue, params);
-  const stringRegExp = filterValues
-    .map((filterValue) => {
-      let formattedValue = filterValue;
+  const stringRegExp = params.useRegExp
+    ? filterValues
+    : filterValues.map((filterValue) => {
+        let stringRegExp = escapeRegExp(normalize(filterValue, params));
 
-      if (!params.useRegExp) {
-        formattedValue = escapeRegExp(normalize(filterValue, params));
-        if (params.mustStart) formattedValue = `^${formattedValue}`;
-        if (params.mustEnd) formattedValue = `${formattedValue}$`;
-      }
+        if (params.mustStart) stringRegExp = `^${stringRegExp}`;
+        if (params.mustEnd) stringRegExp = `${stringRegExp}$`;
 
-      return formattedValue;
-    })
-    .join('|');
+        return stringRegExp;
+      });
 
-  const regex = new RegExp(stringRegExp, 'g');
+  const regex = new RegExp(stringRegExp.join('|'), params.caseSensitive ? 'g' : 'gi');
   return !!normalizedFeatureValue.match(regex);
 }
 
@@ -75,9 +72,7 @@ function escapeRegExp(value) {
 }
 
 function normalize(data, params) {
-  let normalizedData = '' + data;
-
-  if (!params.caseSensitive) normalizedData = normalizedData.toLocaleLowerCase();
+  let normalizedData = String(data);
   if (!params.keepSpecialCharacters)
     normalizedData = normalizedData.normalize('NFD').replace(normalizeRegExp, '');
 

--- a/packages/react-core/src/filters/FilterTypes.js
+++ b/packages/react-core/src/filters/FilterTypes.js
@@ -52,9 +52,11 @@ function stringSearch(filterValues, featureValue, params = {}) {
     .map((filterValue) => {
       let stringRegExp = normalize(filterValue, params);
 
-      if (!params.useRegExp) stringRegExp = escapeRegExp(stringRegExp);
-      if (params.mustStart) stringRegExp = `^${stringRegExp}`;
-      if (params.mustEnd) stringRegExp = `${stringRegExp}$`;
+      if (!params.useRegExp) {
+        stringRegExp = escapeRegExp(stringRegExp);
+        if (params.mustStart) stringRegExp = `^${stringRegExp}`;
+        if (params.mustEnd) stringRegExp = `${stringRegExp}$`;
+      }
 
       return stringRegExp;
     })


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/217708/support-regexp-in-string-search-filter

This PR adds the ability to use regexp values in the STRING_SEARCH filter type as discused in the RFC https://app.shortcut.com/cartoteam/story/216334/rfc-support-regex-in-string-search-filter

## Type of change

- Feature

# Acceptance

Please describe how to validate the feature or fix

1. See attached tests
2. Add regex value to string search filter
3. check that filter is working

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
