### PR TITLE
TimeSeries - Restrict animation when using global mode

### DIFF
--- a/packages/react-widgets/src/widgets/TimeSeriesWidget.js
+++ b/packages/react-widgets/src/widgets/TimeSeriesWidget.js
@@ -106,6 +106,13 @@ function TimeSeriesWidget({
 
   const [selectedStepSize, setSelectedStepSize] = useState(stepSize);
 
+  if (showControls && global) {
+    console.warn(
+      'TimeSeriesWidget cannot show controls while using global mode. Controls will be hidden.'
+    );
+    showControls = false;
+  }
+
   useEffect(() => {
     if (stepSize !== selectedStepSize) {
       setSelectedStepSize(stepSize);


### PR DESCRIPTION
Story details: https://app.shortcut.com/cartoteam/story/227983