### PR TITLE
WrapperWidgetUI support externally controlled `expanded` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- WrapperWidgetUI support externally controlled `expanded` attribute [#376](https://github.com/CartoDB/carto-react/pull/
+
 ## 1.3
 
 ### 1.3.0-alpha.2 (2022-04-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- WrapperWidgetUI support externally controlled `expanded` attribute [#376](https://github.com/CartoDB/carto-react/pull/360)
+- WrapperWidgetUI support externally controlled `expanded` attribute [#375](https://github.com/CartoDB/carto-react/pull/375)
 
 ## 1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- WrapperWidgetUI support externally controlled `expanded` attribute [#376](https://github.com/CartoDB/carto-react/pull/
+- WrapperWidgetUI support externally controlled `expanded` attribute [#376](https://github.com/CartoDB/carto-react/pull/360)
 
 ## 1.3
 

--- a/packages/react-ui/__tests__/widgets/WrapperWidgetUI.test.js
+++ b/packages/react-ui/__tests__/widgets/WrapperWidgetUI.test.js
@@ -50,7 +50,7 @@ describe('WrapperWidgetUI', () => {
       });
     });
 
-    describe('extenally controlled', () => {
+    describe('externally controlled `expanded` state', () => {
       const onExpandedChange = jest.fn();
       test('should obey `expanded=false` with `onExpandedChange` set', () => {
         render(
@@ -66,7 +66,7 @@ describe('WrapperWidgetUI', () => {
         expect(onExpandedChange).not.toBeCalled();
       });
 
-      test('should close', async () => {
+      test('should attempt to close using `onExpandedChange`', async () => {
         render(
           <WrapperWidgetUI
             expanded={true}
@@ -81,7 +81,7 @@ describe('WrapperWidgetUI', () => {
         expect(onExpandedChange).toBeCalledWith(false);
       });
 
-      test('should open', async () => {
+      test('should attempt to open using `onExpandedChange', async () => {
         render(
           <WrapperWidgetUI
             expanded={false}

--- a/packages/react-ui/__tests__/widgets/WrapperWidgetUI.test.js
+++ b/packages/react-ui/__tests__/widgets/WrapperWidgetUI.test.js
@@ -50,6 +50,53 @@ describe('WrapperWidgetUI', () => {
       });
     });
 
+    describe('extenally controlled', () => {
+      const onExpandedChange = jest.fn();
+      test('should obey `expanded=false` with `onExpandedChange` set', () => {
+        render(
+          <WrapperWidgetUI
+            expanded={false}
+            title={TITLE}
+            onExpandedChange={onExpandedChange}
+          >
+            <div>CONTENT</div>
+          </WrapperWidgetUI>
+        );
+        expect(screen.queryByText('CONTENT')).not.toBeInTheDocument();
+        expect(onExpandedChange).not.toBeCalled();
+      });
+
+      test('should close', async () => {
+        render(
+          <WrapperWidgetUI
+            expanded={true}
+            title={TITLE}
+            onExpandedChange={onExpandedChange}
+          >
+            <div>CONTENT</div>
+          </WrapperWidgetUI>
+        );
+        expect(screen.getByText('CONTENT')).toBeInTheDocument();
+        fireEvent.click(screen.getByText(TITLE));
+        expect(onExpandedChange).toBeCalledWith(false);
+      });
+
+      test('should open', async () => {
+        render(
+          <WrapperWidgetUI
+            expanded={false}
+            title={TITLE}
+            onExpandedChange={onExpandedChange}
+          >
+            <div>CONTENT</div>
+          </WrapperWidgetUI>
+        );
+        expect(screen.queryByText('CONTENT')).not.toBeInTheDocument();
+        fireEvent.click(screen.getByText(TITLE));
+        expect(onExpandedChange).toBeCalledWith(true);
+      });
+    });
+
     describe('with options', () => {
       const NUMBER_OF_OPTIONS = 3;
       const OPTIONS = [...Array(NUMBER_OF_OPTIONS)].map((_, idx) => ({

--- a/packages/react-ui/src/types.d.ts
+++ b/packages/react-ui/src/types.d.ts
@@ -4,6 +4,8 @@ export type WrapperWidgetUI = {
   title: string;
   isLoading?: boolean;
   expandable?: boolean;
+  expanded?: boolean;
+  setExpanded?: (v: boolean) => void;
   actions?: { id: string; name: string; icon: React.ReactElement; action: Function }[];
   options?: { id: string; name: string; action: Function }[];
   children?: React.ReactNode;

--- a/packages/react-ui/src/types.d.ts
+++ b/packages/react-ui/src/types.d.ts
@@ -5,7 +5,7 @@ export type WrapperWidgetUI = {
   isLoading?: boolean;
   expandable?: boolean;
   expanded?: boolean;
-  setExpanded?: (v: boolean) => void;
+  onExpandedChange?: (v: boolean) => void;
   actions?: { id: string; name: string; icon: React.ReactElement; action: Function }[];
   options?: { id: string; name: string; action: Function }[];
   children?: React.ReactNode;

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.js
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.js
@@ -116,7 +116,7 @@ function WrapperWidgetUI(props) {
     typeof props.expanded === 'boolean' && typeof props.onExpandedChange === 'function';
   const expanded =
     props.expandable !== false ? (externalExpanded ? props.expanded : expandedInt) : true;
-  const setExpanded = externalExpanded ? setExpandedInt : props.onExpandedChange;
+  const setExpanded = externalExpanded ? props.onExpandedChange : setExpandedInt;
 
   const [anchorEl, setAnchorEl] = useState(null);
   const classes = useStyles({ ...props, expanded });

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.js
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.js
@@ -110,7 +110,9 @@ const useStyles = makeStyles((theme) => ({
 
 function WrapperWidgetUI(props) {
   const wrapper = createRef();
-  const [expanded, setExpanded] = useState(true);
+  const [expandedInt, setExpandedInt] = useState(true);
+  const expanded = props.expandable !== false ? props.expanded ?? expandedInt : true;
+  const setExpanded = props.setExpanded ?? setExpandedInt;
   const [anchorEl, setAnchorEl] = useState(null);
   const classes = useStyles({ ...props, expanded });
   const open = Boolean(anchorEl);

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.js
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.js
@@ -112,7 +112,7 @@ function WrapperWidgetUI(props) {
   const wrapper = createRef();
   const [expandedInt, setExpandedInt] = useState(true);
   const expanded = props.expandable !== false ? props.expanded ?? expandedInt : true;
-  const setExpanded = props.setExpanded ?? setExpandedInt;
+  const setExpanded = props.onExpendedChange ?? setExpandedInt;
   const [anchorEl, setAnchorEl] = useState(null);
   const classes = useStyles({ ...props, expanded });
   const open = Boolean(anchorEl);

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.js
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.js
@@ -110,9 +110,14 @@ const useStyles = makeStyles((theme) => ({
 
 function WrapperWidgetUI(props) {
   const wrapper = createRef();
+
   const [expandedInt, setExpandedInt] = useState(true);
-  const expanded = props.expandable !== false ? props.expanded ?? expandedInt : true;
-  const setExpanded = props.onExpendedChange ?? setExpandedInt;
+  const externalExpanded =
+    typeof props.expanded === 'boolean' && typeof props.onExpandedChange === 'function';
+  const expanded =
+    props.expandable !== false ? (externalExpanded ? props.expanded : expandedInt) : true;
+  const setExpanded = externalExpanded ? setExpandedInt : props.onExpandedChange;
+
   const [anchorEl, setAnchorEl] = useState(null);
   const classes = useStyles({ ...props, expanded });
   const open = Boolean(anchorEl);
@@ -246,6 +251,7 @@ function WrapperWidgetUI(props) {
 }
 
 WrapperWidgetUI.defaultProps = {
+  expanded: true,
   expandable: true,
   isLoading: false
 };
@@ -253,6 +259,8 @@ WrapperWidgetUI.defaultProps = {
 WrapperWidgetUI.propTypes = {
   title: PropTypes.string.isRequired,
   expandable: PropTypes.bool,
+  expanded: PropTypes.bool,
+  onExpandedChange: PropTypes.func,
   isLoading: PropTypes.bool,
   actions: PropTypes.arrayOf(
     PropTypes.shape({

--- a/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
@@ -47,6 +47,10 @@ export const Expandable = Template.bind({});
 const ExpandableProps = { title: 'Expandable', expandable: true };
 Expandable.args = ExpandableProps;
 
+export const NotExpanded = Template.bind({});
+const NotExpandedProps = { title: 'Not expanded/collapsed', expanded: false };
+NotExpanded.args = NotExpandedProps;
+
 export const NotExpandable = Template.bind({});
 const NotExpandableProps = { title: 'Not Expandable', expandable: false };
 NotExpandable.args = NotExpandableProps;


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/212117/collapsed-state-of-widgets-is-not-saved

WrapperWidgetUI support externally controlled `expanded` attribute, so builder can control it and save in `Widget` state.

If this PR requires a companion in carto-react-template, please also link them both.

## Type of change

- Feature

# Acceptance

Unit-tests added
Demo in https://github.com/CartoDB/cloud-native/pull/5736

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
