### PR TITLE
Use static bins in HistogramWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Not released
 
 - Fix filters with null as upper or lower bound [#403](https://github.com/CartoDB/carto-react/pull/403)
-- - Use static bins in HistogramWidget [#402](https://github.com/CartoDB/carto-react/pull/402)
+- Use static bins in HistogramWidget [#402](https://github.com/CartoDB/carto-react/pull/402)
 - Fix deprecated warning in HistogramWidgetUI [#401](https://github.com/CartoDB/carto-react/pull/401)
 - TimeSeries - Restrict animation when using global mode [#399](https://github.com/CartoDB/carto-react/pull/399)
 - Pass layer obj to LegendComponent [#398](https://github.com/CartoDB/carto-react/pull/398)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Use static bins in HistogramWidget [#402](https://github.com/CartoDB/carto-react/pull/402)
 - Fix deprecated warning in HistogramWidgetUI [#401](https://github.com/CartoDB/carto-react/pull/401)
 - TimeSeries - Restrict animation when using global mode [#399](https://github.com/CartoDB/carto-react/pull/399)
 - Pass layer obj to LegendComponent [#398](https://github.com/CartoDB/carto-react/pull/398)

--- a/packages/react-core/__tests__/operations/histogram.test.js
+++ b/packages/react-core/__tests__/operations/histogram.test.js
@@ -14,41 +14,13 @@ const INVALID_DATA = [{ [COLUMN]: null }, { [COLUMN]: undefined }];
 
 const ticks = Array.from(new Set(VALUES));
 
-const TICKS_RESULTS = {
-  [AggregationTypes.COUNT]: [0, 1, 2, 3, 2, 1],
-  [AggregationTypes.AVG]: [0, 1, 2, 3, 4, 5],
-  [AggregationTypes.MIN]: [0, 1, 2, 3, 4, 5],
-  [AggregationTypes.MAX]: [0, 1, 2, 3, 4, 5],
-  [AggregationTypes.SUM]: [0, 1, 4, 9, 8, 5]
-};
-
-const DEFAULT_TICKS_RESULT = {
-  min: Math.min(...VALUES),
-  max: Math.max(...VALUES),
-  ticks
-};
-
-const BINS_RESULTS = {
-  [AggregationTypes.COUNT]: [1, 2, 3, 2, 1],
-  [AggregationTypes.AVG]: [1, 2, 3, 4, 5],
-  [AggregationTypes.MIN]: [1, 2, 3, 4, 5],
-  [AggregationTypes.MAX]: [1, 2, 3, 4, 5],
-  [AggregationTypes.SUM]: [1, 4, 9, 8, 5]
-};
-
-const DEFAULT_BINS_RESULT = {
-  min: Math.min(...VALUES),
-  max: Math.max(...VALUES),
-  ticks: [1.8, 2.6, 3.4, 4.2]
-};
-
 describe('histogram', () => {
-  test('should return an empty object due to empty features array', () => {
-    expect(histogram({ data: [] })).toEqual({});
+  test('should return an empty array due to empty features array', () => {
+    expect(histogram({ data: [] })).toEqual([]);
   });
 
   describe('valid features', () => {
-    test('should return an empty object due to invalid operation', () => {
+    test('should return an empty array due to invalid operation', () => {
       expect(
         histogram({
           data: VALID_DATA,
@@ -57,164 +29,80 @@ describe('histogram', () => {
           // @ts-ignore
           operation: 'pow'
         })
-      ).toEqual({});
+      ).toEqual([]);
     });
 
-    test('should return an object where the bins array has the same length as ticks plus one, due to the addition of extreme values', () => {
+    test('should return an array of bins with same length as ticks plus two, due to the addition of extreme values', () => {
       const h = histogram({
         data: VALID_DATA,
         valuesColumns: [COLUMN],
         ticks,
         operation: AggregationTypes.COUNT
       });
-
-      expect(h.data?.length).toBe(ticks.length + 1);
-      expect(h.ticks).toEqual(ticks);
+      expect(h.length).toBe(1 + ticks.length);
     });
 
-    test('should return an object where the ticks property has the same length as bins minus one ', () => {
-      const nBins = 15;
-
-      const h = histogram({
-        data: VALID_DATA,
-        valuesColumns: [COLUMN],
-        bins: nBins,
-        operation: AggregationTypes.COUNT
-      });
-
-      expect(h.ticks?.length).toBe(nBins - 1);
-      expect(h.data?.length).toBe(nBins);
-    });
+    const RESULTS = {
+      [AggregationTypes.COUNT]: [0, 1, 2, 3, 2, 1],
+      [AggregationTypes.AVG]: [0, 1, 2, 3, 4, 5],
+      [AggregationTypes.MIN]: [0, 1, 2, 3, 4, 5],
+      [AggregationTypes.MAX]: [0, 1, 2, 3, 4, 5],
+      [AggregationTypes.SUM]: [0, 1, 4, 9, 8, 5]
+    };
 
     describe('one valuesColumns', () => {
-      describe('using manual ticks', () => {
-        Object.entries(TICKS_RESULTS).forEach(([operation, result]) => {
-          test(operation, () => {
-            const groups = histogram({
-              data: VALID_DATA,
-              valuesColumns: [COLUMN],
-              ticks,
-              // @ts-ignore
-              operation
-            });
-            expect(groups).toEqual({ data: result, ...DEFAULT_TICKS_RESULT });
+      Object.entries(RESULTS).forEach(([operation, result]) => {
+        test(operation, () => {
+          const groups = histogram({
+            data: VALID_DATA,
+            valuesColumns: [COLUMN],
+            ticks,
+            // @ts-ignore
+            operation
           });
-        });
-      });
-
-      describe('using bins', () => {
-        Object.entries(BINS_RESULTS).forEach(([operation, result]) => {
-          test(operation, () => {
-            const groups = histogram({
-              data: VALID_DATA,
-              valuesColumns: [COLUMN],
-              bins: 5,
-              // @ts-ignore
-              operation
-            });
-            expect(groups).toEqual({ data: result, ...DEFAULT_BINS_RESULT });
-          });
+          expect(groups).toEqual(result);
         });
       });
     });
 
     describe('multiple valuesColumns', () => {
-      describe('using manual ticks', () => {
-        const defaultResult = {
-          min: DEFAULT_TICKS_RESULT.min * 2,
-          max: DEFAULT_TICKS_RESULT.max * 2,
-          ticks: DEFAULT_TICKS_RESULT.ticks.map((tick) => tick * 2)
-        };
+      const RESULTS_FOR_MULTIPLE = Object.entries(RESULTS).reduce(
+        (acc, [operation, result], idx) => {
+          acc[operation] = result.map(
+            (value) =>
+              // === 0 is AggregationTypes.COUNT
+              value * (idx === 0 ? 1 : 2)
+          );
+          return acc;
+        },
+        {}
+      );
 
-        const RESULTS_FOR_MULTIPLE = Object.entries(TICKS_RESULTS).reduce(
-          (acc, [operation, result], idx) => {
-            acc[operation] = result.map(
-              (value) =>
-                // === 0 is AggregationTypes.COUNT
-                value * (idx === 0 ? 1 : 2)
-            );
-            return acc;
-          },
-          {}
-        );
-
-        Object.entries(RESULTS_FOR_MULTIPLE).forEach(([operation, result]) => {
-          test(operation, () => {
-            const groups = histogram({
-              data: VALID_DATA,
-              valuesColumns: [COLUMN, `${COLUMN}_2`],
-              joinOperation: AggregationTypes.SUM,
-              ticks: defaultResult.ticks,
-              // @ts-ignore
-              operation
-            });
-            expect(groups).toEqual({ data: result, ...defaultResult });
+      Object.entries(RESULTS_FOR_MULTIPLE).forEach(([operation, result]) => {
+        test(operation, () => {
+          const groups = histogram({
+            data: VALID_DATA,
+            valuesColumns: [COLUMN, `${COLUMN}_2`],
+            joinOperation: AggregationTypes.SUM,
+            ticks: ticks.map((tick) => tick * 2),
+            // @ts-ignore
+            operation
           });
-        });
-      });
-
-      describe('using bins', () => {
-        const defaultResult = {
-          min: DEFAULT_BINS_RESULT.min * 2,
-          max: DEFAULT_BINS_RESULT.max * 2,
-          ticks: DEFAULT_BINS_RESULT.ticks.map((tick) => tick * 2)
-        };
-
-        const RESULTS_FOR_MULTIPLE = Object.entries(BINS_RESULTS).reduce(
-          (acc, [operation, result], idx) => {
-            acc[operation] = result.map(
-              (value) =>
-                // === 0 is AggregationTypes.COUNT
-                value * (idx === 0 ? 1 : 2)
-            );
-            return acc;
-          },
-          {}
-        );
-
-        Object.entries(RESULTS_FOR_MULTIPLE).forEach(([operation, result]) => {
-          test(operation, () => {
-            const groups = histogram({
-              data: VALID_DATA,
-              valuesColumns: [COLUMN, `${COLUMN}_2`],
-              joinOperation: AggregationTypes.SUM,
-              bins: 5,
-              // @ts-ignore
-              operation
-            });
-            expect(groups).toEqual({ data: result, ...defaultResult });
-          });
+          expect(groups).toEqual(result);
         });
       });
     });
+  });
 
-    describe('invalid features', () => {
-      describe('should return all bins values to 0 due to invalid column data', () => {
-        test('using manual ticks', () => {
-          const h = histogram({
-            data: INVALID_DATA,
-            valuesColumns: [COLUMN],
-            ticks,
-            operation: AggregationTypes.COUNT
-          });
-          expect(h).toEqual({
-            data: [0, 0, 0, 0, 0, 0],
-            max: Number.MIN_SAFE_INTEGER,
-            min: Number.MAX_SAFE_INTEGER,
-            ticks: [1, 2, 3, 4, 5]
-          });
-        });
-        test('using bins', () => {
-          expect(() =>
-            histogram({
-              data: INVALID_DATA,
-              valuesColumns: [COLUMN],
-              bins: 6,
-              operation: AggregationTypes.COUNT
-            })
-          ).toThrowError();
-        });
+  describe('invalid features', () => {
+    test('should return all bins values to 0 due to invalid column data', () => {
+      const h = histogram({
+        data: INVALID_DATA,
+        valuesColumns: [COLUMN],
+        ticks,
+        operation: AggregationTypes.COUNT
       });
+      expect(h).toEqual([0, 0, 0, 0, 0, 0]);
     });
   });
 });

--- a/packages/react-core/src/operations/histogram.d.ts
+++ b/packages/react-core/src/operations/histogram.d.ts
@@ -5,7 +5,6 @@ export function histogram(args: {
   data: Record<string, unknown>[];
   valuesColumns?: string[];
   joinOperation?: AggregationTypes;
-  ticks?: number[];
-  bins?: number;
+  ticks: number[];
   operation?: AggregationTypes;
 }): HistogramFeature;

--- a/packages/react-core/src/operations/histogram.js
+++ b/packages/react-core/src/operations/histogram.js
@@ -1,34 +1,8 @@
 import { aggregate, aggregationFunctions } from './aggregation';
-import { AggregationTypes } from './constants/AggregationTypes';
 
-export function histogram({
-  data,
-  valuesColumns,
-  joinOperation,
-  bins = 15,
-  ticks: _ticks = [],
-  operation
-}) {
+export function histogram({ data, valuesColumns, joinOperation, ticks, operation }) {
   if (Array.isArray(data) && data.length === 0) {
-    return {};
-  }
-  const ticks = [..._ticks];
-  const useBins = !ticks.length && bins;
-
-  let min = Number.MAX_SAFE_INTEGER;
-  let max = Number.MIN_SAFE_INTEGER;
-
-  if (useBins) {
-    min = aggregationFunctions[AggregationTypes.MIN](data, valuesColumns, joinOperation);
-    max = aggregationFunctions[AggregationTypes.MAX](data, valuesColumns, joinOperation);
-
-    if (!isFinite(min) || !isFinite(max)) {
-      throw new Error('Cannot calculate histogram without valid data');
-    }
-
-    for (let i = 1; i < bins; i += 1) {
-      ticks.push(min + (max - min) * (i / bins));
-    }
+    return [];
   }
 
   const binsContainer = [Number.MIN_SAFE_INTEGER, ...ticks].map((tick, index, arr) => ({
@@ -47,14 +21,6 @@ export function histogram({
       return;
     }
 
-    if (!useBins) {
-      if (featureValue < min) {
-        min = featureValue;
-      } else if (featureValue > max) {
-        max = featureValue;
-      }
-    }
-
     const binContainer = binsContainer.find(
       (bin) => bin.start <= featureValue && bin.end > featureValue
     );
@@ -70,13 +36,8 @@ export function histogram({
 
   if (targetOperation) {
     const transformedBins = binsContainer.map((binContainer) => binContainer.values);
-    return {
-      min,
-      max,
-      ticks,
-      data: transformedBins.map((values) => (values.length ? targetOperation(values) : 0))
-    };
+    return transformedBins.map((values) => (values.length ? targetOperation(values) : 0));
   }
 
-  return {};
+  return [];
 }

--- a/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
@@ -6,6 +6,7 @@ import { darken, Grid, Link, makeStyles, Typography, useTheme } from '@material-
 import { processFormatterRes } from '../utils/formatterUtils';
 import detectTouchscreen from '../utils/detectTouchScreen';
 import useHistogramInteractivity from './useHistogramInteractivity';
+import { cartoThemeOptions } from '../..';
 
 const IS_TOUCH_SCREEN = detectTouchscreen();
 
@@ -44,6 +45,12 @@ function HistogramWidgetUI({
 }) {
   const classes = useStyles();
   const theme = useTheme();
+
+  // TODO: JUST FOR BUILDER LINK
+  theme.typography.charts = cartoThemeOptions.typography.charts;
+  theme.palette.charts = cartoThemeOptions.palette.charts;
+  theme.palette.secondary.main = cartoThemeOptions.palette.secondary.main;
+  theme.palette.other = cartoThemeOptions.palette.other;
 
   const filterable = _filterable && !!onSelectedBarsChange;
 
@@ -149,7 +156,8 @@ function HistogramWidgetUI({
         showMinLabel: false,
         inside: true,
         color: (value) => {
-          const maxValue = Math.max(...data.map((d) => d || Number.MIN_SAFE_INTEGER));
+          const maxValue =
+            Math.max(...data.map((d) => d ?? Number.MIN_SAFE_INTEGER)) || 1;
           let col = 'transparent';
           if (value >= maxValue) {
             col = theme.palette.charts.maxLabel;

--- a/packages/react-widgets/__tests__/models/HistogramModel.test.js
+++ b/packages/react-widgets/__tests__/models/HistogramModel.test.js
@@ -4,26 +4,13 @@ import { Methods, executeTask } from '@carto/react-workers';
 import { executeSQL } from '@carto/react-api/';
 
 const TICKS = [1, 2, 3];
-
 const RESULT = [3, 1, 2, 0];
-
-const MOCK_WORKER_RESPONSE = {
-  data: RESULT,
-  min: 0,
-  max: 4,
-  ticks: TICKS
-};
 
 const MOCK_SQL_RESPONSE = Array(TICKS.length)
   .fill(null)
   // Only results [0,2] are used, because we're mocking the case
   // when SQL doesn't have values for the last tick
-  .map((_, idx) => ({
-    tick: idx,
-    value: RESULT[idx],
-    _min: 0,
-    _max: 4
-  }));
+  .map((_, idx) => ({ tick: idx, value: RESULT[idx] }));
 
 jest.mock('@carto/react-api', () => ({
   executeSQL: jest
@@ -34,7 +21,7 @@ jest.mock('@carto/react-api', () => ({
 jest.mock('@carto/react-workers', () => ({
   executeTask: jest
     .fn()
-    .mockImplementation(() => new Promise((resolve) => resolve(MOCK_WORKER_RESPONSE))),
+    .mockImplementation(() => new Promise((resolve) => resolve(RESULT))),
   Methods: {
     FEATURES_HISTOGRAM: 'featuresHistogram'
   }
@@ -52,7 +39,6 @@ describe('getHistogram', () => {
             apiVersion: 'v2'
           }
         },
-        bins: 18,
         ticks: TICKS,
         operation: AggregationTypes.COUNT,
         column: 'column_1'
@@ -60,7 +46,7 @@ describe('getHistogram', () => {
 
       const data = await getHistogram(props);
 
-      expect(data).toBe(MOCK_WORKER_RESPONSE);
+      expect(data).toBe(RESULT);
 
       expect(executeTask).toHaveBeenCalledWith(
         props.source.id,
@@ -70,15 +56,14 @@ describe('getHistogram', () => {
           filtersLogicalOperator: props.source.filtersLogicalOperator,
           operation: props.operation,
           column: props.column,
-          ticks: props.ticks,
-          bins: props.bins
+          ticks: props.ticks
         }
       );
     });
   });
 
   describe('global mode', () => {
-    test('should work correctly using ticks', async () => {
+    test('should work correctly', async () => {
       const props = {
         source: {
           id: '__test__',
@@ -98,49 +83,11 @@ describe('getHistogram', () => {
 
       const data = await getHistogram(props);
 
-      expect(data).toEqual({ data: RESULT, max: 4, min: 0, ticks: TICKS });
+      expect(data).toEqual(RESULT);
 
       expect(executeSQL).toHaveBeenCalledWith({
         credentials: props.source.credentials,
-        query: `SELECT tick, count(column_1) as value, MIN(q._min) _min, MAX(q._max) _max FROM (SELECT CASE WHEN column_1 < 1 THEN 0 WHEN column_1 < 2 THEN 1 WHEN column_1 < 3 THEN 2 ELSE 3 END as tick, column_1, minMax.* FROM __test__, (SELECT MIN(column_1) _min, MAX(column_1) _max FROM __test__) minMax) q GROUP BY tick`,
-        connection: props.source.connection,
-        opts: {
-          abortController: undefined
-        }
-      });
-    });
-
-    test('should work correctly using bins', async () => {
-      const props = {
-        source: {
-          id: '__test__',
-          type: 'table',
-          data: '__test__',
-          credentials: {
-            apiVersion: 'v3',
-            accessToken: '__test_token__'
-          },
-          connection: '__test_connection__'
-        },
-        ticks: [],
-        bins: 4,
-        operation: AggregationTypes.COUNT,
-        column: 'column_1',
-        global: true
-      };
-
-      const data = await getHistogram(props);
-
-      expect(data).toEqual({
-        data: RESULT,
-        min: 0,
-        max: 4,
-        ticks: TICKS
-      });
-
-      expect(executeSQL).toHaveBeenCalledWith({
-        credentials: props.source.credentials,
-        query: `SELECT tick, count(column_1) as value, MIN(q._min) _min, MAX(q._max) _max FROM (SELECT CASE WHEN column_1 < (minMax._min + (minMax._max - minMax._min) * (1 / 4)) THEN 0 WHEN column_1 < (minMax._min + (minMax._max - minMax._min) * (2 / 4)) THEN 1 WHEN column_1 < (minMax._min + (minMax._max - minMax._min) * (3 / 4)) THEN 2 ELSE 3 END as tick, column_1, minMax.* FROM __test__, (SELECT MIN(column_1) _min, MAX(column_1) _max FROM __test__) minMax) q GROUP BY tick`,
+        query: `SELECT tick, count(column_1) as value FROM (SELECT CASE WHEN column_1 < 1 THEN 0 WHEN column_1 < 2 THEN 1 WHEN column_1 < 3 THEN 2 ELSE 3 END as tick, column_1 FROM __test__) q GROUP BY tick`,
         connection: props.source.connection,
         opts: {
           abortController: undefined
@@ -167,8 +114,7 @@ describe('getHistogram', () => {
           },
           connection: '__test_connection__'
         },
-        ticks: [],
-        bins: 4,
+        ticks: TICKS,
         operation: AggregationTypes.COUNT,
         column: 'column_1',
         global: true
@@ -176,16 +122,11 @@ describe('getHistogram', () => {
 
       const data = await getHistogram(props);
 
-      expect(data).toEqual({
-        data: RESULT,
-        min: 0,
-        max: 4,
-        ticks: TICKS
-      });
+      expect(data).toEqual(RESULT);
 
       expect(executeSQL).toHaveBeenCalledWith({
         credentials: props.source.credentials,
-        query: `SELECT tick, count(column_1) as value, MIN(q._min) _min, MAX(q._max) _max FROM (SELECT CASE WHEN column_1 < (minMax._min + (minMax._max - minMax._min) * (1 / 4)) THEN 0 WHEN column_1 < (minMax._min + (minMax._max - minMax._min) * (2 / 4)) THEN 1 WHEN column_1 < (minMax._min + (minMax._max - minMax._min) * (3 / 4)) THEN 2 ELSE 3 END as tick, column_1, minMax.* FROM __test__, (SELECT MIN(column_1) _min, MAX(column_1) _max FROM __test__ WHERE ((column_1 >= 0 and column_1 <= 1))) minMax WHERE ((column_1 >= 0 and column_1 <= 1))) q GROUP BY tick`,
+        query: `SELECT tick, count(column_1) as value FROM (SELECT CASE WHEN column_1 < 1 THEN 0 WHEN column_1 < 2 THEN 1 WHEN column_1 < 3 THEN 2 ELSE 3 END as tick, column_1 FROM __test__ WHERE ((column_1 >= 0 and column_1 <= 1))) q GROUP BY tick`,
         connection: props.source.connection,
         opts: {
           abortController: undefined

--- a/packages/react-widgets/src/models/HistogramModel.js
+++ b/packages/react-widgets/src/models/HistogramModel.js
@@ -8,12 +8,11 @@ export function getHistogram(props) {
 
 // From local
 function fromLocal(props) {
-  const { source, column, operation, ticks, bins } = props;
+  const { source, column, operation, ticks } = props;
 
   return executeTask(source.id, Methods.FEATURES_HISTOGRAM, {
     filters: source.filters,
     filtersLogicalOperator: source.filtersLogicalOperator,
-    bins,
     operation,
     column,
     ticks
@@ -22,7 +21,7 @@ function fromLocal(props) {
 
 // From remote
 async function fromRemote(props) {
-  const { source, ticks, bins, abortController } = props;
+  const { source, ticks, abortController } = props;
   const { credentials, connection } = source;
 
   const query = buildSqlQueryToGetHistogram(props);
@@ -34,56 +33,24 @@ async function fromRemote(props) {
     opts: { abortController }
   }).then(normalizeObjectKeys);
 
-  const nBreaks = ticks.length ? ticks.length + 1 : bins;
-
-  const result = Array(nBreaks).fill(0);
+  const result = Array(ticks.length + 1).fill(0);
   data.forEach(({ tick, value }) => (result[tick] = value));
 
-  const min = data[0]._min;
-  const max = data[0]._max;
-
-  return {
-    min,
-    max,
-    data: result,
-    ticks: ticks.length
-      ? ticks
-      : Array(nBreaks - 1)
-          .fill(0)
-          .map((_, index) => min + (max - min) * ((index + 1) / nBreaks))
-  };
+  return result;
 }
 
 function buildSqlQueryToGetHistogram(props) {
-  const { column, operation, ticks, bins } = props;
+  const { column, operation, ticks } = props;
 
-  const breaks = ticks.length ? ticks : Array(bins - 1).fill(-1);
-  const caseTicks = breaks.map(
-    (t, index) =>
-      `WHEN ${column} < ${
-        t === -1
-          ? `(minMax._min + (minMax._max - minMax._min) * (${index + 1} / ${bins}))`
-          : t
-      } THEN ${index}`
-  );
-  caseTicks.push(`ELSE ${breaks.length}`);
+  const caseTicks = ticks.map((t, index) => `WHEN ${column} < ${t} THEN ${index}`);
+  caseTicks.push(`ELSE ${ticks.length}`);
 
   const selectValueClause = `${operation}(${column}) as value`;
   const selectTickClause = `CASE ${caseTicks.join(' ')} END as tick`;
 
   const tableName = formatTableNameWithFilters(props);
 
-  const minMaxQuery = `SELECT MIN(${column}) _min, MAX(${column}) _max FROM ${tableName}`;
+  const subQuery = `SELECT ${selectTickClause}, ${column} FROM ${tableName}`;
 
-  const subQueryFrom = formatTableNameWithFilters({
-    ...props,
-    source: {
-      ...props.source,
-      data: `${props.source.data}, (${minMaxQuery}) minMax`
-    }
-  });
-
-  const subQuery = `SELECT ${selectTickClause}, ${column}, minMax.* FROM ${subQueryFrom}`;
-
-  return `SELECT tick, ${selectValueClause}, MIN(q._min) _min, MAX(q._max) _max FROM (${subQuery}) q GROUP BY tick`;
+  return `SELECT tick, ${selectValueClause} FROM (${subQuery}) q GROUP BY tick`;
 }

--- a/packages/react-widgets/src/types.d.ts
+++ b/packages/react-widgets/src/types.d.ts
@@ -28,7 +28,10 @@ export type GeocoderWidget = {
 }
 
 export type HistogramWidget = {
-  ticks: number[],
+  ticks?: number[],
+  bins?: number;
+  min: number;
+  max: number;
   xAxisformatter?: Function,
   tooltip?: boolean,
 } & CommonWidgetProps & MonoColumnWidgetProps;

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -22,6 +22,8 @@ const EMPTY_ARRAY = [];
  * @param  {string} props.title - Title to show in the widget header.
  * @param  {string} props.dataSource - ID of the data source to get the data from.
  * @param  {string} props.column - Name of the data source's column to get the data from.
+ * @param  {number} props.min - Min value of the indicated column
+ * @param  {number} props.max - Max value of the indicated column
  * @param  {string} [props.operation] - Operation to apply to the column. Must be one of those defined in `AggregationTypes` object.
  * @param  {number[]} [props.ticks] - Array of thresholds for the X axis.
  * @param  {number} [props.bins] - Number of bins to calculate the ticks.
@@ -42,7 +44,9 @@ function HistogramWidget({
   dataSource,
   column,
   operation,
-  ticks: _ticks,
+  ticks: _ticks = [],
+  min,
+  max,
   xAxisFormatter,
   bins,
   formatter,
@@ -61,25 +65,39 @@ function HistogramWidget({
     checkIfSourceIsDroppingFeature(state, dataSource)
   );
 
-  const { data: _data, isLoading } = useWidgetFetch(getHistogram, {
+  const ticks = useMemo(() => {
+    if (_ticks?.length) return _ticks;
+
+    if (bins) {
+      if (!isFinite(min) || !isFinite(max)) {
+        throw new Error('Cannot calculate histogram without valid data');
+      }
+
+      const result = [];
+      for (let i = 1; i < bins; i += 1) {
+        ticks.push(min + (max - min) * (i / bins));
+      }
+      return result;
+    }
+
+    throw new Error('You must specify either ticks or bins.');
+  }, [min, max, _ticks, bins]);
+
+  let { data = EMPTY_ARRAY, isLoading } = useWidgetFetch(getHistogram, {
     id,
     dataSource,
     params: {
       column,
       operation,
-      ticks: _ticks,
-      bins
+      ticks
     },
     global,
     onError
   });
 
-  const {
-    min = Number.MIN_SAFE_INTEGER,
-    max = Number.MAX_SAFE_INTEGER,
-    data = [],
-    ticks = _ticks
-  } = _data || {};
+  if (data.length && data.length - 1 !== ticks.length) {
+    data = Array(ticks.length).fill(0);
+  }
 
   const thresholdsFromFilters = useWidgetFilterValues({
     dataSource,
@@ -164,6 +182,8 @@ HistogramWidget.propTypes = {
   title: PropTypes.string.isRequired,
   dataSource: PropTypes.string.isRequired,
   column: PropTypes.string.isRequired,
+  min: PropTypes.number.isRequired,
+  max: PropTypes.number.isRequired,
   ticks: PropTypes.arrayOf(PropTypes.number),
   bins: PropTypes.number,
   operation: PropTypes.oneOf(Object.values(AggregationTypes)),

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -69,7 +69,7 @@ function HistogramWidget({
     if (_ticks?.length) return _ticks;
 
     if (bins) {
-      if (!isFinite(min) || !isFinite(max)) {
+      if (!Number.isFinite(min) || !Number.isFinite(max)) {
         throw new Error('Cannot calculate histogram without valid data');
       }
 

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -95,10 +95,6 @@ function HistogramWidget({
     onError
   });
 
-  if (data.length && data.length - 1 !== ticks.length) {
-    data = Array(ticks.length).fill(0);
-  }
-
   const thresholdsFromFilters = useWidgetFilterValues({
     dataSource,
     id,


### PR DESCRIPTION
- Added `min: number` and `max: number` props as mandatory.
- Remove code to calculate viewport min/max.
- Restore the old HistogramModel and histogram aggregation fn, and their tests.
- Calculate ticks manually outside the widget fetch, and keep them until min/max change.
- Fixed minor issues in HistogramWidgetUI when the max Y axis value is 0.