### PR TITLE
LegendCategories - display ellipsis and tooltip if label is too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Display ellipsis and tooltip for long labels in Legend [#408](https://github.com/CartoDB/carto-react/pull/408)
+
 ## 1.3
 
 ### 1.3.0-alpha.9 (2022-05-12)

--- a/packages/react-ui/__tests__/widgets/legend/LegendCategories.test.js
+++ b/packages/react-ui/__tests__/widgets/legend/LegendCategories.test.js
@@ -13,8 +13,10 @@ const DEFAULT_LEGEND = {
 describe('LegendCategories', () => {
   test('renders labels correctly', () => {
     render(<LegendCategories legend={DEFAULT_LEGEND} />);
-    expect(screen.queryByText('Category 1')).toBeInTheDocument();
-    expect(screen.queryByText('Category 2')).toBeInTheDocument();
+    const categoryOne = screen.getAllByText(/Category 1/);
+    const categoryTwo = screen.getAllByText(/Category 2/);
+    expect(categoryOne[0]).toBeInTheDocument();
+    expect(categoryTwo[0]).toBeInTheDocument();
   });
   test('renders colors (CARTOColors) correctly', () => {
     render(<LegendCategories legend={DEFAULT_LEGEND} />);

--- a/packages/react-ui/src/widgets/legend/LegendCategories.js
+++ b/packages/react-ui/src/widgets/legend/LegendCategories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Box, Grid, makeStyles, Tooltip, Typography } from '@material-ui/core';
 import { getPalette } from '../../utils/palette';
 import PropTypes from 'prop-types';
@@ -57,6 +57,7 @@ const useStyles = makeStyles((theme) => ({
     }
   },
   circle: {
+    whiteSpace: 'nowrap',
     display: 'block',
     width: '12px',
     height: '12px',
@@ -74,14 +75,47 @@ const useStyles = makeStyles((theme) => ({
       borderRadius: '50%',
       boxSizing: 'content-box'
     }
+  },
+  flexParent: {
+    display: 'flex',
+    alignItems: 'center'
+  },
+  longTruncate: {
+    flex: 1,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis'
+  },
+  titlePhantom: {
+    opacity: 0,
+    position: 'absolute',
+    whiteSpace: 'nowrap',
+    pointerEvents: 'none'
   }
 }));
 
 function Row({ label, isMax, isStrokeColor, color = '#000' }) {
   const classes = useStyles({ isMax });
 
+  const [showTooltip, setShowTooltip] = useState(false);
+  const labelRef = useRef(null);
+  const labelPhantomRef = useRef(null);
+
+  useEffect(() => {
+    if (!labelPhantomRef?.current || !labelRef?.current) {
+      return;
+    }
+    const labelSizes = labelRef?.current.getBoundingClientRect();
+    const labelPhantomSizes = labelPhantomRef?.current.getBoundingClientRect();
+    setShowTooltip(labelPhantomSizes.width > labelSizes.width);
+  }, [setShowTooltip, labelPhantomRef, labelRef]);
+
   return (
-    <Grid container item className={classes.legendCategories}>
+    <Grid
+      container
+      item
+      className={[classes.legendCategories, classes.flexParent].join(' ')}
+    >
       <Tooltip title={isMax ? 'Most representative' : ''} placement='right' arrow>
         <Box
           mr={1.5}
@@ -90,7 +124,18 @@ function Row({ label, isMax, isStrokeColor, color = '#000' }) {
           style={isStrokeColor ? { borderColor: color } : { backgroundColor: color }}
         />
       </Tooltip>
-      <Typography variant='overline'>{label}</Typography>
+      <Tooltip title={showTooltip ? label : ''} placement='right' arrow>
+        <Typography ref={labelRef} variant='overline' className={classes.longTruncate}>
+          {label}
+        </Typography>
+      </Tooltip>
+      <Typography
+        ref={labelPhantomRef}
+        variant='overline'
+        className={[classes.longTruncate, classes.titlePhantom].join(' ')}
+      >
+        {label}
+      </Typography>
     </Grid>
   );
 }

--- a/packages/react-ui/src/widgets/legend/LegendCategories.js
+++ b/packages/react-ui/src/widgets/legend/LegendCategories.js
@@ -111,31 +111,31 @@ function Row({ label, isMax, isStrokeColor, color = '#000' }) {
   }, [setShowTooltip, labelPhantomRef, labelRef]);
 
   return (
-    <Grid
-      container
-      item
-      className={[classes.legendCategories, classes.flexParent].join(' ')}
-    >
-      <Tooltip title={isMax ? 'Most representative' : ''} placement='right' arrow>
-        <Box
-          mr={1.5}
-          component='span'
-          className={classes.circle}
-          style={isStrokeColor ? { borderColor: color } : { backgroundColor: color }}
-        />
-      </Tooltip>
-      <Tooltip title={showTooltip ? label : ''} placement='right' arrow>
+    <Tooltip title={showTooltip ? label : ''} placement='left' arrow>
+      <Grid
+        container
+        item
+        className={[classes.legendCategories, classes.flexParent].join(' ')}
+      >
+        <Tooltip title={isMax ? 'Most representative' : ''} placement='top' arrow>
+          <Box
+            mr={1.5}
+            component='span'
+            className={classes.circle}
+            style={isStrokeColor ? { borderColor: color } : { backgroundColor: color }}
+          />
+        </Tooltip>
         <Typography ref={labelRef} variant='overline' className={classes.longTruncate}>
           {label}
         </Typography>
-      </Tooltip>
-      <Typography
-        ref={labelPhantomRef}
-        variant='overline'
-        className={[classes.longTruncate, classes.titlePhantom].join(' ')}
-      >
-        {label}
-      </Typography>
-    </Grid>
+        <Typography
+          ref={labelPhantomRef}
+          variant='overline'
+          className={[classes.longTruncate, classes.titlePhantom].join(' ')}
+        >
+          {label}
+        </Typography>
+      </Grid>
+    </Tooltip>
   );
 }


### PR DESCRIPTION

# LegendCategories - display ellipsis and tooltip if label is too long

Shortcut: https://app.shortcut.com/cartoteam/story/218032/legends-fix-the-mismatch-in-the-legends-when-the-names-are-too-long

![Captura de pantalla 2022-05-12 a las 11 55 40](https://user-images.githubusercontent.com/9006480/168045880-5aa864d4-e63b-4bbc-84e2-b65eda05fb8c.png)
![Captura de pantalla 2022-05-12 a las 11 55 45](https://user-images.githubusercontent.com/9006480/168045888-65e9287d-3a84-42e9-aaaf-8e5ccf685e49.png)


## Type of change

- Fix
