### PR TITLE
Use en dash for intervals instead of hyphen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Spatial index support for useCartoLayerProps [#425](https://github.com/CartoDB/carto-react/pull/425)
 - Ensure source exists in HistogramWidget before getting stats [#426](https://github.com/CartoDB/carto-react/pull/426)
+- Use en dash for intervals instead of hyphen [#428](https://github.com/CartoDB/carto-react/pull/428)
 
 ## 1.3
 

--- a/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
@@ -346,7 +346,7 @@ function defaultTooltipFormatter(params, xAxisFormatter, yAxisFormatter) {
   }
 
   const [left, right, value] = params.data.value;
-  const title = `${processFormatterRes(xAxisFormatter(left))} - ${processFormatterRes(
+  const title = `${processFormatterRes(xAxisFormatter(left))} — ${processFormatterRes(
     xAxisFormatter(right)
   )}`;
   const formattedValue = processFormatterRes(yAxisFormatter(value));


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/9151432/173010349-4264146a-3166-41dc-83a7-3a7e73b2c792.png)

After:

![image](https://user-images.githubusercontent.com/9151432/173012406-21b0b037-f8e7-453b-b5af-484b927e8818.png)
