### PR TITLE
Fix histogram bar selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix histogram bar selection [#384](https://github.com/CartoDB/carto-react/pull/384)
+
 ## 1.3
 
 ### 1.3.0-alpha.5 (2022-04-25)

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -101,8 +101,8 @@ function HistogramWidget(props) {
     ({ bars }) => {
       if (bars && bars.length) {
         const thresholds = bars.map((i) => {
-          let left = ticks[i - 1];
-          let right = ticks.length !== i + 1 ? ticks[i] : undefined;
+          let left = i ? ticks[i - 1] : undefined;
+          let right = ticks.length === i ? undefined : ticks[i];
 
           return [left, right];
         });

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -101,8 +101,8 @@ function HistogramWidget(props) {
     ({ bars }) => {
       if (bars && bars.length) {
         const thresholds = bars.map((i) => {
-          let left = i ? ticks[i - 1] : undefined;
-          let right = ticks.length === i ? undefined : ticks[i];
+          let left = ticks[i - 1];
+          let right = ticks.length !== i ? ticks[i] : undefined;
 
           return [left, right];
         });


### PR DESCRIPTION
To fix https://app.shortcut.com/cartoteam/story/221511/ac_7xhfwyml-histogram-widget-on-click-second-to-last-column-selects-last-column