### PR TITLE
New alpha release 1.3.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## Not released
 
+## 1.3
+
+### 1.3.0-alpha.2 (2022-04-11)
+
+- Bump deck.gl to 8.7.5 [#373](https://github.com/CartoDB/carto-react/pull/373)
 - Bump deck.gl to 8.7.3 [#360](https://github.com/CartoDB/carto-react/pull/360)
 - Fix aggregation to ignore NULL values [#367](https://github.com/CartoDB/carto-react/pull/367)
 - Fix regression for PieWidgetUI category selection logic [#369](https://github.com/CartoDB/carto-react/pull/369)
 - Add support for formatted labels in LegendRamp [#372](https://github.com/CartoDB/carto-react/pull/372)
-- Bump deck.gl to 8.7.5 [#373](https://github.com/CartoDB/carto-react/pull/373)
-
-## 1.3
 
 ### 1.3.0-alpha.1 (2022-03-25)
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "1.3.0-alpha.1"
+  "version": "1.3.0-alpha.2"
 }

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-api",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0-alpha.2",
   "description": "CARTO for React - Api",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-auth",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0-alpha.2",
   "description": "CARTO for React - Auth",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-basemaps/package.json
+++ b/packages/react-basemaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-basemaps",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0-alpha.2",
   "description": "CARTO for React - Basemaps",
   "keywords": [
     "carto",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-core",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0-alpha.2",
   "description": "CARTO for React - Core",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-redux",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0-alpha.2",
   "description": "CARTO for React - Redux",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-ui",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0-alpha.2",
   "description": "CARTO for React - UI",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-widgets",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0-alpha.2",
   "description": "CARTO for React - Widgets",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-workers/package.json
+++ b/packages/react-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-workers",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0-alpha.2",
   "description": "CARTO for React - Workers",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.9",
-    "@carto/react-core": "^1.3.0-alpha.1",
+    "@carto/react-core": "^1.3.0-alpha.2",
     "@turf/bbox-polygon": "^6.3.0",
     "@turf/boolean-intersects": "^6.3.0",
     "@turf/boolean-within": "^6.3.0",


### PR DESCRIPTION
# Description

New alpha release, including a bump of deck.gl to 8.7.5

## Type of change

- Release

# Acceptance

Everything works as expected with deck.gl 8.7.5 in Builder / c4r-template

The aggregation with NULL values works as expected in Builder (PENDING link cloud-native PR)

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
