### PR TITLE
Show warning when dropping features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not released
 
 - GeocoderWidget support for LDS queries in CARTO 3 [#387](https://github.com/CartoDB/carto-react/pull/387)
+- Display warning when tilesets are dropping features [#385](https://github.com/CartoDB/carto-react/pull/385)
 
 ## 1.3
 
@@ -15,7 +16,6 @@
 - Add callback prop to TableWidget to know when page size changed [#380](https://github.com/CartoDB/carto-react/pull/380)
 - Normalize SQL API response due to providers inconsistency [#382](https://github.com/CartoDB/carto-react/pull/382)
 - Implement CLOSED_OPEN and TIME filters for SQL to allow proper filtering [#381](https://github.com/CartoDB/carto-react/pull/381)
-- Display warning when tilesets are dropping features [#385](https://github.com/CartoDB/carto-react/pull/385)
 
 ### 1.3.0-alpha.4 (2022-04-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add callback prop to TableWidget to know when page size changed [#380](https://github.com/CartoDB/carto-react/pull/380)
 - Normalize SQL API response due to providers inconsistency [#382](https://github.com/CartoDB/carto-react/pull/382)
 - Implement CLOSED_OPEN and TIME filters for SQL to allow proper filtering [#381](https://github.com/CartoDB/carto-react/pull/381)
+- Display warning when tilesets are dropping features [#385](https://github.com/CartoDB/carto-react/pull/385)
 
 ## 1.3
 

--- a/packages/react-api/src/hooks/useTileFeatures.js
+++ b/packages/react-api/src/hooks/useTileFeatures.js
@@ -132,7 +132,8 @@ export default function useTileFeatures({
   return [onDataLoad, onViewportLoad, fetch];
 }
 
-// TODO: Comentario => https://github.com/visgl/loaders.gl/pull/2128
+// WORKAROUND: To read headers and know if the tile is dropping features. 
+// Remove when the new loader is ready => https://github.com/visgl/loaders.gl/pull/2128
 const customFetch = async (url, {layer, loaders, loadOptions, signal}) => {
   loadOptions = loadOptions || layer.getLoadOptions();
   loaders = loaders || layer.props.loaders;

--- a/packages/react-api/src/hooks/useTileFeatures.js
+++ b/packages/react-api/src/hooks/useTileFeatures.js
@@ -111,9 +111,9 @@ export default function useTileFeatures({
 
       debounceIdRef.current = debouncedLoadTiles(tiles);
       const isDroppingFeatures = tiles?.some(tile => tile.content?.isDroppingFeatures)
-      dispatch(setIsDroppingFeatures({ id: source.id, isDroppingFeatures }))
+      dispatch(setIsDroppingFeatures({ id: sourceId, isDroppingFeatures }))
     },
-    [source, stopAnyCompute, setSourceFeaturesReady, debouncedLoadTiles, debounceIdRef, dispatch]
+    [sourceId, stopAnyCompute, setSourceFeaturesReady, debouncedLoadTiles, debounceIdRef, dispatch]
   );
 
   const fetch = useCallback(

--- a/packages/react-api/src/hooks/useTileFeatures.js
+++ b/packages/react-api/src/hooks/useTileFeatures.js
@@ -64,11 +64,14 @@ export default function useTileFeatures({
         return acc;
       }, []);
 
+      const isDroppingFeatures = tiles?.some(tile => tile.content?.isDroppingFeatures)
+      dispatch(setIsDroppingFeatures({ id: sourceId, isDroppingFeatures }))
+
       executeTask(sourceId, Methods.LOAD_TILES, { tiles: cleanedTiles })
         .then(() => setTilesetLoaded(true))
         .catch(throwError);
     },
-    [sourceId, setTilesetLoaded]
+    [sourceId, setTilesetLoaded, dispatch]
   );
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -110,10 +113,8 @@ export default function useTileFeatures({
       setSourceFeaturesReady(false);
 
       debounceIdRef.current = debouncedLoadTiles(tiles);
-      const isDroppingFeatures = tiles?.some(tile => tile.content?.isDroppingFeatures)
-      dispatch(setIsDroppingFeatures({ id: sourceId, isDroppingFeatures }))
     },
-    [sourceId, stopAnyCompute, setSourceFeaturesReady, debouncedLoadTiles, debounceIdRef, dispatch]
+    [stopAnyCompute, setSourceFeaturesReady, debouncedLoadTiles, debounceIdRef]
   );
 
   const fetch = useCallback(

--- a/packages/react-redux/src/slices/cartoSlice.d.ts
+++ b/packages/react-redux/src/slices/cartoSlice.d.ts
@@ -9,6 +9,7 @@ type Source = SourceProps & {
   id: string
   filters?: any
   filtersLogicalOperator?: FiltersLogicalOperators
+  isDroppingFeatures?: boolean
 };
 
 type Layer = {

--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -60,6 +60,11 @@ export const createCartoSlice = (initialState) => {
         action.payload.credentials = action.payload.credentials || state.credentials;
         state.dataSources[action.payload.id] = action.payload;
       },
+      setIsDroppingFeatures: (state, action) => {
+        const source = state.dataSources[action.payload.id];
+        source.isDroppingFeatures = action.payload.isDroppingFeatures;
+        state.dataSources[action.payload.id] = source;
+      },
       removeSource: (state, action) => {
         delete state.dataSources[action.payload];
         removeWorker(action.payload);
@@ -201,6 +206,13 @@ export const addSource = ({
   type: 'carto/addSource',
   payload: { id, data, type, credentials, connection, filtersLogicalOperator }
 });
+
+/**
+ * Action to set the `isDroppingFeature` flag
+ * @param {string} id - unique id for the source
+ * @param {boolean} isDroppingFeatures - flag that indicate if tiles are generated using a dropping feature strategy
+ */
+export const setIsDroppingFeatures = ({id, isDroppingFeatures}) => ({ type: 'carto/setIsDroppingFeatures', payload: { id, isDroppingFeatures }})
 
 /**
  * Action to remove a source from the store

--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -311,6 +311,7 @@ const _setViewPort = (payload) => ({ type: 'carto/setViewPort', payload });
  * Redux selector to get a source by ID
  */
 export const selectSourceById = (state, id) => state.carto.dataSources[id];
+export const checkIfSourceIsDroppingFeature = (state, id) => state.carto.dataSources[id]?.isDroppingFeatures;
 
 /**
  * Redux selector to select the spatial filter of a given sourceId or the root one

--- a/packages/react-ui/src/widgets/NoDataAlert.js
+++ b/packages/react-ui/src/widgets/NoDataAlert.js
@@ -18,17 +18,16 @@ function NoDataAlert({
 }) {
 
   return severity ? (
-      <Alert severity={severity}>
-        {title && <AlertTitle>{title}</AlertTitle>}
-        <AlertBody>{body}</AlertBody>
-      </Alert>
-    ) : (
-      <Box>
-        {title && <Typography variant="body2">{title}</Typography>}
-        <AlertBody color="textSecondary">{body}</AlertBody>
-      </Box>
-    )
-  );
+    <Alert severity={severity}>
+      {title && <AlertTitle>{title}</AlertTitle>}
+      <AlertBody>{body}</AlertBody>
+    </Alert>
+  ) : (
+    <Box>
+      {title && <Typography variant="body2">{title}</Typography>}
+      <AlertBody color="textSecondary">{body}</AlertBody>
+    </Box>
+  )
 }
 
 export default NoDataAlert;

--- a/packages/react-ui/src/widgets/NoDataAlert.js
+++ b/packages/react-ui/src/widgets/NoDataAlert.js
@@ -1,16 +1,33 @@
 import React from 'react';
 import { Alert, AlertTitle } from '@material-ui/lab';
-import { Box } from '@material-ui/core';
+import { Box, Typography } from '@material-ui/core';
+
+function AlertBody ({ color = undefined, children }) {
+  return children ? (
+  <Box mt={0.5}>
+    <Typography variant="caption" color={color || 'inherit'} style={{ fontWeight: 'normal' }}>{children}</Typography>
+  </Box>
+) : (
+  <Box mt={-1} />
+)}
 
 function NoDataAlert({
   title = 'No data available',
-  body = 'There are no results for the combination of filters applied to your data. Try tweaking your filters, or zoom and pan the map to adjust the Map View.'
+  body = 'There are no results for the combination of filters applied to your data. Try tweaking your filters, or zoom and pan the map to adjust the Map View.',
+  severity = undefined
 }) {
-  return (
-    <Alert severity='warning'>
-      {title && <AlertTitle>{title}</AlertTitle>}
-      {body || <Box mt={-1} />}
-    </Alert>
+
+  return severity ? (
+      <Alert severity={severity}>
+        {title && <AlertTitle>{title}</AlertTitle>}
+        <AlertBody>{body}</AlertBody>
+      </Alert>
+    ) : (
+      <Box>
+        {title && <Typography variant="body2">{title}</Typography>}
+        <AlertBody color="textSecondary">{body}</AlertBody>
+      </Box>
+    )
   );
 }
 

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -109,7 +109,7 @@ function CategoryWidget(props) {
           searchable={searchable}
         />
       ) : (
-       <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { severity: 'warning', body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
+       <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
 
       )}
     </WrapperWidgetUI>

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -8,6 +8,7 @@ import { getCategories } from '../models';
 import { useWidgetFilterValues } from '../hooks/useWidgetFilterValues';
 import { columnAggregationOn } from './utils/propTypesFns';
 import useWidgetFetch from '../hooks/useWidgetFetch';
+import { defaultDroppingFeaturesAlertProps } from './utils/defaultDroppingFeaturesAlertProps';
 
 const EMPTY_ARRAY = [];
 
@@ -30,6 +31,7 @@ const EMPTY_ARRAY = [];
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  * @param  {Object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]()
+ * @param  {Object} [props.droppingFeaturesAlertProps] - Extra props to pass to [NoDataAlert]() when dropping feature
  */
 function CategoryWidget(props) {
   const {
@@ -48,7 +50,8 @@ function CategoryWidget(props) {
     global,
     onError,
     wrapperProps,
-    noDataAlertProps
+    noDataAlertProps,
+    droppingFeaturesAlertProps = defaultDroppingFeaturesAlertProps
   } = props;
   const dispatch = useDispatch();
 
@@ -108,8 +111,7 @@ function CategoryWidget(props) {
           searchable={searchable}
         />
       ) : (
-       <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
-
+       <NoDataAlert {...(isDroppingFeatures ? droppingFeaturesAlertProps : noDataAlertProps)}/>
       )}
     </WrapperWidgetUI>
   );

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { addFilter, removeFilter, selectSourceById } from '@carto/react-redux';
+import { addFilter, removeFilter, checkIfSourceIsDroppingFeature } from '@carto/react-redux';
 import { WrapperWidgetUI, CategoryWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { _FilterTypes as FilterTypes, AggregationTypes } from '@carto/react-core';
 import { getCategories } from '../models';
@@ -52,8 +52,7 @@ function CategoryWidget(props) {
   } = props;
   const dispatch = useDispatch();
 
-  const source = useSelector((state) => selectSourceById(state, dataSource))
-  const isDroppingFeatures = source?.isDroppingFeatures
+  const isDroppingFeatures = useSelector((state) => checkIfSourceIsDroppingFeature(state, dataSource))
   const selectedCategories =
     useWidgetFilterValues({ dataSource, id, column, type: FilterTypes.IN }) ||
     EMPTY_ARRAY;

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -136,7 +136,8 @@ CategoryWidget.propTypes = {
   global: PropTypes.bool,
   onError: PropTypes.func,
   wrapperProps: PropTypes.object,
-  noDataAlertProps: PropTypes.object
+  noDataAlertProps: PropTypes.object,
+  droppingFeaturesAlertProps: PropTypes.object
 };
 
 CategoryWidget.defaultProps = {

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { addFilter, removeFilter } from '@carto/react-redux';
+import { addFilter, removeFilter, selectSourceById } from '@carto/react-redux';
 import { WrapperWidgetUI, CategoryWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { _FilterTypes as FilterTypes, AggregationTypes } from '@carto/react-core';
 import { getCategories } from '../models';
@@ -52,6 +52,8 @@ function CategoryWidget(props) {
   } = props;
   const dispatch = useDispatch();
 
+  const source = useSelector((state) => selectSourceById(state, dataSource))
+  const isDroppingFeatures = source?.isDroppingFeatures
   const selectedCategories =
     useWidgetFilterValues({ dataSource, id, column, type: FilterTypes.IN }) ||
     EMPTY_ARRAY;
@@ -95,7 +97,7 @@ function CategoryWidget(props) {
 
   return (
     <WrapperWidgetUI title={title} isLoading={isLoading} {...wrapperProps}>
-      {data.length || isLoading ? (
+      {(data.length && !isDroppingFeatures) || isLoading ? (
         <CategoryWidgetUI
           data={data}
           formatter={formatter}
@@ -107,7 +109,8 @@ function CategoryWidget(props) {
           searchable={searchable}
         />
       ) : (
-        <NoDataAlert {...noDataAlertProps} />
+       <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { severity: 'warning', body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
+
       )}
     </WrapperWidgetUI>
   );

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -6,7 +6,7 @@ import { AggregationTypes } from '@carto/react-core';
 import { columnAggregationOn } from './utils/propTypesFns';
 import useWidgetFetch from '../hooks/useWidgetFetch';
 import { useSelector } from 'react-redux';
-import { selectSourceById } from '@carto/react-redux/';
+import { checkIfSourceIsDroppingFeature } from '@carto/react-redux/';
 import { NoDataAlert } from '@carto/react-ui/';
 
 /**
@@ -37,8 +37,7 @@ function FormulaWidget({
   onError,
   wrapperProps
 }) {
-  const source = useSelector((state) => selectSourceById(state, dataSource))
-  const isDroppingFeatures = source?.isDroppingFeatures
+  const isDroppingFeatures = useSelector((state) => checkIfSourceIsDroppingFeature(state, dataSource))
   const { data, isLoading } = useWidgetFetch(getFormula, {
     id,
     dataSource,

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -54,7 +54,7 @@ function FormulaWidget({
   return (
     <WrapperWidgetUI title={title} isLoading={isLoading} {...wrapperProps}>
       {isDroppingFeatures ? (
-        <NoDataAlert severity="warning" body="Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map." />
+        <NoDataAlert body="Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map." />
       ) : (
         <FormulaWidgetUI
           data={data}

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -5,6 +5,9 @@ import { getFormula } from '../models';
 import { AggregationTypes } from '@carto/react-core';
 import { columnAggregationOn } from './utils/propTypesFns';
 import useWidgetFetch from '../hooks/useWidgetFetch';
+import { useSelector } from 'react-redux';
+import { selectSourceById } from '@carto/react-redux/';
+import { NoDataAlert } from '@carto/react-ui/';
 
 /**
  * Renders a <FormulaWidget /> component
@@ -34,6 +37,8 @@ function FormulaWidget({
   onError,
   wrapperProps
 }) {
+  const source = useSelector((state) => selectSourceById(state, dataSource))
+  const isDroppingFeatures = source?.isDroppingFeatures
   const { data, isLoading } = useWidgetFetch(getFormula, {
     id,
     dataSource,
@@ -48,12 +53,16 @@ function FormulaWidget({
 
   return (
     <WrapperWidgetUI title={title} isLoading={isLoading} {...wrapperProps}>
-      <FormulaWidgetUI
-        data={data}
-        formatter={formatter}
-        unitBefore={true}
-        animation={animation}
-      />
+      {isDroppingFeatures ? (
+        <NoDataAlert severity="warning" body="Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map." />
+      ) : (
+        <FormulaWidgetUI
+          data={data}
+          formatter={formatter}
+          unitBefore={true}
+          animation={animation}
+        />
+      )}
     </WrapperWidgetUI>
   );
 }

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -8,6 +8,7 @@ import useWidgetFetch from '../hooks/useWidgetFetch';
 import { useSelector } from 'react-redux';
 import { checkIfSourceIsDroppingFeature } from '@carto/react-redux/';
 import { NoDataAlert } from '@carto/react-ui/';
+import { defaultDroppingFeaturesAlertProps } from './utils/defaultDroppingFeaturesAlertProps';
 
 /**
  * Renders a <FormulaWidget /> component
@@ -23,6 +24,7 @@ import { NoDataAlert } from '@carto/react-ui/';
  * @param  {boolean} [props.global] - Enable/disable the viewport filtering in the data fetching.
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
+ * @param  {Object} [props.droppingFeaturesAlertProps] - Extra props to pass to [NoDataAlert]() when dropping feature
  */
 function FormulaWidget({
   id,
@@ -35,7 +37,8 @@ function FormulaWidget({
   animation,
   global,
   onError,
-  wrapperProps
+  wrapperProps,
+  droppingFeaturesAlertProps = defaultDroppingFeaturesAlertProps
 }) {
   const isDroppingFeatures = useSelector((state) => checkIfSourceIsDroppingFeature(state, dataSource))
   const { data, isLoading } = useWidgetFetch(getFormula, {
@@ -53,7 +56,7 @@ function FormulaWidget({
   return (
     <WrapperWidgetUI title={title} isLoading={isLoading} {...wrapperProps}>
       {isDroppingFeatures ? (
-        <NoDataAlert body="Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map." />
+        <NoDataAlert {...droppingFeaturesAlertProps} />
       ) : (
         <FormulaWidgetUI
           data={data}

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -81,7 +81,8 @@ FormulaWidget.propTypes = {
   animation: PropTypes.bool,
   global: PropTypes.bool,
   onError: PropTypes.func,
-  wrapperProps: PropTypes.object
+  wrapperProps: PropTypes.object,
+  droppingFeaturesAlertProps: PropTypes.object
 };
 
 FormulaWidget.defaultProps = {

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -178,7 +178,8 @@ HistogramWidget.propTypes = {
   ticks: PropTypes.array.isRequired,
   onError: PropTypes.func,
   wrapperProps: PropTypes.object,
-  noDataAlertProps: PropTypes.object
+  noDataAlertProps: PropTypes.object,
+  droppingFeaturesAlertProps: PropTypes.object
 };
 
 HistogramWidget.defaultProps = {

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { PropTypes } from 'prop-types';
-import { addFilter, removeFilter } from '@carto/react-redux';
+import { addFilter, removeFilter, selectSourceById } from '@carto/react-redux';
 import { WrapperWidgetUI, HistogramWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { _FilterTypes as FilterTypes, AggregationTypes } from '@carto/react-core';
 import { getHistogram } from '../models';
@@ -49,6 +49,8 @@ function HistogramWidget(props) {
     noDataAlertProps
   } = props;
   const dispatch = useDispatch();
+  const source = useSelector((state) => selectSourceById(state, dataSource))
+  const isDroppingFeatures = source?.isDroppingFeatures
 
   const { data = [], isLoading } = useWidgetFetch(getHistogram, {
     id,
@@ -139,7 +141,7 @@ function HistogramWidget(props) {
 
   return (
     <WrapperWidgetUI title={title} {...wrapperProps} isLoading={isLoading}>
-      {data.length || isLoading ? (
+      {(data.length && !isDroppingFeatures) || isLoading ? (
         <HistogramWidgetUI
           data={data}
           dataAxis={dataAxis || ticksForDataAxis}
@@ -153,7 +155,7 @@ function HistogramWidget(props) {
           filterable={filterable}
         />
       ) : (
-        <NoDataAlert {...noDataAlertProps} />
+        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { severity: 'warning', body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
       )}
     </WrapperWidgetUI>
   );

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -155,7 +155,7 @@ function HistogramWidget(props) {
           filterable={filterable}
         />
       ) : (
-        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { severity: 'warning', body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
+        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
       )}
     </WrapperWidgetUI>
   );

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { PropTypes } from 'prop-types';
-import { addFilter, removeFilter, selectSourceById } from '@carto/react-redux';
+import { addFilter, removeFilter, checkIfSourceIsDroppingFeature } from '@carto/react-redux';
 import { WrapperWidgetUI, HistogramWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { _FilterTypes as FilterTypes, AggregationTypes } from '@carto/react-core';
 import { getHistogram } from '../models';
@@ -49,8 +49,7 @@ function HistogramWidget(props) {
     noDataAlertProps
   } = props;
   const dispatch = useDispatch();
-  const source = useSelector((state) => selectSourceById(state, dataSource))
-  const isDroppingFeatures = source?.isDroppingFeatures
+  const isDroppingFeatures = useSelector((state) => checkIfSourceIsDroppingFeature(state, dataSource))
 
   const { data = [], isLoading } = useWidgetFetch(getHistogram, {
     id,

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -7,6 +7,7 @@ import { _FilterTypes as FilterTypes, AggregationTypes } from '@carto/react-core
 import { getHistogram } from '../models';
 import { useWidgetFilterValues } from '../hooks/useWidgetFilterValues';
 import useWidgetFetch from '../hooks/useWidgetFetch';
+import { defaultDroppingFeaturesAlertProps } from './utils/defaultDroppingFeaturesAlertProps';
 
 const EMPTY_ARRAY = [];
 
@@ -28,6 +29,7 @@ const EMPTY_ARRAY = [];
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  * @param  {Object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]()
+ * @param  {Object} [props.droppingFeaturesAlertProps] - Extra props to pass to [NoDataAlert]() when dropping feature
  */
 function HistogramWidget(props) {
   const {
@@ -46,7 +48,8 @@ function HistogramWidget(props) {
     global,
     onError,
     wrapperProps,
-    noDataAlertProps
+    noDataAlertProps,
+    droppingFeaturesAlertProps = defaultDroppingFeaturesAlertProps
   } = props;
   const dispatch = useDispatch();
   const isDroppingFeatures = useSelector((state) => checkIfSourceIsDroppingFeature(state, dataSource))
@@ -154,7 +157,7 @@ function HistogramWidget(props) {
           filterable={filterable}
         />
       ) : (
-        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
+        <NoDataAlert {...(isDroppingFeatures ? droppingFeaturesAlertProps : noDataAlertProps)} />
       )}
     </WrapperWidgetUI>
   );

--- a/packages/react-widgets/src/widgets/PieWidget.js
+++ b/packages/react-widgets/src/widgets/PieWidget.js
@@ -8,6 +8,7 @@ import { getCategories } from '../models';
 import { useWidgetFilterValues } from '../hooks/useWidgetFilterValues';
 import { columnAggregationOn } from './utils/propTypesFns';
 import useWidgetFetch from '../hooks/useWidgetFetch';
+import { defaultDroppingFeaturesAlertProps } from './utils/defaultDroppingFeaturesAlertProps';
 
 const EMPTY_ARRAY = [];
 
@@ -31,6 +32,7 @@ const EMPTY_ARRAY = [];
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  * @param  {Object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]()
+ * @param  {Object} [props.droppingFeaturesAlertProps] - Extra props to pass to [NoDataAlert]() when dropping feature
  */
 function PieWidget({
   id,
@@ -50,7 +52,8 @@ function PieWidget({
   colors,
   onError,
   wrapperProps,
-  noDataAlertProps
+  noDataAlertProps,
+  droppingFeaturesAlertProps = defaultDroppingFeaturesAlertProps
 }) {
   const dispatch = useDispatch();
   const isDroppingFeatures = useSelector((state) => checkIfSourceIsDroppingFeature(state, dataSource))
@@ -112,7 +115,7 @@ function PieWidget({
           onSelectedCategoriesChange={handleSelectedCategoriesChange}
         />
       ) : (
-        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
+        <NoDataAlert {...(isDroppingFeatures ? droppingFeaturesAlertProps : noDataAlertProps)}/>
       )}
     </WrapperWidgetUI>
   );

--- a/packages/react-widgets/src/widgets/PieWidget.js
+++ b/packages/react-widgets/src/widgets/PieWidget.js
@@ -113,7 +113,7 @@ function PieWidget({
           onSelectedCategoriesChange={handleSelectedCategoriesChange}
         />
       ) : (
-        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { severity: 'warning', body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
+        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
       )}
     </WrapperWidgetUI>
   );

--- a/packages/react-widgets/src/widgets/PieWidget.js
+++ b/packages/react-widgets/src/widgets/PieWidget.js
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { addFilter, removeFilter, selectSourceById } from '@carto/react-redux';
+import { addFilter, removeFilter, checkIfSourceIsDroppingFeature } from '@carto/react-redux';
 import { WrapperWidgetUI, PieWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { _FilterTypes as FilterTypes, AggregationTypes } from '@carto/react-core';
 import { getCategories } from '../models';
@@ -53,8 +53,7 @@ function PieWidget({
   noDataAlertProps
 }) {
   const dispatch = useDispatch();
-  const source = useSelector((state) => selectSourceById(state, dataSource))
-  const isDroppingFeatures = source?.isDroppingFeatures
+  const isDroppingFeatures = useSelector((state) => checkIfSourceIsDroppingFeature(state, dataSource))
 
   const selectedCategories =
     useWidgetFilterValues({ dataSource, id, column, type: FilterTypes.IN }) ||

--- a/packages/react-widgets/src/widgets/PieWidget.js
+++ b/packages/react-widgets/src/widgets/PieWidget.js
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { addFilter, removeFilter } from '@carto/react-redux';
+import { addFilter, removeFilter, selectSourceById } from '@carto/react-redux';
 import { WrapperWidgetUI, PieWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { _FilterTypes as FilterTypes, AggregationTypes } from '@carto/react-core';
 import { getCategories } from '../models';
@@ -53,6 +53,8 @@ function PieWidget({
   noDataAlertProps
 }) {
   const dispatch = useDispatch();
+  const source = useSelector((state) => selectSourceById(state, dataSource))
+  const isDroppingFeatures = source?.isDroppingFeatures
 
   const selectedCategories =
     useWidgetFilterValues({ dataSource, id, column, type: FilterTypes.IN }) ||
@@ -97,7 +99,7 @@ function PieWidget({
 
   return (
     <WrapperWidgetUI title={title} isLoading={isLoading} {...wrapperProps}>
-      {data.length || isLoading ? (
+      {(data.length && !isDroppingFeatures) || isLoading ? (
         <PieWidgetUI
           data={data}
           formatter={formatter}
@@ -111,7 +113,7 @@ function PieWidget({
           onSelectedCategoriesChange={handleSelectedCategoriesChange}
         />
       ) : (
-        <NoDataAlert {...noDataAlertProps} />
+        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { severity: 'warning', body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
       )}
     </WrapperWidgetUI>
   );

--- a/packages/react-widgets/src/widgets/PieWidget.js
+++ b/packages/react-widgets/src/widgets/PieWidget.js
@@ -142,7 +142,8 @@ PieWidget.propTypes = {
   onError: PropTypes.func,
   colors: PropTypes.arrayOf(PropTypes.string),
   wrapperProps: PropTypes.object,
-  noDataAlertProps: PropTypes.object
+  noDataAlertProps: PropTypes.object,
+  droppingFeaturesAlertProps: PropTypes.object
 };
 
 PieWidget.defaultProps = {

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -6,6 +6,7 @@ import { WrapperWidgetUI, ScatterPlotWidgetUI, NoDataAlert } from '@carto/react-
 import { getScatter } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
 import { columnAggregationOn } from './utils/propTypesFns';
+import { defaultDroppingFeaturesAlertProps } from './utils/defaultDroppingFeaturesAlertProps';
 
 /**
  * Renders a <ScatterPlotWidget /> component
@@ -24,6 +25,7 @@ import { columnAggregationOn } from './utils/propTypesFns';
  * @param  {errorCallback} [props.onError] - Function to handle error messages from the widget.
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  * @param  {Object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]()
+ * @param  {Object} [props.droppingFeaturesAlertProps] - Extra props to pass to [NoDataAlert]() when dropping feature
  */
 function ScatterPlotWidget(props) {
   const {
@@ -40,7 +42,8 @@ function ScatterPlotWidget(props) {
     tooltipFormatter,
     onError,
     wrapperProps,
-    noDataAlertProps
+    noDataAlertProps,
+    droppingFeaturesAlertProps = defaultDroppingFeaturesAlertProps
   } = props;
   const isDroppingFeatures = useSelector((state) => checkIfSourceIsDroppingFeature(state, dataSource))
 
@@ -101,7 +104,7 @@ function ScatterPlotWidget(props) {
           animation={animation}
         />
       ) : (
-        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
+        <NoDataAlert {...(isDroppingFeatures ? droppingFeaturesAlertProps : noDataAlertProps)}/>
       )}
     </WrapperWidgetUI>
   );

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { PropTypes } from 'prop-types';
-import { selectAreFeaturesReadyForSource, selectSourceById } from '@carto/react-redux';
+import { selectAreFeaturesReadyForSource, checkIfSourceIsDroppingFeature } from '@carto/react-redux';
 import { WrapperWidgetUI, ScatterPlotWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { getScatter } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
@@ -42,8 +42,7 @@ function ScatterPlotWidget(props) {
     wrapperProps,
     noDataAlertProps
   } = props;
-  const source = useSelector((state) => selectSourceById(state, dataSource))
-  const isDroppingFeatures = source?.isDroppingFeatures
+  const isDroppingFeatures = useSelector((state) => checkIfSourceIsDroppingFeature(state, dataSource))
 
   const [scatterData, setScatterData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -102,7 +102,7 @@ function ScatterPlotWidget(props) {
           animation={animation}
         />
       ) : (
-        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { severity: 'warning', body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
+        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
       )}
     </WrapperWidgetUI>
   );

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -130,7 +130,8 @@ ScatterPlotWidget.propTypes = {
   tooltipFormatter: PropTypes.func,
   onError: PropTypes.func,
   wrapperProps: PropTypes.object,
-  noDataAlertProps: PropTypes.object
+  noDataAlertProps: PropTypes.object,
+  droppingFeaturesAlertProps: PropTypes.object
 };
 
 ScatterPlotWidget.defaultProps = {

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { PropTypes } from 'prop-types';
-import { selectAreFeaturesReadyForSource } from '@carto/react-redux';
+import { selectAreFeaturesReadyForSource, selectSourceById } from '@carto/react-redux';
 import { WrapperWidgetUI, ScatterPlotWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { getScatter } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
@@ -42,6 +42,8 @@ function ScatterPlotWidget(props) {
     wrapperProps,
     noDataAlertProps
   } = props;
+  const source = useSelector((state) => selectSourceById(state, dataSource))
+  const isDroppingFeatures = source?.isDroppingFeatures
 
   const [scatterData, setScatterData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -91,7 +93,7 @@ function ScatterPlotWidget(props) {
 
   return (
     <WrapperWidgetUI title={title} isLoading={isLoading} {...wrapperProps}>
-      {scatterData.length || isLoading ? (
+      {(scatterData.length && !isDroppingFeatures) || isLoading ? (
         <ScatterPlotWidgetUI
           data={scatterData}
           tooltipFormatter={tooltipFormatter}
@@ -100,7 +102,7 @@ function ScatterPlotWidget(props) {
           animation={animation}
         />
       ) : (
-        <NoDataAlert {...noDataAlertProps} />
+        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { severity: 'warning', body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
       )}
     </WrapperWidgetUI>
   );

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -121,7 +121,7 @@ function TableWidget({
           dense={dense}
         />
       ) : (
-        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { severity: 'warning', body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
+        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
       )}
     </WrapperWidgetUI>
   );

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -5,6 +5,7 @@ import { WrapperWidgetUI, TableWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { getTable } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
 import { selectAreFeaturesReadyForSource, checkIfSourceIsDroppingFeature } from '@carto/react-redux';
+import { defaultDroppingFeaturesAlertProps } from './utils/defaultDroppingFeaturesAlertProps';
 
 /**
  * Renders a <TableWidget /> component
@@ -20,6 +21,7 @@ import { selectAreFeaturesReadyForSource, checkIfSourceIsDroppingFeature } from 
  * @param  {Function} [props.onPageSizeChange] - Function called when the page size is changed internally
  * @param  {string} [props.height] - Static widget height, required for scrollable table content
  * @param  {boolean} [props.dense] - Whether the table should use a compact layout with smaller cell paddings
+ * @param  {Object} [props.droppingFeaturesAlertProps] - Extra props to pass to [NoDataAlert]() when dropping feature
  */
 function TableWidget({
   id,
@@ -32,7 +34,8 @@ function TableWidget({
   initialPageSize = 10,
   onPageSizeChange,
   height,
-  dense
+  dense,
+  droppingFeaturesAlertProps = defaultDroppingFeaturesAlertProps
 }) {
   const isDroppingFeatures = useSelector((state) => checkIfSourceIsDroppingFeature(state, dataSource))
 
@@ -120,7 +123,7 @@ function TableWidget({
           dense={dense}
         />
       ) : (
-        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
+        <NoDataAlert {...(isDroppingFeatures ? droppingFeaturesAlertProps : noDataAlertProps)}/>
       )}
     </WrapperWidgetUI>
   );

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { WrapperWidgetUI, TableWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { getTable } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
-import { selectAreFeaturesReadyForSource, selectSourceById } from '@carto/react-redux';
+import { selectAreFeaturesReadyForSource, checkIfSourceIsDroppingFeature } from '@carto/react-redux';
 
 /**
  * Renders a <TableWidget /> component
@@ -34,8 +34,7 @@ function TableWidget({
   height,
   dense
 }) {
-  const source = useSelector((state) => selectSourceById(state, dataSource))
-  const isDroppingFeatures = source?.isDroppingFeatures
+  const isDroppingFeatures = useSelector((state) => checkIfSourceIsDroppingFeature(state, dataSource))
 
   const [rowsPerPage, setRowsPerPage] = useState(initialPageSize);
   const [page, setPage] = useState(0);

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { WrapperWidgetUI, TableWidgetUI, NoDataAlert } from '@carto/react-ui';
 import { getTable } from '../models';
 import useSourceFilters from '../hooks/useSourceFilters';
-import { selectAreFeaturesReadyForSource } from '@carto/react-redux/';
+import { selectAreFeaturesReadyForSource, selectSourceById } from '@carto/react-redux';
 
 /**
  * Renders a <TableWidget /> component
@@ -34,6 +34,9 @@ function TableWidget({
   height,
   dense
 }) {
+  const source = useSelector((state) => selectSourceById(state, dataSource))
+  const isDroppingFeatures = source?.isDroppingFeatures
+
   const [rowsPerPage, setRowsPerPage] = useState(initialPageSize);
   const [page, setPage] = useState(0);
   const [totalCount, setTotalCount] = useState(0);
@@ -99,7 +102,7 @@ function TableWidget({
 
   return (
     <WrapperWidgetUI title={title} {...wrapperProps} isLoading={isLoading}>
-      {rows.length || isLoading ? (
+      {(rows.length && !isDroppingFeatures) || isLoading ? (
         <TableWidgetUI
           columns={columns}
           rows={rows}
@@ -118,7 +121,7 @@ function TableWidget({
           dense={dense}
         />
       ) : (
-        <NoDataAlert {...noDataAlertProps} />
+        <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { severity: 'warning', body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
       )}
     </WrapperWidgetUI>
   );

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -143,6 +143,7 @@ TableWidget.propTypes = {
   onError: PropTypes.func,
   wrapperProps: PropTypes.object,
   noDataAlertProps: PropTypes.object,
+  droppingFeaturesAlertProps: PropTypes.object,
   initialPageSize: PropTypes.number,
   onPageSizeChange: PropTypes.func,
   height: PropTypes.string,

--- a/packages/react-widgets/src/widgets/TimeSeriesWidget.js
+++ b/packages/react-widgets/src/widgets/TimeSeriesWidget.js
@@ -17,6 +17,7 @@ import { capitalize, Menu, MenuItem, SvgIcon, Typography } from '@material-ui/co
 import { PropTypes } from 'prop-types';
 import { columnAggregationOn } from './utils/propTypesFns';
 import useWidgetFetch from '../hooks/useWidgetFetch';
+import { defaultDroppingFeaturesAlertProps } from './utils/defaultDroppingFeaturesAlertProps';
 
 // Due to the widget groups the data by a certain stepSize, when filtering
 // the filter applied must be a range that represent the grouping range.
@@ -64,6 +65,7 @@ const STEP_SIZE_RANGE_MAPPING = {
  * @param  {function} [props.onStop] - Event raised when the animation is stopped.
  * @param  {function} [props.onTimelineUpdate] - Event raised when the timeline is updated. It happens when the animation is playing. The function receive as param the date that is being shown.
  * @param  {function} [props.onTimeWindowUpdate] - Event raised when the timeWindow is updated. It happens when the animation is playing with a timeWindow enabled. The function receive as param an array of two date objects.
+ * @param  {Object} [props.droppingFeaturesAlertProps] - Extra props to pass to [NoDataAlert]() when dropping feature
  */
 function TimeSeriesWidget({
   // Widget
@@ -96,7 +98,8 @@ function TimeSeriesWidget({
   timeWindow,
   onTimeWindowUpdate,
   // Both
-  stepSize
+  stepSize,
+  droppingFeaturesAlertProps = defaultDroppingFeaturesAlertProps
 }) {
   const dispatch = useDispatch();
   const isDroppingFeatures = useSelector((state) => checkIfSourceIsDroppingFeature(state, dataSource))
@@ -243,7 +246,7 @@ function TimeSeriesWidget({
             onTimeWindowUpdate={handleTimeWindowUpdate}
           />
         ) : (
-          <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
+          <NoDataAlert {...(isDroppingFeatures ? droppingFeaturesAlertProps : noDataAlertProps)}/>
         )}
       </WrapperWidgetUI>
       <Menu

--- a/packages/react-widgets/src/widgets/TimeSeriesWidget.js
+++ b/packages/react-widgets/src/widgets/TimeSeriesWidget.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { getTimeSeries } from '../models';
-import { addFilter, removeFilter } from '@carto/react-redux';
+import { addFilter, removeFilter, selectSourceById } from '@carto/react-redux';
 import {
   TimeSeriesWidgetUI,
   WrapperWidgetUI,
@@ -99,6 +99,8 @@ function TimeSeriesWidget({
   stepSize
 }) {
   const dispatch = useDispatch();
+  const source = useSelector((state) => selectSourceById(state, dataSource))
+  const isDroppingFeatures = source?.isDroppingFeatures
 
   const [selectedStepSize, setSelectedStepSize] = useState(stepSize);
 
@@ -220,7 +222,7 @@ function TimeSeriesWidget({
             : [])
         ]}
       >
-        {data.length || isLoading ? (
+        {(data.length && !isDroppingFeatures) || isLoading ? (
           <TimeSeriesWidgetUI
             data={data}
             stepSize={selectedStepSize}
@@ -242,7 +244,7 @@ function TimeSeriesWidget({
             onTimeWindowUpdate={handleTimeWindowUpdate}
           />
         ) : (
-          <NoDataAlert {...noDataAlertProps} />
+          <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { severity: 'warning', body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
         )}
       </WrapperWidgetUI>
       <Menu

--- a/packages/react-widgets/src/widgets/TimeSeriesWidget.js
+++ b/packages/react-widgets/src/widgets/TimeSeriesWidget.js
@@ -244,7 +244,7 @@ function TimeSeriesWidget({
             onTimeWindowUpdate={handleTimeWindowUpdate}
           />
         ) : (
-          <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { severity: 'warning', body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
+          <NoDataAlert {...noDataAlertProps} {...(isDroppingFeatures ? { body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.' } : {})}/>
         )}
       </WrapperWidgetUI>
       <Menu

--- a/packages/react-widgets/src/widgets/TimeSeriesWidget.js
+++ b/packages/react-widgets/src/widgets/TimeSeriesWidget.js
@@ -81,6 +81,7 @@ function TimeSeriesWidget({
   onError,
   wrapperProps,
   noDataAlertProps,
+  droppingFeaturesAlertProps = defaultDroppingFeaturesAlertProps,
   // UI
   chartType,
   tooltip,
@@ -98,8 +99,7 @@ function TimeSeriesWidget({
   timeWindow,
   onTimeWindowUpdate,
   // Both
-  stepSize,
-  droppingFeaturesAlertProps = defaultDroppingFeaturesAlertProps
+  stepSize
 }) {
   const dispatch = useDispatch();
   const isDroppingFeatures = useSelector((state) => checkIfSourceIsDroppingFeature(state, dataSource))
@@ -290,6 +290,7 @@ TimeSeriesWidget.propTypes = {
   onError: PropTypes.func,
   wrapperProps: PropTypes.object,
   noDataAlertProps: PropTypes.object,
+  droppingFeaturesAlertProps: PropTypes.object,
   // UI
   tooltip: PropTypes.bool,
   tooltipFormatter: PropTypes.func,

--- a/packages/react-widgets/src/widgets/TimeSeriesWidget.js
+++ b/packages/react-widgets/src/widgets/TimeSeriesWidget.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { getTimeSeries } from '../models';
-import { addFilter, removeFilter, selectSourceById } from '@carto/react-redux';
+import { addFilter, removeFilter, checkIfSourceIsDroppingFeature } from '@carto/react-redux';
 import {
   TimeSeriesWidgetUI,
   WrapperWidgetUI,
@@ -99,8 +99,7 @@ function TimeSeriesWidget({
   stepSize
 }) {
   const dispatch = useDispatch();
-  const source = useSelector((state) => selectSourceById(state, dataSource))
-  const isDroppingFeatures = source?.isDroppingFeatures
+  const isDroppingFeatures = useSelector((state) => checkIfSourceIsDroppingFeature(state, dataSource))
 
   const [selectedStepSize, setSelectedStepSize] = useState(stepSize);
 

--- a/packages/react-widgets/src/widgets/utils/defaultDroppingFeaturesAlertProps.js
+++ b/packages/react-widgets/src/widgets/utils/defaultDroppingFeaturesAlertProps.js
@@ -1,0 +1,3 @@
+export const defaultDroppingFeaturesAlertProps = {
+  body: 'Some rows have been filtered at this zoom level. Zoom in to ensure you see all rows in the map.'
+}


### PR DESCRIPTION
# Description

Shortcut: [(link)](https://app.shortcut.com/cartoteam/story/222853/widgets-display-dropping-features-warning)

Display warning when tilesets are generated using dropping feature strategy

https://user-images.githubusercontent.com/7818205/165553901-a802728b-1b69-45b2-8b51-a63f33eca410.mov


## Type of change
- Feature
