### PR TITLE
Fix regression for PieWidgetUI category selection logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bump deck.gl to 8.7.3 [#360](https://github.com/CartoDB/carto-react/pull/360)
 - Fix aggregation to ignore NULL values [#367](https://github.com/CartoDB/carto-react/pull/367)
+- Fix regression for PieWidgetUI category selection logic [#369](https://github.com/CartoDB/carto-react/pull/369)
 
 ## 1.3
 

--- a/packages/react-ui/src/widgets/PieWidgetUI.js
+++ b/packages/react-ui/src/widgets/PieWidgetUI.js
@@ -131,12 +131,12 @@ function PieWidgetUI({
           // Avoid modifying data item
           const clonedItem = { ...item };
 
+          const disabled =
+            selectedCategories?.length && !selectedCategories.includes(clonedItem.name);
+          
           if (labels?.[clonedItem.name]) {
             clonedItem.name = labels[clonedItem.name];
           }
-
-          const disabled =
-            selectedCategories?.length && !selectedCategories.includes(clonedItem.name);
 
           if (disabled) {
             disableSerie(clonedItem, theme);


### PR DESCRIPTION


# Description

This PR is meant to bring back a bug fix that was performed in PR #332 but overwritten in PR #341 (both from version 1.2.1-beta.8)
The bug fix consisted in fixing the category selection logic for the PieWidgetUI component to avoid using `labels` in the selected category comparison and use the categories from `data` instead

## Type of change

- Fix

# Acceptance

Please describe how to validate the feature or fix

Same as PR #332

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
