### PR TITLE
Simplify 'no data' implementation on FormulaWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- Improve "No Data" UI state for FormulaWidget [#389](https://github.com/CartoDB/carto-react/pull/389)
+- Improve "No Data" UI state for FormulaWidget [#389](https://github.com/CartoDB/carto-react/pull/389) and [#391](https://github.com/CartoDB/carto-react/pull/391)
 
 ## 1.3
 

--- a/packages/react-widgets/__tests__/models/FormulaModel.test.js
+++ b/packages/react-widgets/__tests__/models/FormulaModel.test.js
@@ -3,21 +3,18 @@ import { AggregationTypes } from '@carto/react-core';
 import { Methods, executeTask } from '@carto/react-workers';
 import { executeSQL } from '@carto/react-api';
 
-const RESULT = {
-  value: 3.14,
-  feature_count: 42
-};
+const RESULT = 3.14;
 
 jest.mock('@carto/react-api', () => ({
   executeSQL: jest
     .fn()
-    .mockImplementation(() => new Promise((resolve) => resolve([RESULT])))
+    .mockImplementation(() => new Promise((resolve) => resolve([{ value: RESULT }])))
 }));
 
 jest.mock('@carto/react-workers', () => ({
   executeTask: jest
     .fn()
-    .mockImplementation(() => new Promise((resolve) => resolve(RESULT))),
+    .mockImplementation(() => new Promise((resolve) => resolve({ value: RESULT }))),
   Methods: {
     FEATURES_FORMULA: 'featuresFormula'
   }
@@ -41,7 +38,7 @@ describe('getFormula', () => {
 
       const data = await getFormula(props);
 
-      expect(data).toStrictEqual(RESULT);
+      expect(data).toStrictEqual({ value: RESULT });
 
       expect(executeTask).toHaveBeenCalledWith(
         props.source.id,
@@ -77,11 +74,11 @@ describe('getFormula', () => {
 
       const data = await getFormula(props);
 
-      expect(data).toStrictEqual(RESULT);
+      expect(data).toStrictEqual({ value: RESULT });
 
       expect(executeSQL).toHaveBeenCalledWith({
         credentials: props.source.credentials,
-        query: `SELECT sum(column_1) as value, count(1) as feature_count FROM __test__`,
+        query: `SELECT sum(column_1) as value FROM __test__`,
         connection: props.source.connection,
         opts: {
           abortController: undefined

--- a/packages/react-widgets/src/models/FormulaModel.js
+++ b/packages/react-widgets/src/models/FormulaModel.js
@@ -49,7 +49,5 @@ const buildSqlQueryToGetFormula = (props) => {
     joinOperation
   )}) as value`;
 
-  return `SELECT ${selectClause}, count(1) as feature_count FROM ${formatTableNameWithFilters(
-    props
-  )}`;
+  return `SELECT ${selectClause} FROM ${formatTableNameWithFilters(props)}`;
 };

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -25,7 +25,6 @@ import { defaultDroppingFeaturesAlertProps } from './utils/defaultDroppingFeatur
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  * @param  {Object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default)
  * @param  {Object} [props.droppingFeaturesAlertProps] - Extra props to pass to [NoDataAlert]() when dropping feature
- * @param  {Object} [props.noDataPlaceholder] - String to display when there is no feature to compute value.
  */
 function FormulaWidget({
   id,
@@ -39,8 +38,7 @@ function FormulaWidget({
   global,
   onError,
   wrapperProps,
-  droppingFeaturesAlertProps = defaultDroppingFeaturesAlertProps,
-  noDataPlaceholder
+  droppingFeaturesAlertProps = defaultDroppingFeaturesAlertProps
 }) {
   const isDroppingFeatures = useSelector((state) =>
     checkIfSourceIsDroppingFeature(state, dataSource)
@@ -63,8 +61,8 @@ function FormulaWidget({
         <NoDataAlert {...droppingFeaturesAlertProps} />
       ) : (
         <FormulaWidgetUI
-          data={data?.value !== null ? data?.value : noDataPlaceholder}
-          formatter={data?.value !== null ? formatter : undefined}
+          data={data?.value !== null ? data?.value : undefined}
+          formatter={formatter}
           unitBefore={true}
           animation={animation}
         />
@@ -86,15 +84,13 @@ FormulaWidget.propTypes = {
   global: PropTypes.bool,
   onError: PropTypes.func,
   wrapperProps: PropTypes.object,
-  droppingFeaturesAlertProps: PropTypes.object,
-  noDataPlaceholder: PropTypes.string
+  droppingFeaturesAlertProps: PropTypes.object
 };
 
 FormulaWidget.defaultProps = {
   animation: true,
   global: false,
-  wrapperProps: {},
-  noDataPlaceholder: '-'
+  wrapperProps: {}
 };
 
 export default FormulaWidget;

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -63,12 +63,8 @@ function FormulaWidget({
         <NoDataAlert {...droppingFeaturesAlertProps} />
       ) : (
         <FormulaWidgetUI
-          data={
-            data?.feature_count || operation === AggregationTypes.COUNT
-              ? data?.value
-              : noDataPlaceholder
-          }
-          formatter={data?.feature_count ? formatter : undefined}
+          data={data?.value !== null ? data?.value : noDataPlaceholder}
+          formatter={data?.value !== null ? formatter : undefined}
           unitBefore={true}
           animation={animation}
         />

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -43,7 +43,7 @@ function FormulaWidget({
   const isDroppingFeatures = useSelector((state) =>
     checkIfSourceIsDroppingFeature(state, dataSource)
   );
-  const { data, isLoading } = useWidgetFetch(getFormula, {
+  const { data = { value: undefined }, isLoading } = useWidgetFetch(getFormula, {
     id,
     dataSource,
     params: {
@@ -61,7 +61,7 @@ function FormulaWidget({
         <NoDataAlert {...droppingFeaturesAlertProps} />
       ) : (
         <FormulaWidgetUI
-          data={data?.value !== null ? data?.value : undefined}
+          data={Number.isFinite(data?.value) ? data.value : undefined}
           formatter={formatter}
           unitBefore={true}
           animation={animation}

--- a/packages/react-workers/src/workers/features.worker.js
+++ b/packages/react-workers/src/workers/features.worker.js
@@ -6,7 +6,8 @@ import {
   histogram,
   scatterPlot,
   groupValuesByColumn,
-  groupValuesByDateColumn
+  groupValuesByDateColumn,
+  AggregationTypes
 } from '@carto/react-core';
 import { applySorting } from '../utils/sorting';
 import { Methods } from '../workerMethods';
@@ -99,10 +100,11 @@ function getFormula({
 
     const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
 
-    result = {
-      feature_count: filteredFeatures.length,
-      value: targetOperation(filteredFeatures, column, joinOperation)
-    };
+    if (filteredFeatures.length === 0 && operation !== AggregationTypes.COUNT) {
+      result = { value: null };
+    } else {
+      result = { value: targetOperation(filteredFeatures, column, joinOperation) };
+    }
   }
 
   postMessage({ result });


### PR DESCRIPTION
# Description

Follow-up to https://github.com/CartoDB/carto-react/pull/389 which was merged too quickly.

- Removes the need for `feature_count`, just return `null` as computed value in the case of no data present (except for COUNT which will return 0). But as `null` is considered in `useWidgetFetch` as a loading state, we still need to return an object and not just a scalar.
- Remove the explicit passing of an empty placeholder prop, as `FormulaWidgetUI` already supports this when no data is provided.

## Type of change

- Fix