### PR TITLE
Fix deprecated warning in HistogramWidgetUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Fix deprecated warning in HistogramWidgetUI [#401](https://github.com/CartoDB/carto-react/pull/401)
 - TimeSeries - Restrict animation when using global mode [#399](https://github.com/CartoDB/carto-react/pull/399)
 - Pass layer obj to LegendComponent [#398](https://github.com/CartoDB/carto-react/pull/398)
 - Fix HistogramWidgetUI min/max placement [#397](https://github.com/CartoDB/carto-react/pull/397)

--- a/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
@@ -172,15 +172,6 @@ function HistogramWidgetUI({
 
   // Series
   const seriesOptions = useMemo(() => {
-    const dataWithColor = formattedData.map((item, idx) => {
-      const isDisabled = selectedBars.length && selectedBars.indexOf(idx) === -1;
-      const color = isDisabled
-        ? theme.palette.charts.disabled
-        : theme.palette.secondary.main;
-
-      return { value: item, itemStyle: { color } };
-    });
-
     return {
       type: 'custom',
       cursor: 'pointer',
@@ -188,10 +179,19 @@ function HistogramWidgetUI({
       renderItem: function (params, api) {
         const isLast = params.dataIndex === formattedData.length - 1;
         const isFirst = params.dataIndex === 0;
+
+        // Fill
+        const isDisabled =
+          selectedBars.length && selectedBars.indexOf(params.dataIndex) === -1;
+        const fill = isDisabled
+          ? theme.palette.charts.disabled
+          : theme.palette.secondary.main;
+
+        // Coords to build the bar
         const yValue = api.value(2);
         const [x, y] = api.coord([api.value(0), yValue]);
         const [width, height] = api.size([api.value(1) - api.value(0), yValue]);
-        const style = api.style();
+
         return {
           type: 'rect',
           shape: {
@@ -200,11 +200,11 @@ function HistogramWidgetUI({
             width: width - (isLast ? 0 : 1),
             height
           },
-          style,
+          style: { fill },
           ...(!IS_TOUCH_SCREEN && {
             emphasis: {
               style: {
-                fill: darken(style.fill, 0.25)
+                fill: darken(fill, 0.25)
               }
             }
           })
@@ -215,7 +215,7 @@ function HistogramWidgetUI({
         y: 2,
         tooltip: [0, 1, 2]
       },
-      data: dataWithColor,
+      data: formattedData,
       animation
     };
   }, [


### PR DESCRIPTION
api.style() is deprecated in echarts, so a warning was shown in each render. I've changed the code so we don't use any deprecated fn.