### PR TITLE
Pass layer obj to LegendComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Pass layer obj to LegendComponent [#398](https://github.com/CartoDB/carto-react/pull/398)
 - Fix HistogramWidgetUI min/max placement [#397](https://github.com/CartoDB/carto-react/pull/397)
 - Fix histogram query with filters [#396](https://github.com/CartoDB/carto-react/pull/396)
 

--- a/packages/react-ui/__tests__/widgets/LegendWidgetUI.test.js
+++ b/packages/react-ui/__tests__/widgets/LegendWidgetUI.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { getMaterialUIContext } from './testUtils';
-import LegendWidgetUI, { LEGEND_TYPES } from '../../src/widgets/legend/LegendWidgetUI';
+import LegendWidgetUI from '../../src/widgets/legend/LegendWidgetUI';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Typography } from '@material-ui/core';
 
@@ -171,7 +171,7 @@ describe('LegendWidgetUI', () => {
       ></Widget>
     );
     expect(MyCustomLegendComponent).toHaveBeenCalled();
-    expect(MyCustomLegendComponent).toHaveBeenCalledWith({ legend: DATA[6].legend }, {});
+    expect(MyCustomLegendComponent).toHaveBeenCalledWith({ layer: DATA[6], legend: DATA[6].legend }, {});
     expect(screen.getByText('Test')).toBeInTheDocument();
   });
 

--- a/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
+++ b/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
@@ -189,7 +189,10 @@ function LegendRows({
     <>
       {layers.map(
         (
-          {
+          layer,
+          index
+        ) => {
+          const {
             id,
             title,
             switchable,
@@ -197,9 +200,8 @@ function LegendRows({
             showOpacityControl = false,
             opacity = 1,
             legend = {}
-          },
-          index
-        ) => {
+          } = layer;
+
           const {
             type = LEGEND_TYPES.CUSTOM,
             collapsible = true,
@@ -233,7 +235,7 @@ function LegendRows({
                 onChangeVisibility={onChangeVisibility}
                 onChangeCollapsed={onChangeCollapsed}
               >
-                <LegendComponent legend={legend} />
+                <LegendComponent layer={layer} legend={legend} />
               </LegendWrapper>
               {!isSingle && !isLast && <Divider />}
             </Fragment>


### PR DESCRIPTION
In order to know which is the layer that is rendering the legend we need to pass layer obj as props. It's very very useful when rendering custom legends.