### PR TITLE
Check null value to avoid crash on category widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Fix CategoryWidget search if there are null values [#439](https://github.com/CartoDB/carto-react/pull/439)
 - Layout improvements in BarWidgetUI [#438](https://github.com/CartoDB/carto-react/pull/438)
 - Fix FormulaWidget column check [#437](https://github.com/CartoDB/carto-react/pull/437)
 

--- a/packages/react-ui/src/widgets/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI.js
@@ -272,7 +272,8 @@ function CategoryWidgetUI(props) {
           ? list.filter((elem) => {
               return (
                 elem.name !== null &&
-                (elem.name?.toLowerCase().indexOf(searchValue.toLowerCase()) !== -1 ||
+                elem.name !== undefined &&
+                (elem.name.toLowerCase().indexOf(searchValue.toLowerCase()) !== -1 ||
                   (labels[elem.name]
                     ? labels[elem.name]
                         .toLowerCase()

--- a/packages/react-ui/src/widgets/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI.js
@@ -271,11 +271,13 @@ function CategoryWidgetUI(props) {
         return searchValue
           ? list.filter((elem) => {
               return (
-                elem.name.toLowerCase().indexOf(searchValue.toLowerCase()) !== -1 ||
-                (labels[elem.name]
-                  ? labels[elem.name].toLowerCase().indexOf(searchValue.toLowerCase()) !==
-                    -1
-                  : false)
+                elem.name !== null &&
+                (elem.name?.toLowerCase().indexOf(searchValue.toLowerCase()) !== -1 ||
+                  (labels[elem.name]
+                    ? labels[elem.name]
+                        .toLowerCase()
+                        .indexOf(searchValue.toLowerCase()) !== -1
+                    : false))
               );
             })
           : list;
@@ -614,7 +616,8 @@ CategoryWidgetUI.defaultProps = {
 CategoryWidgetUI.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
-      name: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]).isRequired,
+      name: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])
+        .isRequired,
       value: PropTypes.number
     })
   ),


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/239960/ac-pbwqze2p-carto-3-user-s-category-widget-breaking-on-search

We've encountered that there is an issue with category widgets. The whole application crashes if we use this widget filtering a column that contains null values.

## Type of change

- Fix

# Acceptance

1. Add a category widget to a map created filtering a column that contains null values
2. Check that it doesn't fail if we try to search a value in the category widget

# Basic checklist

- [x] Good PR name
- [x] Shortcut link
- [x] Changelog entry
- [x] Just one issue per PR
- [x] GitHub labels
- [x] Proper status & reviewers
- [x] Tests
- [x] Documentation
