### PR TITLE
Spatial index support for useCartoLayerProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Spatial index support for useCartoLayerProps [#425](https://github.com/CartoDB/carto-react/pull/425)
 
 ## 1.3
 

--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -1,11 +1,10 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { selectSpatialFilter } from '@carto/react-redux';
 import useGeojsonFeatures from './useGeojsonFeatures';
 import useTileFeatures from './useTileFeatures';
 import { getDataFilterExtensionProps } from './dataFilterExtensionUtil';
 import { getMaskExtensionProps } from './maskExtensionUtil';
-import { SpatialIndex } from '@carto/react-core';
 
 export default function useCartoLayerProps({
   source,
@@ -16,7 +15,6 @@ export default function useCartoLayerProps({
 }) {
   const viewport = useSelector((state) => state.carto.viewport);
   const spatialFilter = useSelector((state) => selectSpatialFilter(state, source?.id));
-  const [spatialIndex, setSpatialIndex] = useState();
 
   const [onDataLoadForGeojson] = useGeojsonFeatures({
     source,
@@ -31,16 +29,12 @@ export default function useCartoLayerProps({
     viewport,
     spatialFilter,
     uniqueIdProperty,
-    debounceTimeout: viewporFeaturesDebounceTimeout,
-    spatialIndex
+    debounceTimeout: viewporFeaturesDebounceTimeout
   });
 
   const onDataLoad = useCallback(
     (data) => {
       if (data?.tilejson) {
-        setSpatialIndex(
-          Object.values(SpatialIndex).includes(data.scheme) ? data.scheme : undefined
-        );
         return onDataLoadForTile(data);
       }
 

--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -1,10 +1,11 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { selectSpatialFilter } from '@carto/react-redux';
 import useGeojsonFeatures from './useGeojsonFeatures';
 import useTileFeatures from './useTileFeatures';
 import { getDataFilterExtensionProps } from './dataFilterExtensionUtil';
 import { getMaskExtensionProps } from './maskExtensionUtil';
+import { SpatialIndex } from '@carto/react-core';
 
 export default function useCartoLayerProps({
   source,
@@ -15,6 +16,7 @@ export default function useCartoLayerProps({
 }) {
   const viewport = useSelector((state) => state.carto.viewport);
   const spatialFilter = useSelector((state) => selectSpatialFilter(state, source?.id));
+  const [spatialIndex, setSpatialIndex] = useState();
 
   const [onDataLoadForGeojson] = useGeojsonFeatures({
     source,
@@ -29,12 +31,16 @@ export default function useCartoLayerProps({
     viewport,
     spatialFilter,
     uniqueIdProperty,
-    debounceTimeout: viewporFeaturesDebounceTimeout
+    debounceTimeout: viewporFeaturesDebounceTimeout,
+    spatialIndex
   });
 
   const onDataLoad = useCallback(
     (data) => {
       if (data?.tilejson) {
+        setSpatialIndex(
+          Object.values(SpatialIndex).includes(data.scheme) ? data.scheme : undefined
+        );
         return onDataLoadForTile(data);
       }
 

--- a/packages/react-api/src/hooks/useTileFeatures.js
+++ b/packages/react-api/src/hooks/useTileFeatures.js
@@ -3,6 +3,7 @@ import { debounce } from '@carto/react-core';
 import { Methods, executeTask } from '@carto/react-workers';
 import { setIsDroppingFeatures } from '@carto/react-redux';
 import { parse } from '@loaders.gl/core';
+import { Layer } from '@deck.gl/core';
 import { TILE_FORMATS } from '@deck.gl/carto';
 import { throwError } from './utils';
 import useFeaturesCommons from './useFeaturesCommons';
@@ -13,9 +14,10 @@ export default function useTileFeatures({
   viewport,
   spatialFilter,
   uniqueIdProperty,
-  debounceTimeout = 250
+  debounceTimeout = 250,
+  spatialIndex
 }) {
-  const dispatch = useDispatch()
+  const dispatch = useDispatch();
   const [
     debounceIdRef,
     isTilesetLoaded,
@@ -41,7 +43,8 @@ export default function useTileFeatures({
         viewport,
         geometry: spatialFilter,
         uniqueIdProperty,
-        tileFormat
+        tileFormat,
+        spatialIndex
       })
         .then(() => {
           setSourceFeaturesReady(true);
@@ -49,7 +52,7 @@ export default function useTileFeatures({
         .catch(throwError)
         .finally(clearDebounce);
     },
-    [setSourceFeaturesReady, sourceId, tileFormat, clearDebounce]
+    [tileFormat, setSourceFeaturesReady, sourceId, spatialIndex, clearDebounce]
   );
 
   const loadTiles = useCallback(
@@ -64,8 +67,8 @@ export default function useTileFeatures({
         return acc;
       }, []);
 
-      const isDroppingFeatures = tiles?.some(tile => tile.content?.isDroppingFeatures)
-      dispatch(setIsDroppingFeatures({ id: sourceId, isDroppingFeatures }))
+      const isDroppingFeatures = tiles?.some((tile) => tile.content?.isDroppingFeatures);
+      dispatch(setIsDroppingFeatures({ id: sourceId, isDroppingFeatures }));
 
       executeTask(sourceId, Methods.LOAD_TILES, { tiles: cleanedTiles })
         .then(() => setTilesetLoaded(true))
@@ -120,9 +123,13 @@ export default function useTileFeatures({
   const fetch = useCallback(
     (...args) => {
       stopAnyCompute();
-      return customFetch(...args)
+
+      if (spatialIndex) {
+        return Layer.defaultProps.fetch.value(...args);
+      }
+      return customFetch(...args);
     },
-    [stopAnyCompute]
+    [stopAnyCompute, spatialIndex]
   );
 
   const onDataLoad = useCallback(({ tiles: [tile] }) => {
@@ -133,14 +140,15 @@ export default function useTileFeatures({
   return [onDataLoad, onViewportLoad, fetch];
 }
 
-// WORKAROUND: To read headers and know if the tile is dropping features. 
+// WORKAROUND: To read headers and know if the tile is dropping features.
 // Remove when the new loader is ready => https://github.com/visgl/loaders.gl/pull/2128
-const customFetch = async (url, {layer, loaders, loadOptions, signal}) => {
+const customFetch = async (url, { layer, loaders, loadOptions, signal }) => {
   loadOptions = loadOptions || layer.getLoadOptions();
   loaders = loaders || layer.props.loaders;
 
-  const response = await fetch(url, { signal })
-  const isDroppingFeatures = response.headers.get('Features-Dropped-From-Tile') === 'true'
-  const result = await parse(response, loaders, loadOptions)
-  return result ? { ...result, isDroppingFeatures } : null
-}
+  const response = await fetch(url, { signal });
+  const isDroppingFeatures =
+    response.headers.get('Features-Dropped-From-Tile') === 'true';
+  const result = await parse(response, loaders, loadOptions);
+  return result ? { ...result, isDroppingFeatures } : null;
+};

--- a/packages/react-api/src/hooks/useTileFeatures.js
+++ b/packages/react-api/src/hooks/useTileFeatures.js
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useState } from 'react';
-import { debounce } from '@carto/react-core';
+import { debounce, SpatialIndex } from '@carto/react-core';
 import { Methods, executeTask } from '@carto/react-workers';
 import { setIsDroppingFeatures } from '@carto/react-redux';
 import { parse } from '@loaders.gl/core';
@@ -14,8 +14,7 @@ export default function useTileFeatures({
   viewport,
   spatialFilter,
   uniqueIdProperty,
-  debounceTimeout = 250,
-  spatialIndex
+  debounceTimeout = 250
 }) {
   const dispatch = useDispatch();
   const [
@@ -28,6 +27,7 @@ export default function useTileFeatures({
   ] = useFeaturesCommons({ source });
 
   const [tileFormat, setTileFormat] = useState('');
+  const [spatialIndex, setSpatialIndex] = useState();
 
   const sourceId = source?.id;
 
@@ -132,9 +132,10 @@ export default function useTileFeatures({
     [stopAnyCompute, spatialIndex]
   );
 
-  const onDataLoad = useCallback(({ tiles: [tile] }) => {
+  const onDataLoad = useCallback(({ tiles: [tile], scheme }) => {
     const tilesFormat = new URL(tile).searchParams.get('formatTiles');
     setTileFormat(tilesFormat || TILE_FORMATS.MVT);
+    setSpatialIndex(Object.values(SpatialIndex).includes(scheme) ? scheme : undefined);
   }, []);
 
   return [onDataLoad, onViewportLoad, fetch];

--- a/packages/react-core/src/index.d.ts
+++ b/packages/react-core/src/index.d.ts
@@ -30,4 +30,6 @@ export { AggregationFunctions, GroupByFeature, HistogramFeature, Viewport, TileF
 export { GroupDateTypes } from './operations/constants/GroupDateTypes';
 export { groupValuesByDateColumn } from './operations/groupByDate';
 
+export { SpatialIndex } from './operations/constants/SpatialIndexTypes'
+
 export { FEATURE_SELECTION_MODES, EDIT_MODES, MASK_ID } from './utils/featureSelectionConstants';

--- a/packages/react-core/src/index.js
+++ b/packages/react-core/src/index.js
@@ -37,6 +37,8 @@ export { geojsonFeatures } from './filters/geojsonFeatures';
 export { GroupDateTypes } from './operations/constants/GroupDateTypes';
 export { groupValuesByDateColumn } from './operations/groupByDate';
 
+export { SpatialIndex } from './operations/constants/SpatialIndexTypes';
+
 export {
   FEATURE_SELECTION_MODES,
   EDIT_MODES,


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/233636/c4r-h3-qk-qint-support-usecartolayerprops-to-pass-param

Adapt useCartoLayerProps to support Spatial Index
- 8.8.0-alpha.6 DeckGl version is required.
- At high zoom levels we can get failed requests. Check this thread https://cartoteam.slack.com/archives/C035NAP4YHZ/p1654682511529729
- Remember that to test tables with spatial index the `geoColumn` and the `aggregationExp` are mandatories but are no necessary for static tilesets with spatial index

## Type of change
- Feature