### PR TITLE
Allow organizationId for SSO carto3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Not released
 
 - Use labels to calculate BarWidgetUI margin [#444](https://github.com/CartoDB/carto-react/pull/444)
+- Allow specifying organizationId in OAuth to support SSO in carto3 [#445](https://github.com/CartoDB/carto-react/pull/445)
+
 
 ## 1.3
 

--- a/packages/react-redux/src/types.d.ts
+++ b/packages/react-redux/src/types.d.ts
@@ -26,6 +26,7 @@ type InitialCarto2State = {
 type OauthCarto3 = {
   domain: string,
   clientId: string,
+  organizationId: string,
   scopes: Array<string>
   audience: string,
   authorizeEndPoint: string


### PR DESCRIPTION
Allow to specify organizationId, to support SSO in carto3 apps