### PR TITLE
Prelease 1.3.0-alpha.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Not released
 
-- WrapperWidgetUI support externally controlled `expanded` attribute [#375](https://github.com/CartoDB/carto-react/pull/375)
-
 ## 1.3
+
+### 1.3.0-alpha.3 (2022-04-12)
+
+- WrapperWidgetUI support externally controlled `expanded` attribute [#375](https://github.com/CartoDB/carto-react/pull/375)
 
 ### 1.3.0-alpha.2 (2022-04-11)
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "1.3.0-alpha.2"
+  "version": "1.3.0-alpha.3"
 }

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-api",
-  "version": "1.3.0-alpha.2",
+  "version": "1.3.0-alpha.3",
   "description": "CARTO for React - Api",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -64,9 +64,9 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^1.3.0-alpha.1",
-    "@carto/react-redux": "^1.3.0-alpha.1",
-    "@carto/react-workers": "^1.3.0-alpha.1",
+    "@carto/react-core": "^1.3.0-alpha.2",
+    "@carto/react-redux": "^1.3.0-alpha.2",
+    "@carto/react-workers": "^1.3.0-alpha.2",
     "@deck.gl/carto": "^8.7.5",
     "@deck.gl/core": "^8.7.5",
     "@deck.gl/extensions": "^8.7.5",

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-auth",
-  "version": "1.3.0-alpha.2",
+  "version": "1.3.0-alpha.3",
   "description": "CARTO for React - Auth",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -64,7 +64,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^1.3.0-alpha.1",
+    "@carto/react-core": "^1.3.0-alpha.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   }

--- a/packages/react-basemaps/package.json
+++ b/packages/react-basemaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-basemaps",
-  "version": "1.3.0-alpha.2",
+  "version": "1.3.0-alpha.3",
   "description": "CARTO for React - Basemaps",
   "keywords": [
     "carto",

--- a/packages/react-basemaps/package.json
+++ b/packages/react-basemaps/package.json
@@ -64,7 +64,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^1.3.0-alpha.1",
+    "@carto/react-core": "^1.3.0-alpha.2",
     "@deck.gl/google-maps": "^8.7.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-core",
-  "version": "1.3.0-alpha.2",
+  "version": "1.3.0-alpha.3",
   "description": "CARTO for React - Core",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-redux",
-  "version": "1.3.0-alpha.2",
+  "version": "1.3.0-alpha.3",
   "description": "CARTO for React - Redux",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -63,8 +63,8 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^1.3.0-alpha.1",
-    "@carto/react-workers": "^1.3.0-alpha.1",
+    "@carto/react-core": "^1.3.0-alpha.2",
+    "@carto/react-workers": "^1.3.0-alpha.2",
     "@deck.gl/carto": "^8.7.5",
     "@deck.gl/core": "^8.7.5",
     "@reduxjs/toolkit": "^1.5.0"

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -75,7 +75,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^1.3.0-alpha.1",
+    "@carto/react-core": "^1.3.0-alpha.2",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-ui",
-  "version": "1.3.0-alpha.2",
+  "version": "1.3.0-alpha.3",
   "description": "CARTO for React - UI",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-widgets",
-  "version": "1.3.0-alpha.2",
+  "version": "1.3.0-alpha.3",
   "description": "CARTO for React - Widgets",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -65,11 +65,11 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-api": "^1.3.0-alpha.1",
-    "@carto/react-core": "^1.3.0-alpha.1",
-    "@carto/react-redux": "^1.3.0-alpha.1",
-    "@carto/react-ui": "^1.3.0-alpha.1",
-    "@carto/react-workers": "^1.3.0-alpha.1",
+    "@carto/react-api": "^1.3.0-alpha.2",
+    "@carto/react-core": "^1.3.0-alpha.2",
+    "@carto/react-redux": "^1.3.0-alpha.2",
+    "@carto/react-ui": "^1.3.0-alpha.2",
+    "@carto/react-workers": "^1.3.0-alpha.2",
     "@deck.gl/core": "^8.7.5",
     "@deck.gl/layers": "^8.7.5",
     "@material-ui/core": "^4.11.3",

--- a/packages/react-workers/package.json
+++ b/packages/react-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-workers",
-  "version": "1.3.0-alpha.2",
+  "version": "1.3.0-alpha.3",
   "description": "CARTO for React - Workers",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.9",
-    "@carto/react-core": "^1.3.0-alpha.2",
+    "@carto/react-core": "^1.3.0-alpha.3",
     "@turf/bbox-polygon": "^6.3.0",
     "@turf/boolean-intersects": "^6.3.0",
     "@turf/boolean-within": "^6.3.0",


### PR DESCRIPTION
- WrapperWidgetUI support externally controlled `expanded` attribute [#375](https://github.com/CartoDB/carto-react/pull/375)