### PR TITLE
FIX: Cannot filter map with category widget with boolean values. 

### DIFF
--- a/packages/react-core/src/operations/groupBy.js
+++ b/packages/react-core/src/operations/groupBy.js
@@ -11,11 +11,11 @@ export function groupValuesByColumn({
   if (Array.isArray(data) && data.length === 0) {
     return null;
   }
-
   const groups = data.reduce((accumulator, item) => {
     const group = item[keysColumn];
 
-    accumulator[group] = accumulator[group] || [];
+    const values = accumulator.get(group) || []
+    accumulator.set(group, values)
 
     const aggregatedValue = aggregate(item, valuesColumns, joinOperation);
 
@@ -24,16 +24,18 @@ export function groupValuesByColumn({
       aggregatedValue !== undefined;
 
     if (isValid) {
-      accumulator[group].push(aggregatedValue);
+      values.push(aggregatedValue)
+      accumulator.set(group, values);
     }
 
     return accumulator;
-  }, {});
+  }, new Map());
+
 
   const targetOperation = aggregationFunctions[operation];
 
   if (targetOperation) {
-    return Object.entries(groups).map(([name, value]) => ({
+    return Array.from(groups).map(([name, value]) => ({
       name,
       value: targetOperation(value)
     }));

--- a/packages/react-ui/src/widgets/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI.js
@@ -294,7 +294,7 @@ function CategoryWidgetUI(props) {
       if (name === REST_CATEGORY) {
         return `Others ${searchable ? '' : `(${getCategoriesCount()})`}`;
       } else {
-        return labels[name] || name;
+        return labels[name] || `${name}`;
       }
     },
     [getCategoriesCount, labels, searchable]
@@ -614,7 +614,7 @@ CategoryWidgetUI.defaultProps = {
 CategoryWidgetUI.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
-      name: PropTypes.string.isRequired,
+      name: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
       value: PropTypes.number
     })
   ),


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/230271/ac-pbwqze2p-cannot-filter-category-widget-for-boolean-values

Category Widget don't filter properly when column is `boolean`

## Type of change

- Fix

# Acceptance

1. Create a builder map with a layer that has a boolean field. E.g: from team account
 ```sql
     SELECT *, price_num > 500 as price_over_500_bool FROM `carto-dw-ac-7xhfwyml.shared.la_airbnb` 
```
2. Create a category widget based on the boolean column (e.g: `price_over_500_bool`)



https://user-images.githubusercontent.com/7818205/168979059-9d4271a9-41bc-4934-8547-053a6b222282.mov

