### PR TITLE
Fix updateLayer reducer to allow remove the legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Fix updateLayer reducer to allow remove the legend [#448](https://github.com/CartoDB/carto-react/pull/448)
 - Remove xAxisFormatter use in tooltipFormatter in BarWidgetUI [#447](https://github.com/CartoDB/carto-react/pull/447)
 
 ## 1.3

--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -82,18 +82,18 @@ export const createCartoSlice = (initialState) => {
       },
       updateLayer: (state, action) => {
         const layer = state.layers[action.payload.id];
-        if (layer)
+        if (layer) {
+          const newLayerAttrs = action.payload.layerAttributes;
+          const newLayer = { ...layer, ...newLayerAttrs };
+
           // TODO: Study if we should use a deepmerge fn
           state.layers[action.payload.id] = {
-            ...layer,
-            ...action.payload.layerAttributes,
-            ...(layer.legend && {
-              legend: {
-                ...layer.legend,
-                ...action.payload.layerAttributes.legend
-              }
+            ...newLayer,
+            ...(newLayer.legend && {
+              legend: { ...newLayer.legend, ...newLayerAttrs.legend }
             })
           };
+        }
       },
       removeLayer: (state, action) => {
         delete state.layers[action.payload];

--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -83,14 +83,13 @@ export const createCartoSlice = (initialState) => {
       updateLayer: (state, action) => {
         const layer = state.layers[action.payload.id];
         if (layer) {
-          const newLayerAttrs = action.payload.layerAttributes;
-          const newLayer = { ...layer, ...newLayerAttrs };
+          const newLayer = { ...layer, ...action.payload.layerAttributes };
 
           // TODO: Study if we should use a deepmerge fn
           state.layers[action.payload.id] = {
             ...newLayer,
             ...(newLayer.legend && {
-              legend: { ...newLayer.legend, ...newLayerAttrs.legend }
+              legend: { ...layer.legend, ...newLayer.legend }
             })
           };
         }

--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -88,7 +88,7 @@ export const createCartoSlice = (initialState) => {
           // TODO: Study if we should use a deepmerge fn
           state.layers[action.payload.id] = {
             ...newLayer,
-            ...(newLayer.legend && {
+            ...(layer.legend && newLayer.legend && {
               legend: { ...layer.legend, ...newLayer.legend }
             })
           };


### PR DESCRIPTION
Using the current code if you want to remove the legend, you cannot do it because once the layer is added, this code `...(layer.legend && {` is always true.