### PR TITLE
Add filters logical operator prop to source object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Add filters logical operator prop to source object [#363](https://github.com/CartoDB/carto-react/pull/363)
 - Implement multiple operationColumn in core functions [#347](https://github.com/CartoDB/carto-react/pull/347)
 - Add RegExp string filtering capabilities [#362](https://github.com/CartoDB/carto-react/pull/362)
 - Use multiple operationColumn in widgets [#361](https://github.com/CartoDB/carto-react/pull/361)

--- a/packages/react-api/src/hooks/dataFilterExtensionUtil.js
+++ b/packages/react-api/src/hooks/dataFilterExtensionUtil.js
@@ -56,11 +56,12 @@ function getUpdateTriggers(filtersWithoutTimeType, timeFilter) {
   };
 }
 
-function getFilterValue(filtersWithoutTimeType, timeFilter) {
+function getFilterValue(filtersWithoutTimeType, timeFilter, filtersLogicalOperator) {
   const result = Array(MAX_GPU_FILTERS).fill(0);
   const featureFilter = _buildFeatureFilter({
     filters: filtersWithoutTimeType,
-    type: 'number'
+    type: 'number',
+    filtersLogicalOperator
   });
   // We evaluate all filters except the time filter using _buildFeatureFilter function.
   // For the time filter, we return the value of the feature and we will change the getFilterRange result
@@ -79,12 +80,16 @@ function getFilterValue(filtersWithoutTimeType, timeFilter) {
 // The deck.gl DataFilterExtension accepts up to 4 values to filter.
 // We're going to use the first value for all filter except the time filter
 // that will be managed by the second value of the DataFilterExtension
-export function getDataFilterExtensionProps(filters = {}) {
+export function getDataFilterExtensionProps(filters = {}, filtersLogicalOperator) {
   const { filtersWithoutTimeType, timeFilter } = getFiltersByType(filters);
   return {
     filterRange: getFilterRange(timeFilter),
     updateTriggers: getUpdateTriggers(filtersWithoutTimeType, timeFilter),
-    getFilterValue: getFilterValue(filtersWithoutTimeType, timeFilter),
+    getFilterValue: getFilterValue(
+      filtersWithoutTimeType,
+      timeFilter,
+      filtersLogicalOperator
+    ),
     extensions: [dataFilterExtension]
   };
 }

--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -55,7 +55,10 @@ export default function useCartoLayerProps({
     })
   };
 
-  const dataFilterExtensionProps = getDataFilterExtensionProps(source?.filters);
+  const dataFilterExtensionProps = getDataFilterExtensionProps(
+    source?.filters,
+    source?.filtersLogicalOperator
+  );
   const maskExtensionProps = getMaskExtensionProps(spatialFilter?.geometry?.coordinates);
   const extensions = [
     ...dataFilterExtensionProps.extensions,

--- a/packages/react-core/__tests__/filters/Filter.test.js
+++ b/packages/react-core/__tests__/filters/Filter.test.js
@@ -1,5 +1,6 @@
 import { buildBinaryFeatureFilter, buildFeatureFilter } from '../../src/filters/Filter';
 import { POINTS_BINARY_DATA, POLYGONS_BINARY_DATA } from './constants';
+import { FiltersLogicalOperators } from '../../src/operations/constants/FiltersLogicalOperators';
 
 const filters = {
   column1: {
@@ -273,6 +274,45 @@ describe('Filters', () => {
         const isFeatureIncluded = buildFeatureFilter(zeroIsValidForThisFilter)(obj);
         expect(isFeatureIncluded).toBe(0);
       });
+    });
+  });
+
+  describe('feature passes filter - logical OR operator', () => {
+    const params = {
+      filtersLogicalOperator: FiltersLogicalOperators.OR,
+      filters: {
+        column1: {
+          in: {
+            values: [1]
+          }
+        },
+        column2: {
+          in: {
+            values: [2]
+          }
+        }
+      }
+    };
+
+    test('should pass if only first column passes', () => {
+      const feature = { properties: { column1: 1, column2: null } };
+      const result = buildFeatureFilter(params)(feature);
+      expect(result).toBe(true);
+    });
+    test('should pass if only second column passes', () => {
+      const feature = { properties: { column1: null, column2: 2 } };
+      const result = buildFeatureFilter(params)(feature);
+      expect(result).toBe(true);
+    });
+    test('should pass if both columns pass', () => {
+      const feature = { properties: { column1: 1, column2: 2 } };
+      const result = buildFeatureFilter(params)(feature);
+      expect(result).toBe(true);
+    });
+    test('should not pass if none of the columns pass', () => {
+      const feature = { properties: { column1: null, column2: null } };
+      const result = buildFeatureFilter(params)(feature);
+      expect(result).toBe(false);
     });
   });
 

--- a/packages/react-core/src/filters/Filter.js
+++ b/packages/react-core/src/filters/Filter.js
@@ -1,11 +1,12 @@
 import { filterFunctions } from './FilterTypes';
 import { FiltersLogicalOperators } from '../operations/constants/FiltersLogicalOperators';
 
+const logicalOperatorMethods = {
+  [FiltersLogicalOperators.AND]: 'every',
+  [FiltersLogicalOperators.OR]: 'some'
+};
+
 function passesFilter(columns, filters, feature, filtersLogicalOperator) {
-  const logicalOperatorMethods = {
-    [FiltersLogicalOperators.AND]: 'every',
-    [FiltersLogicalOperators.OR]: 'some'
-  };
   const method = logicalOperatorMethods[filtersLogicalOperator];
   return columns[method]((column) => {
     const columnFilters = filters[column];

--- a/packages/react-core/src/filters/Filter.js
+++ b/packages/react-core/src/filters/Filter.js
@@ -1,13 +1,13 @@
 import { filterFunctions } from './FilterTypes';
 import { FiltersLogicalOperators } from '../operations/constants/FiltersLogicalOperators';
 
-const logicalOperatorMethods = {
+const LOGICAL_OPERATOR_METHODS = {
   [FiltersLogicalOperators.AND]: 'every',
   [FiltersLogicalOperators.OR]: 'some'
 };
 
 function passesFilter(columns, filters, feature, filtersLogicalOperator) {
-  const method = logicalOperatorMethods[filtersLogicalOperator];
+  const method = LOGICAL_OPERATOR_METHODS[filtersLogicalOperator];
   return columns[method]((column) => {
     const columnFilters = filters[column];
     const columnFilterTypes = Object.keys(columnFilters);

--- a/packages/react-core/src/filters/Filter.js
+++ b/packages/react-core/src/filters/Filter.js
@@ -1,7 +1,13 @@
 import { filterFunctions } from './FilterTypes';
+import { FiltersLogicalOperators } from '../operations/constants/FiltersLogicalOperators';
 
-function passesFilter(columns, filters, feature) {
-  return columns.every((column) => {
+function passesFilter(columns, filters, feature, filtersLogicalOperator) {
+  const logicalOperatorMethods = {
+    [FiltersLogicalOperators.AND]: 'every',
+    [FiltersLogicalOperators.OR]: 'some'
+  };
+  const method = logicalOperatorMethods[filtersLogicalOperator];
+  return columns[method]((column) => {
     const columnFilters = filters[column];
     const columnFilterTypes = Object.keys(columnFilters);
 
@@ -25,7 +31,11 @@ function passesFilter(columns, filters, feature) {
   });
 }
 
-export function buildFeatureFilter({ filters = {}, type = 'boolean' }) {
+export function buildFeatureFilter({
+  filters = {},
+  type = 'boolean',
+  filtersLogicalOperator = FiltersLogicalOperators.AND
+}) {
   const columns = Object.keys(filters);
 
   if (!columns.length) {
@@ -34,16 +44,16 @@ export function buildFeatureFilter({ filters = {}, type = 'boolean' }) {
 
   return (feature) => {
     const f = feature.properties || feature;
-    const featurePassesFilter = passesFilter(columns, filters, f);
+    const featurePassesFilter = passesFilter(columns, filters, f, filtersLogicalOperator);
 
     return type === 'number' ? Number(featurePassesFilter) : featurePassesFilter;
   };
 }
 
 // Apply certain filters to a collection of features
-export function applyFilters(features, filters) {
+export function applyFilters(features, filters, filtersLogicalOperator) {
   return Object.keys(filters).length
-    ? features.filter(buildFeatureFilter({ filters }))
+    ? features.filter(buildFeatureFilter({ filters, filtersLogicalOperator }))
     : features;
 }
 

--- a/packages/react-core/src/index.d.ts
+++ b/packages/react-core/src/index.d.ts
@@ -13,6 +13,7 @@ export { randomString } from './utils/randomString';
 
 export { makeIntervalComplete } from './utils/makeIntervalComplete';
 
+export { FiltersLogicalOperators } from './operations/constants/FiltersLogicalOperators';
 export { AggregationTypes } from './operations/constants/AggregationTypes';
 export { aggregationFunctions } from './operations/aggregation';
 export { groupValuesByColumn } from './operations/groupBy';

--- a/packages/react-core/src/index.js
+++ b/packages/react-core/src/index.js
@@ -13,6 +13,7 @@ export { randomString } from './utils/randomString';
 
 export { makeIntervalComplete } from './utils/makeIntervalComplete';
 
+export { FiltersLogicalOperators } from './operations/constants/FiltersLogicalOperators';
 export { AggregationTypes } from './operations/constants/AggregationTypes';
 export { aggregationFunctions } from './operations/aggregation';
 export { groupValuesByColumn } from './operations/groupBy';

--- a/packages/react-core/src/operations/constants/FiltersLogicalOperators.d.ts
+++ b/packages/react-core/src/operations/constants/FiltersLogicalOperators.d.ts
@@ -1,0 +1,4 @@
+export enum FiltersLogicalOperators {
+  AND = 'and',
+  OR = 'or'
+}

--- a/packages/react-core/src/operations/constants/FiltersLogicalOperators.js
+++ b/packages/react-core/src/operations/constants/FiltersLogicalOperators.js
@@ -1,0 +1,9 @@
+/**
+ * Enum for the different logical operator applied to source filters
+ * @enum {string}
+ * @readonly
+ */
+export const FiltersLogicalOperators = Object.freeze({
+  AND: 'and',
+  OR: 'or'
+});

--- a/packages/react-redux/src/slices/cartoSlice.d.ts
+++ b/packages/react-redux/src/slices/cartoSlice.d.ts
@@ -1,11 +1,15 @@
 import { Credentials } from '@carto/react-api/';
 import { SourceProps } from '@carto/react-api/types';
-import { _FilterTypes } from '@carto/react-core';
+import { FiltersLogicalOperators, _FilterTypes } from '@carto/react-core';
 import { CartoBasemapsNames, GMapsBasemapsNames } from '@carto/react-basemaps/';
 import { InitialCartoState, CartoState, ViewState } from '../types';
 import { AnyAction, Reducer } from 'redux';
 
-type Source = SourceProps & { id: string } & { filters?: any };
+type Source = SourceProps & {
+  id: string
+  filters?: any
+  filtersLogicalOperator?: FiltersLogicalOperators
+};
 
 type Layer = {
   id: string;

--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -3,7 +3,7 @@ import { WebMercatorViewport } from '@deck.gl/core';
 import { debounce } from '@carto/react-core';
 import { removeWorker } from '@carto/react-workers';
 import { setDefaultCredentials } from '@deck.gl/carto';
-import { FEATURE_SELECTION_MODES } from '@carto/react-core';
+import { FEATURE_SELECTION_MODES, FiltersLogicalOperators } from '@carto/react-core';
 
 /**
  *
@@ -187,10 +187,19 @@ export const createCartoSlice = (initialState) => {
  * @param {string} data - data definition for the source. Query for SQL dataset or the name of the tileset for BigQuery Tileset
  * @param {string} type - type of source. Posible values are sql or bigquery
  * @param {Object} credentials - (optional) Custom credentials to be used in the source
+ * @param {string} connection - connection name for carto 3 source
+ * @param {FiltersLogicalOperators} filtersLogicalOperator - logical operator that defines how filters for different columns are joined together
  */
-export const addSource = ({ id, data, type, credentials, connection }) => ({
+export const addSource = ({
+  id,
+  data,
+  type,
+  credentials,
+  connection,
+  filtersLogicalOperator = FiltersLogicalOperators.AND
+}) => ({
   type: 'carto/addSource',
-  payload: { id, data, type, credentials, connection }
+  payload: { id, data, type, credentials, connection, filtersLogicalOperator }
 });
 
 /**

--- a/packages/react-widgets/src/hooks/useSourceFilters.js
+++ b/packages/react-widgets/src/hooks/useSourceFilters.js
@@ -12,12 +12,20 @@ import { dequal as deepEqual } from 'dequal';
  * @param  {string} props.id - ID of the widget that apply the filter you want to exclude.
  */
 export default function useSourceFilters({ dataSource, id }) {
-  const { filters } = useSelector((state) => selectSourceById(state, dataSource) || {});
+  const { filters, filtersLogicalOperator } = useSelector(
+    (state) => selectSourceById(state, dataSource) || {}
+  );
 
-  const applicableFilters = useMemo(() => getApplicableFilters(filters, id), [
-    filters,
-    id
-  ]);
+  const applicableFilters = useMemo(
+    () => getApplicableFilters(filters, id),
+    [filters, id]
+  );
 
-  return useCustomCompareMemo(applicableFilters, deepEqual);
+  return useCustomCompareMemo(
+    {
+      filters: applicableFilters,
+      filtersLogicalOperator
+    },
+    deepEqual
+  );
 }

--- a/packages/react-widgets/src/models/CategoryModel.js
+++ b/packages/react-widgets/src/models/CategoryModel.js
@@ -1,10 +1,18 @@
 import { Methods, executeTask } from '@carto/react-workers';
 
 export const getCategories = async (props) => {
-  const { column, operationColumn, operation, filters, dataSource } = props;
+  const {
+    column,
+    operationColumn,
+    operation,
+    filters,
+    filtersLogicalOperator,
+    dataSource
+  } = props;
 
   return executeTask(dataSource, Methods.FEATURES_CATEGORY, {
     filters,
+    filtersLogicalOperator,
     operation,
     column,
     operationColumn: operationColumn || column

--- a/packages/react-widgets/src/models/FormulaModel.js
+++ b/packages/react-widgets/src/models/FormulaModel.js
@@ -1,10 +1,11 @@
 import { Methods, executeTask } from '@carto/react-workers';
 
 export const getFormula = async (props) => {
-  const { operation, column, filters, dataSource } = props;
+  const { operation, column, filters, filtersLogicalOperator, dataSource } = props;
 
   return executeTask(dataSource, Methods.FEATURES_FORMULA, {
     filters,
+    filtersLogicalOperator,
     operation,
     column
   });

--- a/packages/react-widgets/src/models/HistogramModel.js
+++ b/packages/react-widgets/src/models/HistogramModel.js
@@ -1,10 +1,11 @@
 import { Methods, executeTask } from '@carto/react-workers';
 
 export const getHistogram = async (props) => {
-  const { column, operation, ticks, filters, dataSource } = props;
+  const { column, operation, ticks, filters, filtersLogicalOperator, dataSource } = props;
 
   return executeTask(dataSource, Methods.FEATURES_HISTOGRAM, {
     filters,
+    filtersLogicalOperator,
     operation,
     column,
     ticks

--- a/packages/react-widgets/src/models/ScatterPlotModel.js
+++ b/packages/react-widgets/src/models/ScatterPlotModel.js
@@ -1,10 +1,11 @@
 import { Methods, executeTask } from '@carto/react-workers';
 
 export const getScatter = async (props) => {
-  const { xAxisColumn, yAxisColumn, filters, dataSource } = props;
+  const { xAxisColumn, yAxisColumn, filters, filtersLogicalOperator, dataSource } = props;
 
   return executeTask(dataSource, Methods.FEATURES_SCATTERPLOT, {
     filters,
+    filtersLogicalOperator,
     xAxisColumn,
     yAxisColumn
   });

--- a/packages/react-widgets/src/models/TableModel.js
+++ b/packages/react-widgets/src/models/TableModel.js
@@ -1,10 +1,19 @@
 import { Methods, executeTask } from '@carto/react-workers';
 
 export const getTable = async (props) => {
-  const { filters, dataSource, rowsPerPage, page, sortBy, sortDirection } = props;
+  const {
+    filters,
+    filtersLogicalOperator,
+    dataSource,
+    rowsPerPage,
+    page,
+    sortBy,
+    sortDirection
+  } = props;
 
   return executeTask(dataSource, Methods.FEATURES_RAW, {
     filters,
+    filtersLogicalOperator,
     limit: rowsPerPage,
     page,
     sortBy,

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { addFilter, removeFilter } from '@carto/react-redux';
+import { addFilter, removeFilter, selectSourceById } from '@carto/react-redux';
 import { WrapperWidgetUI, CategoryWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { _FilterTypes as FilterTypes, AggregationTypes } from '@carto/react-core';
 import { getCategories } from '../models';
@@ -48,6 +48,7 @@ function CategoryWidget(props) {
   } = props;
   const dispatch = useDispatch();
 
+  const source = useSelector((state) => selectSourceById(state, dataSource));
   const isSourceReady = useSelector((state) =>
     selectAreFeaturesReadyForSource(state, dataSource)
   );
@@ -70,6 +71,7 @@ function CategoryWidget(props) {
         operationColumn,
         operation,
         filters,
+        filtersLogicalOperator: source?.filtersLogicalOperator,
         dataSource
       })
         .then((data) => {

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -51,7 +51,6 @@ function CategoryWidget(props) {
   } = props;
   const dispatch = useDispatch();
 
-  const source = useSelector((state) => selectSourceById(state, dataSource));
   const isSourceReady = useSelector((state) =>
     selectAreFeaturesReadyForSource(state, dataSource)
   );
@@ -60,7 +59,7 @@ function CategoryWidget(props) {
 
   const [isLoading, setIsLoading] = useState(true);
 
-  const filters = useSourceFilters({ dataSource, id });
+  const { filters, filtersLogicalOperator } = useSourceFilters({ dataSource, id });
   const selectedCategories =
     useWidgetFilterValues({ dataSource, id, column, type: FilterTypes.IN }) ||
     EMPTY_ARRAY;
@@ -75,7 +74,7 @@ function CategoryWidget(props) {
         joinOperation,
         operation,
         filters,
-        filtersLogicalOperator: source?.filtersLogicalOperator,
+        filtersLogicalOperator,
         dataSource
       })
         .then((data) => {
@@ -96,7 +95,7 @@ function CategoryWidget(props) {
     joinOperation,
     operation,
     filters,
-    source?.filtersLogicalOperator,
+    filtersLogicalOperator,
     dataSource,
     setIsLoading,
     onError,

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { addFilter, removeFilter, selectSourceById } from '@carto/react-redux';
+import { addFilter, removeFilter } from '@carto/react-redux';
 import { WrapperWidgetUI, CategoryWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { _FilterTypes as FilterTypes, AggregationTypes } from '@carto/react-core';
 import { getCategories } from '../models';

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -91,6 +91,7 @@ function CategoryWidget(props) {
     operationColumn,
     operation,
     filters,
+    source?.filtersLogicalOperator,
     dataSource,
     setIsLoading,
     onError,

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -5,7 +5,7 @@ import { WrapperWidgetUI, FormulaWidgetUI } from '@carto/react-ui';
 import { getFormula } from '../models';
 import { AggregationTypes } from '@carto/react-core';
 import useSourceFilters from '../hooks/useSourceFilters';
-import { selectAreFeaturesReadyForSource, selectSourceById } from '@carto/react-redux';
+import { selectAreFeaturesReadyForSource } from '@carto/react-redux';
 import { columnAggregationOn } from './utils/propTypesFns';
 
 /**

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -5,7 +5,7 @@ import { WrapperWidgetUI, FormulaWidgetUI } from '@carto/react-ui';
 import { getFormula } from '../models';
 import { AggregationTypes } from '@carto/react-core';
 import useSourceFilters from '../hooks/useSourceFilters';
-import { selectAreFeaturesReadyForSource } from '@carto/react-redux';
+import { selectAreFeaturesReadyForSource, selectSourceById } from '@carto/react-redux';
 
 /**
  * Renders a <FormulaWidget /> component
@@ -32,6 +32,8 @@ function FormulaWidget(props) {
     onError,
     wrapperProps
   } = props;
+
+  const source = useSelector((state) => selectSourceById(state, dataSource));
   const isSourceReady = useSelector((state) =>
     selectAreFeaturesReadyForSource(state, dataSource)
   );
@@ -48,6 +50,7 @@ function FormulaWidget(props) {
         operation,
         column,
         filters,
+        filtersLogicalOperator: source?.filtersLogicalOperator,
         dataSource
       })
         .then((data) => {
@@ -61,7 +64,16 @@ function FormulaWidget(props) {
           if (onError) onError(error);
         });
     }
-  }, [operation, column, filters, dataSource, setIsLoading, onError, isSourceReady]);
+  }, [
+    operation,
+    column,
+    filters,
+    source?.filtersLogicalOperator,
+    dataSource,
+    setIsLoading,
+    onError,
+    isSourceReady
+  ]);
 
   return (
     <WrapperWidgetUI title={title} isLoading={isLoading} {...wrapperProps}>

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -34,11 +34,10 @@ function FormulaWidget({
   onError,
   wrapperProps
 }) {
-  const source = useSelector((state) => selectSourceById(state, dataSource));
   const isSourceReady = useSelector((state) =>
     selectAreFeaturesReadyForSource(state, dataSource)
   );
-  const filters = useSourceFilters({ dataSource, id });
+  const { filters, filtersLogicalOperator } = useSourceFilters({ dataSource, id });
 
   const [formulaData, setFormulaData] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -52,7 +51,7 @@ function FormulaWidget({
         column,
         joinOperation,
         filters,
-        filtersLogicalOperator: source?.filtersLogicalOperator,
+        filtersLogicalOperator,
         dataSource
       })
         .then((data) => {
@@ -71,7 +70,7 @@ function FormulaWidget({
     column,
     joinOperation,
     filters,
-    source?.filtersLogicalOperator,
+    filtersLogicalOperator,
     dataSource,
     setIsLoading,
     onError,

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { PropTypes } from 'prop-types';
-import { addFilter, removeFilter } from '@carto/react-redux';
+import { addFilter, removeFilter, selectSourceById } from '@carto/react-redux';
 import { WrapperWidgetUI, HistogramWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { _FilterTypes as FilterTypes, AggregationTypes } from '@carto/react-core';
 import { getHistogram } from '../models';
@@ -53,6 +53,7 @@ function HistogramWidget(props) {
   const [isLoading, setIsLoading] = useState(true);
 
   const filters = useSourceFilters({ dataSource, id });
+  const source = useSelector((state) => selectSourceById(state, dataSource));
   const isSourceReady = useSelector((state) =>
     selectAreFeaturesReadyForSource(state, dataSource)
   );
@@ -101,6 +102,7 @@ function HistogramWidget(props) {
         operation,
         ticks,
         filters,
+        filtersLogicalOperator: source?.filtersLogicalOperator,
         dataSource
       })
         .then((data) => {
@@ -121,6 +123,7 @@ function HistogramWidget(props) {
     ticks,
     dataSource,
     filters,
+    source?.filtersLogicalOperator,
     setIsLoading,
     onError,
     isSourceReady

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { PropTypes } from 'prop-types';
-import { addFilter, removeFilter, selectSourceById } from '@carto/react-redux';
+import { addFilter, removeFilter } from '@carto/react-redux';
 import { WrapperWidgetUI, HistogramWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { _FilterTypes as FilterTypes, AggregationTypes } from '@carto/react-core';
 import { getHistogram } from '../models';

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -52,8 +52,7 @@ function HistogramWidget(props) {
   const [histogramData, setHistogramData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  const filters = useSourceFilters({ dataSource, id });
-  const source = useSelector((state) => selectSourceById(state, dataSource));
+  const { filters, filtersLogicalOperator } = useSourceFilters({ dataSource, id });
   const isSourceReady = useSelector((state) =>
     selectAreFeaturesReadyForSource(state, dataSource)
   );
@@ -102,7 +101,7 @@ function HistogramWidget(props) {
         operation,
         ticks,
         filters,
-        filtersLogicalOperator: source?.filtersLogicalOperator,
+        filtersLogicalOperator,
         dataSource
       })
         .then((data) => {
@@ -123,7 +122,7 @@ function HistogramWidget(props) {
     ticks,
     dataSource,
     filters,
-    source?.filtersLogicalOperator,
+    filtersLogicalOperator,
     setIsLoading,
     onError,
     isSourceReady

--- a/packages/react-widgets/src/widgets/PieWidget.js
+++ b/packages/react-widgets/src/widgets/PieWidget.js
@@ -62,7 +62,7 @@ function PieWidget({
   const isSourceReady = useSelector((state) =>
     selectAreFeaturesReadyForSource(state, dataSource)
   );
-  const filters = useSourceFilters({ dataSource, id });
+  const { filters, filtersLogicalOperator } = useSourceFilters({ dataSource, id });
 
   useEffect(() => {
     setIsLoading(true);
@@ -74,6 +74,7 @@ function PieWidget({
         operationColumn,
         joinOperation,
         filters,
+        filtersLogicalOperator,
         dataSource
       })
         .then((data) => {
@@ -94,6 +95,7 @@ function PieWidget({
     joinOperation,
     operation,
     filters,
+    filtersLogicalOperator,
     dataSource,
     setIsLoading,
     onError,

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -46,11 +46,10 @@ function ScatterPlotWidget(props) {
   const [scatterData, setScatterData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  const source = useSelector((state) => selectSourceById(state, dataSource));
   const isSourceReady = useSelector((state) =>
     selectAreFeaturesReadyForSource(state, dataSource)
   );
-  const filters = useSourceFilters({ dataSource, id });
+  const { filters, filtersLogicalOperator } = useSourceFilters({ dataSource, id });
 
   useEffect(() => {
     setIsLoading(true);
@@ -62,7 +61,7 @@ function ScatterPlotWidget(props) {
         yAxisColumn,
         yAxisJoinOperation,
         filters,
-        filtersLogicalOperator: source?.filtersLogicalOperator,
+        filtersLogicalOperator,
         dataSource
       })
         .then((data) => {
@@ -84,7 +83,7 @@ function ScatterPlotWidget(props) {
     yAxisJoinOperation,
     dataSource,
     filters,
-    source?.filtersLogicalOperator,
+    filtersLogicalOperator,
     setIsLoading,
     isSourceReady,
     onError

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { PropTypes } from 'prop-types';
-import { selectAreFeaturesReadyForSource } from '@carto/react-redux';
+import { selectAreFeaturesReadyForSource, selectSourceById } from '@carto/react-redux';
 import { WrapperWidgetUI, ScatterPlotWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { getScatter } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
@@ -41,6 +41,7 @@ function ScatterPlotWidget(props) {
   const [scatterData, setScatterData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
 
+  const source = useSelector((state) => selectSourceById(state, dataSource));
   const isSourceReady = useSelector((state) =>
     selectAreFeaturesReadyForSource(state, dataSource)
   );
@@ -54,6 +55,7 @@ function ScatterPlotWidget(props) {
         xAxisColumn,
         yAxisColumn,
         filters,
+        filtersLogicalOperator: source?.filtersLogicalOperator,
         dataSource
       })
         .then((data) => {
@@ -73,6 +75,7 @@ function ScatterPlotWidget(props) {
     yAxisColumn,
     dataSource,
     filters,
+    source?.filtersLogicalOperator,
     setIsLoading,
     isSourceReady,
     onError

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { PropTypes } from 'prop-types';
-import { selectAreFeaturesReadyForSource, selectSourceById } from '@carto/react-redux';
+import { selectAreFeaturesReadyForSource } from '@carto/react-redux';
 import { WrapperWidgetUI, ScatterPlotWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { getScatter } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { WrapperWidgetUI, TableWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { getTable } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
-import { selectAreFeaturesReadyForSource } from '@carto/react-redux/';
+import { selectAreFeaturesReadyForSource, selectSourceById } from '@carto/react-redux/';
 
 /**
  * Renders a <TableWidget /> component
@@ -42,6 +42,7 @@ function TableWidget({
   const [rows, setRows] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const filters = useSourceFilters({ dataSource, id });
+  const source = useSelector((state) => selectSourceById(state, dataSource));
   const isSourceReady = useSelector((state) =>
     selectAreFeaturesReadyForSource(state, dataSource)
   );
@@ -56,6 +57,7 @@ function TableWidget({
       setIsLoading(true);
       getTable({
         filters,
+        filtersLogicalOperator: source?.filtersLogicalOperator,
         dataSource,
         rowsPerPage,
         page,
@@ -79,6 +81,7 @@ function TableWidget({
     id,
     dataSource,
     filters,
+    source?.filtersLogicalOperator,
     sortBy,
     sortDirection,
     page,

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -41,8 +41,7 @@ function TableWidget({
 
   const [rows, setRows] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
-  const filters = useSourceFilters({ dataSource, id });
-  const source = useSelector((state) => selectSourceById(state, dataSource));
+  const { filters, filtersLogicalOperator } = useSourceFilters({ dataSource, id });
   const isSourceReady = useSelector((state) =>
     selectAreFeaturesReadyForSource(state, dataSource)
   );
@@ -57,7 +56,7 @@ function TableWidget({
       setIsLoading(true);
       getTable({
         filters,
-        filtersLogicalOperator: source?.filtersLogicalOperator,
+        filtersLogicalOperator,
         dataSource,
         rowsPerPage,
         page,
@@ -81,7 +80,7 @@ function TableWidget({
     id,
     dataSource,
     filters,
-    source?.filtersLogicalOperator,
+    filtersLogicalOperator,
     sortBy,
     sortDirection,
     page,

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { WrapperWidgetUI, TableWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { getTable } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
-import { selectAreFeaturesReadyForSource, selectSourceById } from '@carto/react-redux/';
+import { selectAreFeaturesReadyForSource } from '@carto/react-redux/';
 
 /**
  * Renders a <TableWidget /> component

--- a/packages/react-widgets/src/widgets/TimeSeriesWidget.js
+++ b/packages/react-widgets/src/widgets/TimeSeriesWidget.js
@@ -105,7 +105,7 @@ function TimeSeriesWidget({
   const isSourceReady = useSelector((state) =>
     selectAreFeaturesReadyForSource(state, dataSource)
   );
-  const filters = useSourceFilters({ dataSource, id });
+  const { filters } = useSourceFilters({ dataSource, id });
 
   const [timeSeriesData, setTimeSeriesData] = useState([]);
   const [selectedStepSize, setSelectedStepSize] = useState(stepSize);

--- a/packages/react-workers/src/workers/features.worker.js
+++ b/packages/react-workers/src/workers/features.worker.js
@@ -85,13 +85,19 @@ function getGeojsonFeatures({ viewport, geometry, uniqueIdProperty }) {
   postMessage({ result: true });
 }
 
-function getFormula({ filters, operation, column, joinOperation }) {
+function getFormula({
+  filters,
+  filtersLogicalOperator,
+  operation,
+  column,
+  joinOperation
+}) {
   let result = null;
 
   if (currentFeatures) {
     const targetOperation = aggregationFunctions[operation];
 
-    const filteredFeatures = getFilteredFeatures(filters);
+    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
 
     result = [{ value: targetOperation(filteredFeatures, column, joinOperation) }];
   }
@@ -99,11 +105,18 @@ function getFormula({ filters, operation, column, joinOperation }) {
   postMessage({ result });
 }
 
-function getHistogram({ filters, operation, column, ticks, joinOperation }) {
+function getHistogram({
+  filters,
+  filtersLogicalOperator,
+  operation,
+  column,
+  ticks,
+  joinOperation
+}) {
   let result = null;
 
   if (currentFeatures) {
-    const filteredFeatures = getFilteredFeatures(filters);
+    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
 
     result = histogram({
       data: filteredFeatures,
@@ -117,11 +130,18 @@ function getHistogram({ filters, operation, column, ticks, joinOperation }) {
   postMessage({ result });
 }
 
-function getCategories({ filters, operation, column, operationColumn, joinOperation }) {
+function getCategories({
+  filters,
+  filtersLogicalOperator,
+  operation,
+  column,
+  operationColumn,
+  joinOperation
+}) {
   let result = null;
 
   if (currentFeatures) {
-    const filteredFeatures = getFilteredFeatures(filters);
+    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
 
     const groups = groupValuesByColumn({
       data: filteredFeatures,
@@ -137,10 +157,16 @@ function getCategories({ filters, operation, column, operationColumn, joinOperat
   postMessage({ result });
 }
 
-function getScatterPlot({ filters, xAxisColumn, yAxisColumn, joinOperation }) {
+function getScatterPlot({
+  filters,
+  filtersLogicalOperator,
+  xAxisColumn,
+  yAxisColumn,
+  joinOperation
+}) {
   let result = [];
   if (currentFeatures) {
-    const filteredFeatures = getFilteredFeatures(filters);
+    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
     result = scatterPlot({
       data: filteredFeatures,
       xAxisColumns: [xAxisColumn].flat(),
@@ -154,6 +180,7 @@ function getScatterPlot({ filters, xAxisColumn, yAxisColumn, joinOperation }) {
 
 function getTimeSeries({
   filters,
+  filtersLogicalOperator,
   column,
   stepSize,
   operation,
@@ -163,7 +190,7 @@ function getTimeSeries({
   let result = [];
 
   if (currentFeatures) {
-    const filteredFeatures = getFilteredFeatures(filters);
+    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
 
     const groups = groupValuesByDateColumn({
       data: filteredFeatures,
@@ -183,6 +210,7 @@ function getTimeSeries({
 // See sorting details in utils/sorting.js
 function getRawFeatures({
   filters,
+  filtersLogicalOperator,
   limit = 10,
   page = 0,
   sortBy,
@@ -193,7 +221,7 @@ function getRawFeatures({
   let totalCount = 0;
 
   if (currentFeatures) {
-    data = applySorting(getFilteredFeatures(filters), {
+    data = applySorting(getFilteredFeatures(filters, filtersLogicalOperator), {
       sortBy,
       sortByDirection
     });
@@ -215,6 +243,6 @@ function applyPagination(features, { limit, page }) {
   return features.slice(limit * Math.max(0, page), limit * Math.max(1, page + 1));
 }
 
-function getFilteredFeatures(filters = {}) {
-  return _applyFilters(currentFeatures, filters);
+function getFilteredFeatures(filters = {}, filtersLogicalOperator) {
+  return _applyFilters(currentFeatures, filters, filtersLogicalOperator);
 }


### PR DESCRIPTION
# Description

Shortcut RFC: https://app.shortcut.com/cartoteam/story/216324/rfc-add-filter-condition-prop-to-source-object
Shortcut task: https://app.shortcut.com/cartoteam/story/218323/add-filters-logical-operator-prop-to-source-object

Summary of the change: Added a new `filtersLogicalOperator` param that is passed everywhere the `filters` is used. This lets us decide which filtering logical operator to use in the `passesFilter` function that is used by feature workers and by deck.gl layers.

## Type of change

- Feature

# Acceptance

Please describe how to validate the feature or fix:

* This feature can be validated with the new unit test included in the PR

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
