### PR TITLE
Add callback prop to TableWidget to know when page size changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Add callback prop to TableWidget to know when page size changed [#380](https://github.com/CartoDB/carto-react/pull/380)
 - Normalize SQL API response due to providers inconsistency [#382](https://github.com/CartoDB/carto-react/pull/382)
 - Implement CLOSED_OPEN and TIME filters for SQL to allow proper filtering [#381](https://github.com/CartoDB/carto-react/pull/381)
 

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -17,6 +17,7 @@ import { selectAreFeaturesReadyForSource } from '@carto/react-redux/';
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  * @param  {Object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]()
  * @param  {number} [props.initialPageSize] - Initial number of rows per page
+ * @param  {Function} [props.onPageSizeChange] - Function called when the page size is changed internally
  * @param  {string} [props.height] - Static widget height, required for scrollable table content
  * @param  {boolean} [props.dense] - Whether the table should use a compact layout with smaller cell paddings
  */
@@ -29,6 +30,7 @@ function TableWidget({
   noDataAlertProps,
   onError,
   initialPageSize = 10,
+  onPageSizeChange,
   height,
   dense
 }) {
@@ -50,6 +52,12 @@ function TableWidget({
     // force reset the page to 0 when the viewport or filters change
     setPage(0);
   }, [dataSource, isSourceReady, filters]);
+
+  useEffect(() => {
+    if (typeof onPageSizeChange === 'function') {
+      onPageSizeChange(rowsPerPage);
+    }
+  }, [onPageSizeChange, rowsPerPage]);
 
   useEffect(() => {
     if (isSourceReady) {
@@ -131,6 +139,7 @@ TableWidget.propTypes = {
   wrapperProps: PropTypes.object,
   noDataAlertProps: PropTypes.object,
   initialPageSize: PropTypes.number,
+  onPageSizeChange: PropTypes.func,
   height: PropTypes.string,
   dense: PropTypes.bool
 };

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -54,7 +54,7 @@ function TableWidget({
   }, [dataSource, isSourceReady, filters]);
 
   useEffect(() => {
-    if (typeof onPageSizeChange === 'function') {
+    if (onPageSizeChange) {
       onPageSizeChange(rowsPerPage);
     }
   }, [onPageSizeChange, rowsPerPage]);


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/219830/tablewidget-viewport-features-count-table-height

Add a function prop to TableWidget to be called with the new page size when it has been changed in the widget.

![Capture d’écran de 2022-04-21 15-07-29](https://user-images.githubusercontent.com/243653/164464623-927f3a77-65bf-470d-9c29-fe9eabd341e1.png)


## Type of change

- Feature
