### PR TITLE
Fix histogram query with filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix histogram query with filters [#396](https://github.com/CartoDB/carto-react/pull/396)
+
 ## 1.3
 
 ### 1.3.0-alpha.8 (2022-04-29)

--- a/packages/react-widgets/src/models/HistogramModel.js
+++ b/packages/react-widgets/src/models/HistogramModel.js
@@ -75,7 +75,15 @@ function buildSqlQueryToGetHistogram(props) {
 
   const minMaxQuery = `SELECT MIN(${column}) _min, MAX(${column}) _max FROM ${tableName}`;
 
-  const subQuery = `SELECT ${selectTickClause}, ${column}, minMax.* FROM ${tableName}, (${minMaxQuery}) minMax`;
+  const subQueryFrom = formatTableNameWithFilters({
+    ...props,
+    source: {
+      ...props.source,
+      data: `${props.source.data}, (${minMaxQuery}) minMax`
+    }
+  });
+
+  const subQuery = `SELECT ${selectTickClause}, ${column}, minMax.* FROM ${subQueryFrom}`;
 
   return `SELECT tick, ${selectValueClause}, MIN(q._min) _min, MAX(q._max) _max FROM (${subQuery}) q GROUP BY tick`;
 }


### PR DESCRIPTION
The histogram query wasn't working correctly when the source has filters because the query wasn't taking into consideration the minMax subquery in the FROM.

Added test to cover this use case.

Before:
```sql
SELECT
  tick,
  COUNT(revenue) AS value,
  MIN(q._min) _min,
  MAX(q._max) _max
FROM (
  SELECT
    CASE
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (1 / 20)) THEN 0
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (2 / 20)) THEN 1
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (3 / 20)) THEN 2
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (4 / 20)) THEN 3
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (5 / 20)) THEN 4
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (6 / 20)) THEN 5
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (7 / 20)) THEN 6
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (8 / 20)) THEN 7
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (9 / 20)) THEN 8
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (10 / 20)) THEN 9
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (11 / 20)) THEN 10
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (12 / 20)) THEN 11
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (13 / 20)) THEN 12
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (14 / 20)) THEN 13
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (15 / 20)) THEN 14
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (16 / 20)) THEN 15
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (17 / 20)) THEN 16
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (18 / 20)) THEN 17
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (19 / 20)) THEN 18
    ELSE
    19
  END
    AS tick,
    revenue,
    minMax.*
  FROM
    cartobq.public_account.retail_stores
  WHERE
    ((revenue >= 1187843.6
        AND revenue < 1301149.4)),
    (
    SELECT
      MIN(revenue) _min,
      MAX(revenue) _max
    FROM
      cartobq.public_account.retail_stores
    WHERE
      ((revenue >= 1187843.6
          AND revenue < 1301149.4))) minMax) q
GROUP BY
  tick
```

After:
```sql
SELECT
  tick,
  COUNT(revenue) AS value,
  MIN(q._min) _min,
  MAX(q._max) _max
FROM (
  SELECT
    CASE
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (1 / 20)) THEN 0
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (2 / 20)) THEN 1
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (3 / 20)) THEN 2
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (4 / 20)) THEN 3
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (5 / 20)) THEN 4
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (6 / 20)) THEN 5
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (7 / 20)) THEN 6
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (8 / 20)) THEN 7
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (9 / 20)) THEN 8
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (10 / 20)) THEN 9
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (11 / 20)) THEN 10
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (12 / 20)) THEN 11
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (13 / 20)) THEN 12
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (14 / 20)) THEN 13
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (15 / 20)) THEN 14
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (16 / 20)) THEN 15
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (17 / 20)) THEN 16
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (18 / 20)) THEN 17
      WHEN revenue < (minMax._min + (minMax._max - minMax._min) * (19 / 20)) THEN 18
    ELSE
    19
  END
    AS tick,
    revenue,
    minMax.*
  FROM
    cartobq.public_account.retail_stores,
    (
    SELECT
      MIN(revenue) _min,
      MAX(revenue) _max
    FROM
      cartobq.public_account.retail_stores
    WHERE
      ((revenue >= 1187843.6
          AND revenue < 1301149.4))) minMax
  WHERE
    ((revenue >= 1187843.6
        AND revenue < 1301149.4))) q
GROUP BY
  tick
```