### PR TITLE
Use new Query Models in SQL API for global widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Use Model API in global widgets [#415](https://github.com/CartoDB/carto-react/pull/415)
+
 ## 1.3
 
 ### 1.3.0-alpha.11 (2022-05-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- Use Model API in global widgets [#415](https://github.com/CartoDB/carto-react/pull/415)
+- Use new Query Models in SQL API for global widgets [#415](https://github.com/CartoDB/carto-react/pull/415)
 
 ## 1.3
 

--- a/packages/react-api/__tests__/api/model.test.js
+++ b/packages/react-api/__tests__/api/model.test.js
@@ -1,0 +1,68 @@
+import { executeModel } from '../../src/api/model';
+import { QUERY_SOURCE, TABLE_SOURCE, TILESET_SOURCE } from '../dataMocks';
+
+const mockedMakeCall = jest.fn();
+
+jest.mock('../../src/api/common', () => ({
+  ...jest.requireActual('../../src/api/common'),
+  makeCall: (props) => {
+    mockedMakeCall(props);
+    return Promise.resolve();
+  }
+}));
+
+const DEFAULT_PARAMS = { column: '__test__', operation: 'avg' };
+
+describe('model', () => {
+  describe('executeModel', () => {
+    test('works correctly with a table source', () => {
+      executeModel({ model: 'formula', source: TABLE_SOURCE, params: DEFAULT_PARAMS });
+
+      expect(mockedMakeCall).toHaveBeenCalledWith({
+        credentials: TABLE_SOURCE.credentials,
+        opts: { method: 'GET' },
+        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=table&source=cartobq.public_account.seattle_collisions&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&filters=%7B%7D&filtersLogicalOperator=AND'
+      });
+    });
+
+    test('works correctly with a query source', () => {
+      executeModel({ model: 'formula', source: QUERY_SOURCE, params: DEFAULT_PARAMS });
+
+      expect(mockedMakeCall).toHaveBeenCalledWith({
+        credentials: TABLE_SOURCE.credentials,
+        opts: { method: 'GET' },
+        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=query&source=SELECT+*+FROM+%60cartobq.public_account.seattle_collisions%60&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&filters=%7B%7D&filtersLogicalOperator=AND'
+      });
+    });
+
+    test('works correctly when the source is very large', () => {
+      const longQuerySource = {
+        ...QUERY_SOURCE,
+        data: 'a'.repeat(2048)
+      };
+
+      executeModel({ model: 'formula', source: longQuerySource, params: DEFAULT_PARAMS });
+
+      expect(mockedMakeCall).toHaveBeenCalledWith({
+        credentials: TABLE_SOURCE.credentials,
+        opts: {
+          method: 'POST',
+          body: JSON.stringify({
+            type: 'query',
+            source: longQuerySource.data,
+            params: JSON.stringify(DEFAULT_PARAMS),
+            filters: JSON.stringify(longQuerySource.filters),
+            filtersLogicalOperator: longQuerySource.filtersLogicalOperator
+          })
+        },
+        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula'
+      });
+    });
+
+    test('should throw error with a tileset source', () => {
+      expect(() =>
+        executeModel({ model: 'formula', source: TILESET_SOURCE, params: DEFAULT_PARAMS })
+      ).toThrowError();
+    });
+  });
+});

--- a/packages/react-api/__tests__/api/stats.test.js
+++ b/packages/react-api/__tests__/api/stats.test.js
@@ -76,16 +76,7 @@ describe('stats', () => {
     test('table source - should return stats', async () => {
       const TABLE_TEST = {
         input: {
-          source: {
-            type: TABLE_SOURCE,
-            data: 'cartobq.public_account.seattle_collisions',
-            connection: 'carto-ps-bq-developers',
-            credentials: {
-              accessToken: '__test_api_key__',
-              apiBaseUrl: 'https://gcp-us-east1.api.carto.com',
-              apiVersion: 'v3'
-            }
-          },
+          source: TABLE_SOURCE,
           column: 'injuries'
         },
         url: `https://gcp-us-east1.api.carto.com/v3/stats/carto-ps-bq-developers/cartobq.public_account.seattle_collisions/injuries`,

--- a/packages/react-api/__tests__/api/stats.test.js
+++ b/packages/react-api/__tests__/api/stats.test.js
@@ -1,4 +1,5 @@
 import { getStats } from '../../src/api/stats';
+import { QUERY_SOURCE, TABLE_SOURCE, TILESET_SOURCE } from '../dataMocks';
 
 const TABLE_AND_QUERY_STATS = {
   attribute: 'injuries',
@@ -76,7 +77,7 @@ describe('stats', () => {
       const TABLE_TEST = {
         input: {
           source: {
-            type: 'table',
+            type: TABLE_SOURCE,
             data: 'cartobq.public_account.seattle_collisions',
             connection: 'carto-ps-bq-developers',
             credentials: {
@@ -115,16 +116,7 @@ describe('stats', () => {
     test('query source - should return stats', async () => {
       const QUERY_TEST = {
         input: {
-          source: {
-            type: 'query',
-            data: 'SELECT * FROM `cartobq.public_account.seattle_collisions`',
-            connection: 'carto-ps-bq-developers',
-            credentials: {
-              accessToken: '__test_api_key__',
-              apiBaseUrl: 'https://gcp-us-east1.api.carto.com',
-              apiVersion: 'v3'
-            }
-          },
+          source: QUERY_SOURCE,
           column: 'injuries'
         },
         url: `https://gcp-us-east1.api.carto.com/v3/stats/carto-ps-bq-developers/injuries?q=SELECT+*+FROM+%60cartobq.public_account.seattle_collisions%60`,
@@ -155,16 +147,7 @@ describe('stats', () => {
     test('tileset source - should return stats', async () => {
       const TILESET_TEST = {
         input: {
-          source: {
-            type: 'tileset',
-            data: 'cartobq.public_account.pois',
-            connection: 'carto-ps-bq-developers',
-            credentials: {
-              accessToken: '__test_api_key__',
-              apiBaseUrl: 'https://gcp-us-east1.api.carto.com',
-              apiVersion: 'v3'
-            }
-          },
+          source: TILESET_SOURCE,
           column: 'name'
         },
         output: mockTilestats.layers[0].attributes[0]

--- a/packages/react-api/__tests__/dataMocks.js
+++ b/packages/react-api/__tests__/dataMocks.js
@@ -1,0 +1,38 @@
+export const TABLE_SOURCE = {
+  type: 'table',
+  data: 'cartobq.public_account.seattle_collisions',
+  connection: 'carto-ps-bq-developers',
+  filters: {},
+  filtersLogicalOperator: 'AND',
+  credentials: {
+    accessToken: '__test_api_key__',
+    apiBaseUrl: 'https://gcp-us-east1.api.carto.com',
+    apiVersion: 'v3'
+  }
+};
+
+export const QUERY_SOURCE = {
+  type: 'query',
+  data: 'SELECT * FROM `cartobq.public_account.seattle_collisions`',
+  connection: 'carto-ps-bq-developers',
+  filters: {},
+  filtersLogicalOperator: 'AND',
+  credentials: {
+    accessToken: '__test_api_key__',
+    apiBaseUrl: 'https://gcp-us-east1.api.carto.com',
+    apiVersion: 'v3'
+  }
+};
+
+export const TILESET_SOURCE = {
+  type: 'tileset',
+  data: 'cartobq.public_account.pois',
+  connection: 'carto-ps-bq-developers',
+  filters: {},
+  filtersLogicalOperator: 'AND',
+  credentials: {
+    accessToken: '__test_api_key__',
+    apiBaseUrl: 'https://gcp-us-east1.api.carto.com',
+    apiVersion: 'v3'
+  }
+};

--- a/packages/react-api/src/api/model.js
+++ b/packages/react-api/src/api/model.js
@@ -1,0 +1,66 @@
+import { assert, checkCredentials, makeCall } from './common';
+import { MAP_TYPES, API_VERSIONS } from '@deck.gl/carto';
+
+const URL_LENGTH = 2048;
+
+const AVAILABLE_MODELS = ['category', 'histogram', 'formula', 'timeseries'];
+
+/**
+ * Execute a SQL model request.
+ *
+ * @param { object } props
+ * @param { string } props.model - widget's model that we want to get the data for
+ * @param { object } props.source - source that owns the column
+ * @param { object } props.params - widget's props
+ * @param { object= } props.opts - Additional options for the HTTP request
+ */
+export function executeModel(props) {
+  assert(props.source, 'executeModel: missing source');
+  assert(props.model, 'executeModel: missing model');
+  assert(props.params, 'executeModel: missing params');
+
+  assert(
+    AVAILABLE_MODELS.indexOf(props.model) !== -1,
+    `executeModel: model provided isn't valid. Available models: ${AVAILABLE_MODELS.join(
+      ', '
+    )}`
+  );
+
+  const { source, model, params, opts } = props;
+
+  checkCredentials(source.credentials);
+
+  assert(
+    source.credentials.apiVersion === API_VERSIONS.V3,
+    'SQL Model API is a feature only available in CARTO 3.'
+  );
+  assert(source.type !== MAP_TYPES.TILESET, 'executeModel: Tileset not supported');
+
+  let url = `${source.credentials.apiBaseUrl}/v3/sql/${source.connection}/model/${model}`;
+
+  const { filters, filtersLogicalOperator, data, type } = source;
+
+  const queryParams = {
+    type,
+    source: data,
+    params: JSON.stringify(params),
+    filters: JSON.stringify(filters),
+    filtersLogicalOperator
+  };
+
+  const isGet = url.length + JSON.stringify(queryParams).length <= URL_LENGTH;
+
+  if (isGet) {
+    url += '?' + new URLSearchParams(queryParams).toString();
+  }
+
+  return makeCall({
+    url,
+    credentials: source.credentials,
+    opts: {
+      ...opts,
+      method: isGet ? 'GET' : 'POST',
+      ...(!isGet && { body: JSON.stringify(queryParams) })
+    }
+  });
+}

--- a/packages/react-api/src/index.d.ts
+++ b/packages/react-api/src/index.d.ts
@@ -2,6 +2,7 @@ export { executeSQL } from './api/SQL';
 export { ldsGeocode } from './api/lds';
 export { getStats as _getStats } from './api/stats';
 export { getTileJson as _getTileJson } from './api/tilejson';
+export { executeModel as _executeModel } from './api/model';
 
 export { default as useCartoLayerProps } from './hooks/useCartoLayerProps';
 

--- a/packages/react-api/src/index.js
+++ b/packages/react-api/src/index.js
@@ -2,6 +2,7 @@ export { executeSQL } from './api/SQL';
 export { ldsGeocode } from './api/lds';
 export { getStats as _getStats } from './api/stats';
 export { getTileJson as _getTileJson } from './api/tilejson';
+export { executeModel as _executeModel } from './api/model';
 
 export { default as useCartoLayerProps } from './hooks/useCartoLayerProps';
 

--- a/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
@@ -6,7 +6,6 @@ import { darken, Grid, Link, makeStyles, Typography, useTheme } from '@material-
 import { processFormatterRes } from '../utils/formatterUtils';
 import detectTouchscreen from '../utils/detectTouchScreen';
 import useHistogramInteractivity from './useHistogramInteractivity';
-import { cartoThemeOptions } from '../..';
 
 const IS_TOUCH_SCREEN = detectTouchscreen();
 
@@ -45,12 +44,6 @@ function HistogramWidgetUI({
 }) {
   const classes = useStyles();
   const theme = useTheme();
-
-  // TODO: JUST FOR BUILDER LINK
-  theme.typography.charts = cartoThemeOptions.typography.charts;
-  theme.palette.charts = cartoThemeOptions.palette.charts;
-  theme.palette.secondary.main = cartoThemeOptions.palette.secondary.main;
-  theme.palette.other = cartoThemeOptions.palette.other;
 
   const filterable = _filterable && !!onSelectedBarsChange;
 

--- a/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
@@ -6,6 +6,7 @@ import { darken, Grid, Link, makeStyles, Typography, useTheme } from '@material-
 import { processFormatterRes } from '../utils/formatterUtils';
 import detectTouchscreen from '../utils/detectTouchScreen';
 import useHistogramInteractivity from './useHistogramInteractivity';
+import { cartoThemeOptions } from '../..';
 
 const IS_TOUCH_SCREEN = detectTouchscreen();
 
@@ -44,6 +45,12 @@ function HistogramWidgetUI({
 }) {
   const classes = useStyles();
   const theme = useTheme();
+
+  // TODO: JUST FOR BUILDER LINK
+  theme.typography.charts = cartoThemeOptions.typography.charts;
+  theme.palette.charts = cartoThemeOptions.palette.charts;
+  theme.palette.secondary.main = cartoThemeOptions.palette.secondary.main;
+  theme.palette.other = cartoThemeOptions.palette.other;
 
   const filterable = _filterable && !!onSelectedBarsChange;
 

--- a/packages/react-widgets/__tests__/models/FormulaModel.test.js
+++ b/packages/react-widgets/__tests__/models/FormulaModel.test.js
@@ -9,7 +9,7 @@ const mockedExecuteModel = jest.fn();
 jest.mock('@carto/react-api', () => ({
   _executeModel: (props) => {
     mockedExecuteModel(props);
-    return Promise.resolve({ rows: { VALUE: RESULT } });
+    return Promise.resolve({ rows: [{ VALUE: RESULT }] });
   }
 }));
 

--- a/packages/react-widgets/__tests__/models/FormulaModel.test.js
+++ b/packages/react-widgets/__tests__/models/FormulaModel.test.js
@@ -1,14 +1,16 @@
 import { getFormula } from '../../src/models/FormulaModel';
 import { AggregationTypes } from '@carto/react-core';
 import { Methods, executeTask } from '@carto/react-workers';
-import { executeSQL } from '@carto/react-api';
 
 const RESULT = 3.14;
 
+const mockedExecuteModel = jest.fn();
+
 jest.mock('@carto/react-api', () => ({
-  executeSQL: jest
-    .fn()
-    .mockImplementation(() => new Promise((resolve) => resolve([{ value: RESULT }])))
+  _executeModel: (props) => {
+    mockedExecuteModel(props);
+    return Promise.resolve({ rows: { VALUE: RESULT } });
+  }
 }));
 
 jest.mock('@carto/react-workers', () => ({
@@ -76,12 +78,16 @@ describe('getFormula', () => {
 
       expect(data).toStrictEqual({ value: RESULT });
 
-      expect(executeSQL).toHaveBeenCalledWith({
-        credentials: props.source.credentials,
-        query: `SELECT sum(column_1) as value FROM __test__`,
-        connection: props.source.connection,
-        opts: {
-          abortController: undefined
+      expect(mockedExecuteModel).toHaveBeenCalledWith({
+        model: 'formula',
+        opts: { abortController: undefined },
+        params: { column: 'column_1', operation: 'sum' },
+        source: {
+          connection: '__test_connection__',
+          credentials: { accessToken: '__test_token__', apiVersion: 'v3' },
+          data: '__test__',
+          id: '__test__',
+          type: 'table'
         }
       });
     });

--- a/packages/react-widgets/__tests__/models/HistogramModel.test.js
+++ b/packages/react-widgets/__tests__/models/HistogramModel.test.js
@@ -1,7 +1,6 @@
 import { getHistogram } from '../../src/models/HistogramModel';
 import { AggregationTypes, _FilterTypes } from '@carto/react-core';
 import { Methods, executeTask } from '@carto/react-workers';
-import { executeSQL } from '@carto/react-api/';
 
 const TICKS = [1, 2, 3];
 const RESULT = [3, 1, 2, 0];
@@ -12,10 +11,13 @@ const MOCK_SQL_RESPONSE = Array(TICKS.length)
   // when SQL doesn't have values for the last tick
   .map((_, idx) => ({ tick: idx, value: RESULT[idx] }));
 
+const mockedExecuteModel = jest.fn();
+
 jest.mock('@carto/react-api', () => ({
-  executeSQL: jest
-    .fn()
-    .mockImplementation(() => new Promise((resolve) => resolve(MOCK_SQL_RESPONSE)))
+  _executeModel: (props) => {
+    mockedExecuteModel(props);
+    return Promise.resolve({ rows: MOCK_SQL_RESPONSE });
+  }
 }));
 
 jest.mock('@carto/react-workers', () => ({
@@ -69,38 +71,6 @@ describe('getHistogram', () => {
           id: '__test__',
           type: 'table',
           data: '__test__',
-          credentials: {
-            apiVersion: 'v3',
-            accessToken: '__test_token__'
-          },
-          connection: '__test_connection__'
-        },
-        ticks: TICKS,
-        operation: AggregationTypes.COUNT,
-        column: 'column_1',
-        global: true
-      };
-
-      const data = await getHistogram(props);
-
-      expect(data).toEqual(RESULT);
-
-      expect(executeSQL).toHaveBeenCalledWith({
-        credentials: props.source.credentials,
-        query: `SELECT tick, count(column_1) as value FROM (SELECT CASE WHEN column_1 < 1 THEN 0 WHEN column_1 < 2 THEN 1 WHEN column_1 < 3 THEN 2 ELSE 3 END as tick, column_1 FROM __test__) q GROUP BY tick`,
-        connection: props.source.connection,
-        opts: {
-          abortController: undefined
-        }
-      });
-    });
-
-    test('should work correctly using filters', async () => {
-      const props = {
-        source: {
-          id: '__test__',
-          type: 'table',
-          data: '__test__',
           filters: {
             column_1: {
               [_FilterTypes.BETWEEN]: {
@@ -124,13 +94,15 @@ describe('getHistogram', () => {
 
       expect(data).toEqual(RESULT);
 
-      expect(executeSQL).toHaveBeenCalledWith({
-        credentials: props.source.credentials,
-        query: `SELECT tick, count(column_1) as value FROM (SELECT CASE WHEN column_1 < 1 THEN 0 WHEN column_1 < 2 THEN 1 WHEN column_1 < 3 THEN 2 ELSE 3 END as tick, column_1 FROM __test__ WHERE ((column_1 >= 0 and column_1 <= 1))) q GROUP BY tick`,
-        connection: props.source.connection,
-        opts: {
-          abortController: undefined
-        }
+      expect(mockedExecuteModel).toHaveBeenCalledWith({
+        model: 'histogram',
+        opts: { abortController: undefined },
+        params: {
+          column: props.column,
+          operation: props.operation,
+          ticks: props.ticks
+        },
+        source: props.source
       });
     });
   });

--- a/packages/react-widgets/__tests__/models/TimeSeriesModel.test.js
+++ b/packages/react-widgets/__tests__/models/TimeSeriesModel.test.js
@@ -2,6 +2,20 @@ import { getTimeSeries } from '../../src/models/TimeSeriesModel';
 import { AggregationTypes, GroupDateTypes } from '@carto/react-core';
 import { Methods, executeTask } from '@carto/react-workers';
 
+const MOCK_API_RESULT = [
+  { name: Date.UTC(1970, 0, 1, 0, 0), value: 2 },
+  { name: Date.UTC(1970, 1, 1, 0, 0), value: 3 }
+];
+
+const mockedExecuteModel = jest.fn();
+
+jest.mock('@carto/react-api', () => ({
+  _executeModel: (props) => {
+    mockedExecuteModel(props);
+    return Promise.resolve({ rows: MOCK_API_RESULT });
+  }
+}));
+
 const MOCK_WORKER_RESULT = [
   Date.UTC(1970, 0, 1, 0, 0),
   Date.UTC(1970, 0, 1, 0, 30),
@@ -20,10 +34,6 @@ jest.mock('@carto/react-workers', () => ({
 }));
 
 const mockedExecuteSQL = jest.fn();
-
-jest.mock('@carto/react-api', () => ({
-  executeSQL: (...args) => mockedExecuteSQL(...args)
-}));
 
 describe('getTimeSeries', () => {
   describe('local mode', () => {
@@ -64,125 +74,42 @@ describe('getTimeSeries', () => {
   });
 
   describe('global mode', () => {
-    const DEFAULT_PROPS = {
-      source: {
-        id: '__test__',
-        type: 'table',
-        data: '__test__',
-        credentials: {
-          apiVersion: 'v3',
-          accessToken: '__test_token__'
+    test('should work correctly', async () => {
+      const props = {
+        source: {
+          id: '__test__',
+          type: 'table',
+          data: '__test__',
+          credentials: {
+            apiVersion: 'v3',
+            accessToken: '__test_token__'
+          },
+          connection: '__test_connection__'
         },
-        connection: '__test_connection__'
-      },
-      operation: AggregationTypes.COUNT,
-      column: 'date_column',
-      operationColumn: 'opt_column',
-      global: true
-    };
-
-    describe('no-week stepSize', () => {
-      const MOCK_API_RESULT = [
-        {
-          ['_agg_' + GroupDateTypes.YEARS]: 1970,
-          ['_agg_' + GroupDateTypes.MONTHS]: 1,
-          value: 2
-        },
-        {
-          ['_agg_' + GroupDateTypes.YEARS]: 1970,
-          ['_agg_' + GroupDateTypes.MONTHS]: 2,
-          value: 3
-        }
-      ];
-
-      const RESULT = [
-        { name: Date.UTC(1970, 0, 1, 0, 0), value: 2 },
-        { name: Date.UTC(1970, 1, 1, 0, 0), value: 3 }
-      ];
-
-      test('should work correctly', async () => {
-        mockedExecuteSQL.mockImplementation(
-          () => new Promise((resolve) => resolve(MOCK_API_RESULT))
-        );
-
-        const props = {
-          ...DEFAULT_PROPS,
-          stepSize: GroupDateTypes.MONTHS
-        };
-
-        const data = await getTimeSeries(props);
-
-        expect(data).toEqual(RESULT);
-
-        expect(mockedExecuteSQL).toHaveBeenCalledWith({
-          credentials: props.source.credentials,
-          query: `SELECT extract(year from cast(date_column as timestamp)) as _agg_year,extract(month from cast(date_column as timestamp)) as _agg_month,count(*) as value FROM __test__ GROUP BY _agg_year,_agg_month ORDER BY _agg_year,_agg_month`,
-          connection: props.source.connection,
-          opts: {
-            abortController: undefined
-          }
-        });
-      });
-    });
-
-    describe('week stepSize', () => {
-      const MOCK_API_RESULT = [
-        {
-          ['_agg_' + GroupDateTypes.YEARS]: 1970,
-          ['_agg_' + GroupDateTypes.MONTHS]: 1,
-          ['_agg_' + GroupDateTypes.DAYS]: 1,
-          value: 2,
-          _grouped_count: 10
-        },
-        {
-          ['_agg_' + GroupDateTypes.YEARS]: 1970,
-          ['_agg_' + GroupDateTypes.MONTHS]: 1,
-          ['_agg_' + GroupDateTypes.DAYS]: 2,
-          value: 3,
-          _grouped_count: 20
-        }
-      ];
-
-      const RESULTS = {
-        [AggregationTypes.AVG]: [{ name: -259200000, value: 2.6666666666666665 }],
-        [AggregationTypes.SUM]: [{ name: -259200000, value: 5 }],
-        [AggregationTypes.MIN]: [{ name: -259200000, value: 2 }],
-        [AggregationTypes.MAX]: [{ name: -259200000, value: 3 }],
-        [AggregationTypes.COUNT]: [{ name: -259200000, value: 5 }]
+        operation: AggregationTypes.COUNT,
+        column: 'date_column',
+        operationColumn: 'opt_column',
+        global: true,
+        stepSize: GroupDateTypes.MONTHS
       };
 
-      const RESULTS_QUERIES = {
-        [AggregationTypes.AVG]: `SELECT extract(year from cast(date_column as timestamp)) as _agg_year,extract(month from cast(date_column as timestamp)) as _agg_month,extract(day from cast(date_column as timestamp)) as _agg_day,avg(opt_column) as value,count(*) as _grouped_count FROM __test__ GROUP BY _agg_year,_agg_month,_agg_day ORDER BY _agg_year,_agg_month,_agg_day`,
-        [AggregationTypes.SUM]: `SELECT extract(year from cast(date_column as timestamp)) as _agg_year,extract(month from cast(date_column as timestamp)) as _agg_month,extract(day from cast(date_column as timestamp)) as _agg_day,sum(opt_column) as value FROM __test__ GROUP BY _agg_year,_agg_month,_agg_day ORDER BY _agg_year,_agg_month,_agg_day`,
-        [AggregationTypes.MIN]: `SELECT extract(year from cast(date_column as timestamp)) as _agg_year,extract(month from cast(date_column as timestamp)) as _agg_month,extract(day from cast(date_column as timestamp)) as _agg_day,min(opt_column) as value FROM __test__ GROUP BY _agg_year,_agg_month,_agg_day ORDER BY _agg_year,_agg_month,_agg_day`,
-        [AggregationTypes.MAX]: `SELECT extract(year from cast(date_column as timestamp)) as _agg_year,extract(month from cast(date_column as timestamp)) as _agg_month,extract(day from cast(date_column as timestamp)) as _agg_day,max(opt_column) as value FROM __test__ GROUP BY _agg_year,_agg_month,_agg_day ORDER BY _agg_year,_agg_month,_agg_day`,
-        [AggregationTypes.COUNT]: `SELECT extract(year from cast(date_column as timestamp)) as _agg_year,extract(month from cast(date_column as timestamp)) as _agg_month,extract(day from cast(date_column as timestamp)) as _agg_day,count(*) as value FROM __test__ GROUP BY _agg_year,_agg_month,_agg_day ORDER BY _agg_year,_agg_month,_agg_day`
-      };
+      const data = await getTimeSeries(props);
 
-      test('should work correctly', () => {
-        mockedExecuteSQL.mockImplementation(
-          () => new Promise((resolve) => resolve(MOCK_API_RESULT))
-        );
+      expect(data).toEqual(MOCK_API_RESULT);
 
-        const props = {
-          ...DEFAULT_PROPS,
-          stepSize: GroupDateTypes.WEEKS
-        };
-
-        Object.keys(RESULTS).forEach((operation) => {
-          getTimeSeries({ ...props, operation }).then((data) =>
-            expect(data).toEqual(RESULTS[operation])
-          );
-
-          expect(mockedExecuteSQL).toHaveBeenCalledWith({
-            credentials: props.source.credentials,
-            query: RESULTS_QUERIES[operation],
-            connection: props.source.connection,
-            opts: {
-              abortController: undefined
-            }
-          });
-        });
+      expect(mockedExecuteModel).toHaveBeenCalledWith({
+        model: 'timeseries',
+        source: props.source,
+        params: {
+          column: props.column,
+          operation: props.operation,
+          operationColumn: props.operationColumn || props.column,
+          stepSize: props.stepSize,
+          joinOperation: props.joinOperation
+        },
+        opts: {
+          abortController: undefined
+        }
       });
     });
   });

--- a/packages/react-widgets/src/models/CategoryModel.js
+++ b/packages/react-widgets/src/models/CategoryModel.js
@@ -23,13 +23,15 @@ function fromLocal(props) {
 // From remote
 function fromRemote(props) {
   const { source, abortController, ...params } = props;
+  const { column, operation, operationColumn } = params;
 
   return _executeModel({
     model: 'category',
     source,
     params: {
-      ...params,
-      operationColumn: params.operationColumn || params.column
+      column,
+      operation,
+      operationColumn: operationColumn || column
     },
     opts: { abortController }
   }).then((res) => normalizeObjectKeys(res.rows));

--- a/packages/react-widgets/src/models/FormulaModel.js
+++ b/packages/react-widgets/src/models/FormulaModel.js
@@ -1,11 +1,6 @@
-import { executeSQL } from '@carto/react-api';
+import { _executeModel } from '@carto/react-api';
 import { Methods, executeTask } from '@carto/react-workers';
-import {
-  formatOperationColumn,
-  formatTableNameWithFilters,
-  normalizeObjectKeys,
-  wrapModelCall
-} from './utils';
+import { normalizeObjectKeys, wrapModelCall } from './utils';
 
 export function getFormula(props) {
   return wrapModelCall(props, fromLocal, fromRemote);
@@ -26,28 +21,12 @@ function fromLocal(props) {
 
 // From remote
 function fromRemote(props) {
-  const { source, abortController } = props;
-  const { credentials, connection } = source;
+  const { source, abortController, ...params } = props;
 
-  const query = buildSqlQueryToGetFormula(props);
-
-  return executeSQL({
-    credentials,
-    query,
-    connection,
+  return _executeModel({
+    model: 'formula',
+    source,
+    params,
     opts: { abortController }
-  })
-    .then(normalizeObjectKeys)
-    .then((data) => data[0]);
+  }).then((res) => normalizeObjectKeys(res.rows));
 }
-
-const buildSqlQueryToGetFormula = (props) => {
-  const { column, joinOperation, operation } = props;
-
-  const selectClause = `${operation}(${formatOperationColumn(
-    column,
-    joinOperation
-  )}) as value`;
-
-  return `SELECT ${selectClause} FROM ${formatTableNameWithFilters(props)}`;
-};

--- a/packages/react-widgets/src/models/FormulaModel.js
+++ b/packages/react-widgets/src/models/FormulaModel.js
@@ -29,5 +29,5 @@ function fromRemote(props) {
     source,
     params: { column: column || '*', operation },
     opts: { abortController }
-  }).then((res) => normalizeObjectKeys(res.rows));
+  }).then((res) => normalizeObjectKeys(res.rows[0]));
 }

--- a/packages/react-widgets/src/models/FormulaModel.js
+++ b/packages/react-widgets/src/models/FormulaModel.js
@@ -22,11 +22,12 @@ function fromLocal(props) {
 // From remote
 function fromRemote(props) {
   const { source, abortController, ...params } = props;
+  const { column, operation } = params;
 
   return _executeModel({
     model: 'formula',
     source,
-    params,
+    params: { column: column || '*', operation },
     opts: { abortController }
   }).then((res) => normalizeObjectKeys(res.rows));
 }

--- a/packages/react-widgets/src/models/HistogramModel.js
+++ b/packages/react-widgets/src/models/HistogramModel.js
@@ -1,4 +1,4 @@
-import { executeSQL } from '@carto/react-api';
+import { executeSQL, _executeModel } from '@carto/react-api';
 import { Methods, executeTask } from '@carto/react-workers';
 import { formatTableNameWithFilters, normalizeObjectKeys, wrapModelCall } from './utils';
 
@@ -21,36 +21,19 @@ function fromLocal(props) {
 
 // From remote
 async function fromRemote(props) {
-  const { source, ticks, abortController } = props;
-  const { credentials, connection } = source;
+  const { source, abortController, ...params } = props;
 
-  const query = buildSqlQueryToGetHistogram(props);
+  const { ticks } = params;
 
-  const data = await executeSQL({
-    credentials,
-    query,
-    connection,
+  const data = await _executeModel({
+    model: 'histogram',
+    source,
+    params,
     opts: { abortController }
-  }).then(normalizeObjectKeys);
+  }).then((res) => normalizeObjectKeys(res.rows));
 
   const result = Array(ticks.length + 1).fill(0);
   data.forEach(({ tick, value }) => (result[tick] = value));
 
   return result;
-}
-
-function buildSqlQueryToGetHistogram(props) {
-  const { column, operation, ticks } = props;
-
-  const caseTicks = ticks.map((t, index) => `WHEN ${column} < ${t} THEN ${index}`);
-  caseTicks.push(`ELSE ${ticks.length}`);
-
-  const selectValueClause = `${operation}(${column}) as value`;
-  const selectTickClause = `CASE ${caseTicks.join(' ')} END as tick`;
-
-  const tableName = formatTableNameWithFilters(props);
-
-  const subQuery = `SELECT ${selectTickClause}, ${column} FROM ${tableName}`;
-
-  return `SELECT tick, ${selectValueClause} FROM (${subQuery}) q GROUP BY tick`;
 }

--- a/packages/react-widgets/src/models/HistogramModel.js
+++ b/packages/react-widgets/src/models/HistogramModel.js
@@ -1,6 +1,6 @@
-import { executeSQL, _executeModel } from '@carto/react-api';
+import { _executeModel } from '@carto/react-api';
 import { Methods, executeTask } from '@carto/react-workers';
-import { formatTableNameWithFilters, normalizeObjectKeys, wrapModelCall } from './utils';
+import { normalizeObjectKeys, wrapModelCall } from './utils';
 
 export function getHistogram(props) {
   return wrapModelCall(props, fromLocal, fromRemote);
@@ -23,12 +23,12 @@ function fromLocal(props) {
 async function fromRemote(props) {
   const { source, abortController, ...params } = props;
 
-  const { ticks } = params;
+  const { column, operation, ticks } = params;
 
   const data = await _executeModel({
     model: 'histogram',
     source,
-    params,
+    params: { column, operation, ticks },
     opts: { abortController }
   }).then((res) => normalizeObjectKeys(res.rows));
 

--- a/packages/react-widgets/src/models/TimeSeriesModel.js
+++ b/packages/react-widgets/src/models/TimeSeriesModel.js
@@ -1,17 +1,6 @@
-import { executeSQL, _executeModel } from '@carto/react-api/';
-import {
-  AggregationTypes,
-  getMonday,
-  GroupDateTypes,
-  groupValuesByDateColumn
-} from '@carto/react-core/';
+import { _executeModel } from '@carto/react-api/';
 import { Methods, executeTask } from '@carto/react-workers';
-import {
-  formatOperationColumn,
-  formatTableNameWithFilters,
-  normalizeObjectKeys,
-  wrapModelCall
-} from './utils';
+import { normalizeObjectKeys, wrapModelCall } from './utils';
 
 export function getTimeSeries(props) {
   return wrapModelCall(props, fromLocal, fromRemote);

--- a/packages/react-widgets/src/models/TimeSeriesModel.js
+++ b/packages/react-widgets/src/models/TimeSeriesModel.js
@@ -1,4 +1,4 @@
-import { executeSQL } from '@carto/react-api/';
+import { executeSQL, _executeModel } from '@carto/react-api/';
 import {
   AggregationTypes,
   getMonday,
@@ -38,205 +38,20 @@ function fromLocal({
 }
 
 // From remote
-const STEP_SIZE_TO_GROUP_QUERY_MAP = {
-  [GroupDateTypes.YEARS]: [GroupDateTypes.YEARS],
-  [GroupDateTypes.MONTHS]: [GroupDateTypes.YEARS, GroupDateTypes.MONTHS],
-  [GroupDateTypes.DAYS]: [
-    GroupDateTypes.YEARS,
-    GroupDateTypes.MONTHS,
-    GroupDateTypes.DAYS
-  ],
-  [GroupDateTypes.HOURS]: [
-    GroupDateTypes.YEARS,
-    GroupDateTypes.MONTHS,
-    GroupDateTypes.DAYS,
-    GroupDateTypes.HOURS
-  ],
-  [GroupDateTypes.MINUTES]: [
-    GroupDateTypes.YEARS,
-    GroupDateTypes.MONTHS,
-    GroupDateTypes.DAYS,
-    GroupDateTypes.HOURS,
-    GroupDateTypes.MINUTES
-  ]
-};
+function fromRemote(props) {
+  const { source, abortController, ...params } = props;
+  const { column, operationColumn, joinOperation, operation, stepSize } = params;
 
-const FORMAT_NAME_BY_STEP_SIZE = {
-  [GroupDateTypes.YEARS]: (row) =>
-    Date.UTC(row[stepSizeQueryColumn(GroupDateTypes.YEARS)], 0),
-  [GroupDateTypes.MONTHS]: (row) =>
-    Date.UTC(
-      row[stepSizeQueryColumn(GroupDateTypes.YEARS)],
-      row[stepSizeQueryColumn(GroupDateTypes.MONTHS)] - 1
-    ),
-  [GroupDateTypes.DAYS]: (row) =>
-    Date.UTC(
-      row[stepSizeQueryColumn(GroupDateTypes.YEARS)],
-      row[stepSizeQueryColumn(GroupDateTypes.MONTHS)] - 1,
-      row[stepSizeQueryColumn(GroupDateTypes.DAYS)]
-    ),
-  [GroupDateTypes.HOURS]: (row) =>
-    Date.UTC(
-      row[stepSizeQueryColumn(GroupDateTypes.YEARS)],
-      row[stepSizeQueryColumn(GroupDateTypes.MONTHS)] - 1,
-      row[stepSizeQueryColumn(GroupDateTypes.DAYS)],
-      row[stepSizeQueryColumn(GroupDateTypes.HOURS)]
-    ),
-  [GroupDateTypes.MINUTES]: (row) =>
-    Date.UTC(
-      row[stepSizeQueryColumn(GroupDateTypes.YEARS)],
-      row[stepSizeQueryColumn(GroupDateTypes.MONTHS)] - 1,
-      row[stepSizeQueryColumn(GroupDateTypes.DAYS)],
-      row[stepSizeQueryColumn(GroupDateTypes.HOURS)],
-      row[stepSizeQueryColumn(GroupDateTypes.MINUTES)]
-    )
-};
-
-function groupWeeklyAverageValuesByDateColumn(data) {
-  const groups = data.reduce((acc, item) => {
-    const value = item.name;
-    const formattedValue = new Date(value);
-    const groupKey = getMonday(formattedValue);
-
-    if (!isNaN(groupKey)) {
-      let groupedValues = acc.get(groupKey);
-      if (!groupedValues) {
-        groupedValues = [];
-        acc.set(groupKey, groupedValues);
-      }
-
-      // In order to calculate the weighted average, we need to multiply the aggregated value by the weight that
-      // is the number of elements that were grouped (_grouped_count)
-      const weightedValue = item.value * item._grouped_count;
-
-      const isValid = weightedValue !== null && weightedValue !== undefined;
-
-      if (isValid) {
-        groupedValues.push([weightedValue, item._grouped_count]);
-        acc.set(groupKey, groupedValues);
-      }
-    }
-
-    return acc;
-  }, new Map());
-
-  return [...groups.entries()].map(([name, value]) => {
-    const weightedValues = value.flat().filter((_, idx) => idx % 2 === 0);
-    const weights = value.flat().filter((_, idx) => idx % 2 !== 0);
-
-    return {
-      name,
-      // Pondered average is the sum of the weighted values divided by the sum of the weights
-      value: sum(weightedValues) / sum(weights)
-    };
-  });
-}
-
-// In order to keep compatibility with the different providers, we group the data in the query using
-// multiple extract fns. After that, we must build the date using the resulting _agg_* columns
-function formatRemoteData(data, props) {
-  const { stepSize, operation } = props;
-
-  const dateFormatter =
-    FORMAT_NAME_BY_STEP_SIZE[
-      stepSize === GroupDateTypes.WEEKS ? GroupDateTypes.DAYS : stepSize
-    ];
-
-  // For weeks, each provider behavies differently, so we need to group the data in the local
-  // For any other AggregationTypes it's easy, but AVG should be made using a weighted average
-  if (stepSize === GroupDateTypes.WEEKS && operation === AggregationTypes.AVG) {
-    const formattedData = data.map((row) => ({
-      value: row.value,
-      name: dateFormatter(row),
-      _grouped_count: row._grouped_count
-    }));
-
-    return groupWeeklyAverageValuesByDateColumn(formattedData);
-  } else {
-    const formattedData = data.map((row) => ({
-      value: row.value,
-      name: dateFormatter(row)
-    }));
-
-    if (stepSize === GroupDateTypes.WEEKS) {
-      return groupValuesByDateColumn({
-        data: formattedData,
-        keysColumn: 'name',
-        valuesColumns: ['value'],
-        groupType: stepSize,
-        operation: operation === AggregationTypes.COUNT ? AggregationTypes.SUM : operation
-      });
-    }
-
-    return formattedData;
-  }
-}
-
-async function fromRemote(props) {
-  const { source, abortController } = props;
-  const { credentials, connection } = source;
-
-  const query = buildSqlQueryToGetTimeSeries(props);
-
-  const data = await executeSQL({
-    credentials,
-    query,
-    connection,
+  return _executeModel({
+    model: 'timeseries',
+    source,
+    params: {
+      column,
+      stepSize,
+      operationColumn: operationColumn || column,
+      joinOperation,
+      operation
+    },
     opts: { abortController }
-  }).then(normalizeObjectKeys);
-
-  return formatRemoteData(data, props);
-}
-
-function buildSqlQueryToGetTimeSeries(props) {
-  const { column, operation, operationColumn, joinOperation, stepSize } = props;
-
-  const isWeekly = stepSize === GroupDateTypes.WEEKS;
-
-  const stepSizesToGroupBy =
-    STEP_SIZE_TO_GROUP_QUERY_MAP[
-      // In weeks, group by days and then group by weeks in local
-      isWeekly ? GroupDateTypes.DAYS : stepSize
-    ];
-
-  if (!stepSizesToGroupBy) throw new Error(`${stepSize} not supported`);
-
-  const selectDateClause = stepSizesToGroupBy
-    .map(
-      (step) =>
-        `extract(${step} from cast(${column} as timestamp)) as ${stepSizeQueryColumn(
-          step
-        )}`
-    )
-    .join();
-
-  const selectValueClause = `${operation}(${
-    operation === AggregationTypes.COUNT
-      ? '*'
-      : formatOperationColumn(operationColumn || column, joinOperation)
-  }) as value`;
-
-  const selectClause = [
-    selectDateClause,
-    selectValueClause,
-    ...(isWeekly && operation === AggregationTypes.AVG
-      ? // _grouped_count is needed for weighted average
-        [`count(*) as _grouped_count`]
-      : [])
-  ];
-
-  const byColumns = stepSizesToGroupBy.map(stepSizeQueryColumn);
-
-  const tableName = formatTableNameWithFilters(props);
-
-  return `SELECT ${selectClause} FROM ${tableName} GROUP BY ${byColumns} ORDER BY ${byColumns}`.trim();
-}
-
-// Aux
-function sum(data) {
-  return data.reduce((acc, item) => (acc += item), 0);
-}
-
-function stepSizeQueryColumn(stepSize) {
-  return `_agg_${stepSize}`;
+  }).then((res) => normalizeObjectKeys(res.rows));
 }


### PR DESCRIPTION
This PR covers the changes needed to use the new Model API in the global widgets.

In order to use the Model API, a new api fn has been implemented in @carto/react-api called `executeModel` following the same path that with Stats API, LDS API and SQL API.

Updated widgets:

- [x] CategoryWidget (also Pie)
- [x] FormulaWidget
- [x] HistogramWidget
- [x] TimeSeriesWidget

This PR is pending of merge of [this one](https://github.com/CartoDB/cloud-native/pull/6840).