### PR TITLE
Remove xAxisFormatter use in tooltipFormatter in BarWidgetUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Remove xAxisFormatter use in tooltipFormatter in BarWidgetUI [#447](https://github.com/CartoDB/carto-react/pull/447)
+
 ## 1.3
 
 ### 1.3.0-beta.5 (2022-07-05)

--- a/packages/react-ui/src/widgets/BarWidgetUI.js
+++ b/packages/react-ui/src/widgets/BarWidgetUI.js
@@ -78,10 +78,10 @@ function BarWidgetUI(props) {
         return position;
       },
       formatter(params) {
-        return tooltipFormatter(params, xAxisFormatter, yAxisFormatter);
+        return tooltipFormatter(params, yAxisFormatter);
       }
     }),
-    [theme, tooltip, tooltipFormatter, xAxisFormatter, yAxisFormatter]
+    [theme, tooltip, tooltipFormatter, yAxisFormatter]
   );
 
   // xAxis
@@ -376,13 +376,13 @@ function calculateMargin(label = '', amountCategories = 0) {
   return (label.length * 8.5) / 6;
 }
 
-function defaultTooltipFormatter(params, xAxisFormatter, yAxisFormatter) {
+function defaultTooltipFormatter(params, yAxisFormatter) {
   if (!params || !params?.length) {
     return null;
   }
 
   let message = '';
-  message += `${processFormatterRes(xAxisFormatter(params[0].axisValueLabel))}`;
+  message += params[0].axisValueLabel;
   message += params
     .map(({ seriesName, value, data, marker }) => {
       const formattedSeriesName = seriesName ? seriesName + ': ' : '';


### PR DESCRIPTION
Due to we already process x axis labels before adding them in the echarts structure, we no longer need to apply the x axis formatting in the tooltip Formatter.