### PR TITLE
Return the spatial index ID as a property to be available for widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## Not released
-
+- Return the spatial index ID as a property to be available for widgets [#440](https://github.com/CartoDB/carto-react/pull/440)
 - Fix CategoryWidget search if there are null values [#439](https://github.com/CartoDB/carto-react/pull/439)
 - Layout improvements in BarWidgetUI [#438](https://github.com/CartoDB/carto-react/pull/438)
 - Fix FormulaWidget column check [#437](https://github.com/CartoDB/carto-react/pull/437)

--- a/packages/react-core/src/filters/tileFeatures.js
+++ b/packages/react-core/src/filters/tileFeatures.js
@@ -13,6 +13,7 @@ export function tileFeatures({
   geometry,
   uniqueIdProperty,
   tileFormat,
+  geoColumName,
   spatialIndex
 }) {
   const geometryToIntersect = getGeometryToIntersect(viewport, geometry);
@@ -22,7 +23,12 @@ export function tileFeatures({
   }
 
   if (spatialIndex) {
-    return tileFeaturesSpatialIndex({ tiles, geometryToIntersect, spatialIndex });
+    return tileFeaturesSpatialIndex({
+      tiles,
+      geometryToIntersect,
+      geoColumName,
+      spatialIndex
+    });
   }
   return tileFeaturesGeometries({
     tiles,

--- a/packages/react-core/src/filters/tileFeaturesSpatialIndex.d.ts
+++ b/packages/react-core/src/filters/tileFeaturesSpatialIndex.d.ts
@@ -5,5 +5,6 @@ import { TileFeaturesResponse } from "../types";
 export default function tileFeaturesSpatialIndex(arg: {
   tiles: any;
   geometryToIntersect: Feature<Polygon | MultiPolygon>;
+  geoColumName: string;
   spatialIndex: SpatialIndex;
 }): TileFeaturesResponse;

--- a/packages/react-core/src/filters/tileFeaturesSpatialIndex.js
+++ b/packages/react-core/src/filters/tileFeaturesSpatialIndex.js
@@ -9,10 +9,12 @@ import { SpatialIndex } from '../operations/constants/SpatialIndexTypes';
 export default function tileFeaturesSpatialIndex({
   tiles,
   geometryToIntersect,
+  geoColumName,
   spatialIndex
 }) {
   const map = new Map();
   const resolution = getResolution(tiles, spatialIndex);
+  const spatialIndexIDName = geoColumName ? geoColumName : spatialIndex;
 
   if (!resolution) {
     return [];
@@ -39,7 +41,7 @@ export default function tileFeaturesSpatialIndex({
 
     tile.data.forEach((d) => {
       if (cellsDictionary[d.id]) {
-        map.set(d.id, d.properties);
+        map.set(d.id, { ...d.properties, [spatialIndexIDName]: d.id });
       }
     });
   }

--- a/packages/react-core/src/operations/constants/SpatialIndexTypes.d.ts
+++ b/packages/react-core/src/operations/constants/SpatialIndexTypes.d.ts
@@ -2,5 +2,6 @@ export enum SpatialIndex {
   H3 = 'h3',
   S2 = 's2',
   QUADKEY = 'quadkey',
-  QUADINT = 'quadint'
+  QUADINT = 'quadint',
+  QUADBIN = 'quadbin'
 }

--- a/packages/react-core/src/operations/constants/SpatialIndexTypes.js
+++ b/packages/react-core/src/operations/constants/SpatialIndexTypes.js
@@ -2,5 +2,6 @@ export const SpatialIndex = Object.freeze({
   H3: 'h3',
   S2: 's2',
   QUADKEY: 'quadkey',
-  QUADINT: 'quadint'
+  QUADINT: 'quadint',
+  QUADBIN: 'quadbin'
 });

--- a/packages/react-core/src/types.d.ts
+++ b/packages/react-core/src/types.d.ts
@@ -26,12 +26,13 @@ export type ScatterPlotFeature = [number, number][];
 export type Viewport = [number, number, number, number];
 
 export type TileFeatures = {
-  tiles: any; // TODO: add proper deck.gl type
+  tiles?: any; // TODO: add proper deck.gl type
   viewport: Viewport;
   geometry?: Geometry;
   uniqueIdProperty?: string;
   tileFormat: TILE_FORMATS;
-  spatialIndex?: SpatialIndex
+  geoColumName?: string;
+  spatialIndex?: SpatialIndex;
 };
 
 export type TileFeaturesResponse = Record<string, unknown>[] | [];

--- a/packages/react-workers/src/workers/features.worker.js
+++ b/packages/react-workers/src/workers/features.worker.js
@@ -59,6 +59,7 @@ function getTileFeatures({
   geometry,
   uniqueIdProperty,
   tileFormat,
+  geoColumName,
   spatialIndex
 }) {
   currentFeatures = tileFeatures({
@@ -67,6 +68,7 @@ function getTileFeatures({
     geometry,
     uniqueIdProperty,
     tileFormat,
+    geoColumName,
     spatialIndex
   });
   postMessage({ result: true });


### PR DESCRIPTION
# Description
TileFeatures returns the spatial index ID as a property to be available for widgets. We name the property using the geoColumn or the scheme so we're sure that we're not going to overwrite other user property

## Type of change

- Feature