### PR TITLE
Fix HistogramWidgetUI min/max placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix HistogramWidgetUI min/max placement [#397](https://github.com/CartoDB/carto-react/pull/397)
+
 ## 1.3
 
 ### 1.3.0-alpha.8 (2022-04-29)

--- a/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
@@ -314,12 +314,12 @@ export default HistogramWidgetUI;
 
 // Aux
 function formatMin(value) {
-  const spaces = Array(String(value).replace(/\./g, '').length).fill('  ').join('');
+  const spaces = Array(String(value).length).fill('  ').join('');
   return `${spaces}${value}`;
 }
 
 function formatMax(value) {
-  const spaces = Array(String(value).replace(/\./g, '').length).fill('  ').join('');
+  const spaces = Array(String(value).length).fill('  ').join('');
   return `${value}${spaces}`;
 }
 

--- a/packages/react-ui/storybook/stories/widgetsUI/HistogramWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/HistogramWidgetUI.stories.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import HistogramWidgetUI from '../../../src/widgets/HistogramWidgetUI/HistogramWidgetUI';
 
 const options = {


### PR DESCRIPTION
When using decimals, the placement wasn't being done correctly.

Before:

<img width="90" alt="image" src="https://user-images.githubusercontent.com/9151432/166440789-0c1caf85-030d-49b8-9e02-805cff5a8806.png">

After:

<img width="82" alt="image" src="https://user-images.githubusercontent.com/9151432/166440811-4ea476a0-9341-4c66-bf6a-d42adcc7f96e.png">
