### PR TITLE
Fix aggregation excluding NULL values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not released
 
 - Bump deck.gl to 8.7.3 [#360](https://github.com/CartoDB/carto-react/pull/360)
+- Fix aggregation to ignore NULL values [#367](https://github.com/CartoDB/carto-react/pull/367)
 
 ## 1.3
 

--- a/packages/react-core/__tests__/operations/aggregation.test.js
+++ b/packages/react-core/__tests__/operations/aggregation.test.js
@@ -11,6 +11,11 @@ const features = [...Array(VALUES.length)].map((_, idx) => ({
   [COLUMN_2]: VALUES[idx] - 1
 }));
 
+const featuresIncludingNull = [...Array(VALUES.length)].map((_, idx) => ({
+  [COLUMN]: VALUES[idx],
+  [COLUMN_2]: idx === 0 ? null : VALUES[idx]
+}));
+
 describe('aggregation', () => {
   describe('aggregationFunctions', () => {
     const RESULTS = {
@@ -53,6 +58,61 @@ describe('aggregation', () => {
           test(operation, () => {
             const func = aggregationFunctions[operation];
             expect(func(features, [COLUMN, COLUMN_2], operation)).toEqual(result);
+          });
+        });
+      });
+
+      describe('when value is null', () => {
+        describe('by values', () => {
+          const RESULTS = {
+            [AggregationTypes.COUNT]: VALUES.length,
+            [AggregationTypes.AVG]: 3,
+            [AggregationTypes.MIN]: 1,
+            [AggregationTypes.MAX]: 5,
+            [AggregationTypes.SUM]: 12
+          };
+
+          Object.entries(RESULTS).forEach(([operation, result]) => {
+            test(operation, () => {
+              const func = aggregationFunctions[operation];
+              expect(func([1, 2, null, 4, 5])).toEqual(result);
+            });
+          });
+        });
+
+        describe('by features', () => {
+          const RESULTS = {
+            [AggregationTypes.COUNT]: VALUES.length,
+            [AggregationTypes.AVG]: 3.5,
+            [AggregationTypes.MIN]: 2,
+            [AggregationTypes.MAX]: 5,
+            [AggregationTypes.SUM]: 14
+          };
+
+          Object.entries(RESULTS).forEach(([operation, result]) => {
+            test(operation, () => {
+              const func = aggregationFunctions[operation];
+              expect(func(featuresIncludingNull, [COLUMN_2], operation)).toEqual(result);
+            });
+          });
+        });
+
+        describe('multiple keys', () => {
+          const RESULTS_FOR_MULTIPLE_KEYS = {
+            [AggregationTypes.COUNT]: VALUES.length,
+            [AggregationTypes.AVG]: 3,
+            [AggregationTypes.MIN]: 1,
+            [AggregationTypes.MAX]: 5,
+            [AggregationTypes.SUM]: 29
+          };
+
+          Object.entries(RESULTS_FOR_MULTIPLE_KEYS).forEach(([operation, result]) => {
+            test(operation, () => {
+              const func = aggregationFunctions[operation];
+              expect(func(featuresIncludingNull, [COLUMN, COLUMN_2], operation)).toEqual(
+                result
+              );
+            });
           });
         });
       });

--- a/packages/react-core/src/operations/aggregation.js
+++ b/packages/react-core/src/operations/aggregation.js
@@ -39,9 +39,9 @@ function filterFalsyElements(values, keys) {
 
   if (!keys?.length) {
     return values.filter(filterFn);
-  } else if (keys.length === 1) {
-    return values.filter((v) => filterFn(v[keys[0]]));
   }
+
+  return values.filter((v) => filterFn(v[keys[0]]));
 }
 
 // Aggregation functions

--- a/packages/react-core/src/operations/aggregation.js
+++ b/packages/react-core/src/operations/aggregation.js
@@ -1,11 +1,21 @@
 import { AggregationTypes } from './constants/AggregationTypes';
 
+const applyAggregationFunction = (aggFn, ...args) => {
+  const [values, keys, operation] = args;
+  const normalizedKeys = normalizeKeys(keys);
+  const elements =
+    (normalizedKeys?.length || 0) <= 1
+      ? filterFalsyElements(values, normalizedKeys)
+      : values;
+  return aggFn(elements, keys, operation);
+};
+
 export const aggregationFunctions = {
   [AggregationTypes.COUNT]: (values) => values.length,
-  [AggregationTypes.MIN]: min,
-  [AggregationTypes.MAX]: max,
-  [AggregationTypes.SUM]: sum,
-  [AggregationTypes.AVG]: avg
+  [AggregationTypes.MIN]: (...args) => applyAggregationFunction(min, ...args),
+  [AggregationTypes.MAX]: (...args) => applyAggregationFunction(max, ...args),
+  [AggregationTypes.SUM]: (...args) => applyAggregationFunction(sum, ...args),
+  [AggregationTypes.AVG]: (...args) => applyAggregationFunction(avg, ...args)
 };
 
 export function aggregate(feature, keys, operation) {
@@ -22,6 +32,16 @@ export function aggregate(feature, keys, operation) {
   }
 
   return aggregationFn(keys.map((column) => feature[column]));
+}
+
+function filterFalsyElements(values, keys) {
+  const filterFn = (value) => value !== null && value !== undefined;
+
+  if (!keys?.length) {
+    return values.filter(filterFn);
+  } else if (keys.length === 1) {
+    return values.filter((v) => filterFn(v[keys[0]]));
+  }
 }
 
 // Aggregation functions


### PR DESCRIPTION
# Description

Shortcut: [(link)](https://app.shortcut.com/cartoteam/story/220189/team-error-with-formula-widget-and-null-values)

Formula widget was displaying incorrect values because NULL values were considered as 0. Now we're ignoring this items instead.

**BEFORE**:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/7818205/161097288-b81ead48-55db-46a6-b9c6-144c2ecadb6c.png">


**NOW**:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/7818205/161096732-6e613e34-b332-478d-8da4-7e6c00a17426.png">


## Type of change

- Fix

