### PR TITLE
Fix filters with null as upper or lower bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Fix filters with null as upper or lower bound [#403](https://github.com/CartoDB/carto-react/pull/403)
 - Fix deprecated warning in HistogramWidgetUI [#401](https://github.com/CartoDB/carto-react/pull/401)
 - TimeSeries - Restrict animation when using global mode [#399](https://github.com/CartoDB/carto-react/pull/399)
 - Pass layer obj to LegendComponent [#398](https://github.com/CartoDB/carto-react/pull/398)

--- a/packages/react-core/__tests__/utils/makeIntervalComplete.test.js
+++ b/packages/react-core/__tests__/utils/makeIntervalComplete.test.js
@@ -6,12 +6,22 @@ describe('make interval complete', () => {
     expect(makeIntervalComplete(DATA)).toEqual([[Number.MIN_SAFE_INTEGER, 1]]);
   });
 
+  test('first value is null', () => {
+    const DATA = [[null, 1]];
+    expect(makeIntervalComplete(DATA)).toEqual([[Number.MIN_SAFE_INTEGER, 1]]);
+  });
+
   test('last value is undefined', () => {
     const DATA = [[1, undefined]];
     expect(makeIntervalComplete(DATA)).toEqual([[1, Number.MAX_SAFE_INTEGER]]);
   });
 
-  test('both values are not undefined', () => {
+  test('last value is null', () => {
+    const DATA = [[1, null]];
+    expect(makeIntervalComplete(DATA)).toEqual([[1, Number.MAX_SAFE_INTEGER]]);
+  });
+
+  test('both values are not undefined or null', () => {
     const DATA = [[1, 1]];
     expect(makeIntervalComplete(DATA)).toEqual([[1, 1]]);
   });

--- a/packages/react-core/src/utils/makeIntervalComplete.js
+++ b/packages/react-core/src/utils/makeIntervalComplete.js
@@ -1,10 +1,10 @@
 export function makeIntervalComplete(values) {
   return values.map((val) => {
-    if (val[0] === undefined) {
+    if (val[0] === undefined || val[0] === null) {
       return [Number.MIN_SAFE_INTEGER, val[1]];
     }
 
-    if (val[1] === undefined) {
+    if (val[1] === undefined || val[1] === null) {
       return [val[0], Number.MAX_SAFE_INTEGER];
     }
 


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/226915/public-map-when-there-is-a-filter-applied-the-layer-doesn-t-appear-on-first-load

For some reason open intervals bounds are saved as `null` and not `undefined` in CARTO 3, so they are not replaced by `Number.MIN/MAX_SAFE_INTEGER` during this normalization.
As a result, filters with no upper bound are failing because `x < null` is always false.

Though a fix could be made in cloud-native to always ensure `undefined` is used, this wouldn't fix previous maps already saved with `null`, and anyways I think it's more robust to test both `undefined` and `null` here.
What do you think?

## Type of change

- Fix