### PR TITLE
LegendCategories: support for custom markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Not released
 
+- LegendCategories: support for custom markers [#451](https://github.com/CartoDB/carto-react/pull/451)
+
+## 1.4
 ## 1.3
 
 ### 1.3.0 (2022-07-11)

--- a/packages/react-ui/__tests__/widgets/legend/LegendCategories.test.js
+++ b/packages/react-ui/__tests__/widgets/legend/LegendCategories.test.js
@@ -40,4 +40,16 @@ describe('LegendCategories', () => {
       expect(elements[idx]).toHaveStyle(`border-color: ${color}`)
     );
   });
+  test('renders icons correctly', () => {
+    render(
+      <LegendCategories
+        legend={{ ...DEFAULT_LEGEND, customMarkers: 'https://xyz.com/x.png' }}
+      />
+    );
+    const elements = document.querySelectorAll('[class*="markerIcon"]');
+    getPalette(COLOR, 2).forEach((color, idx) => {
+      expect(elements[idx]).toHaveStyle(`mask-image: url(https://xyz.com/x.png)`);
+      expect(elements[idx]).toHaveStyle(`background-color: ${color}`);
+    });
+  });
 });

--- a/packages/react-ui/__tests__/widgets/legend/LegendCategories.test.js
+++ b/packages/react-ui/__tests__/widgets/legend/LegendCategories.test.js
@@ -20,22 +20,21 @@ describe('LegendCategories', () => {
   });
   test('renders colors (CARTOColors) correctly', () => {
     render(<LegendCategories legend={DEFAULT_LEGEND} />);
-    const elements = document.querySelectorAll('[class*="markerCircle"]');
+    const elements = document.querySelectorAll('[class*="marker"]');
     getPalette(COLOR, 2).forEach((color, idx) =>
       expect(elements[idx]).toHaveStyle(`background-color: ${color}`)
     );
   });
   test('renders colors (hex) correctly', () => {
     render(<LegendCategories legend={{ ...DEFAULT_LEGEND, colors: ['#000', '#fff'] }} />);
-    const [firstCategory, secondCategory] = document.querySelectorAll(
-      '[class*="markerCircle"]'
-    );
+    const [firstCategory, secondCategory] =
+      document.querySelectorAll('[class*="marker"]');
     expect(firstCategory).toHaveStyle('background-color: #000;');
     expect(secondCategory).toHaveStyle('background-color: #fff;');
   });
   test('renders stroked colors correctly', () => {
     render(<LegendCategories legend={{ ...DEFAULT_LEGEND, isStrokeColor: true }} />);
-    const elements = document.querySelectorAll('[class*="markerCircle"]');
+    const elements = document.querySelectorAll('[class*="marker"]');
     getPalette(COLOR, 2).forEach((color, idx) =>
       expect(elements[idx]).toHaveStyle(`border-color: ${color}`)
     );
@@ -46,7 +45,7 @@ describe('LegendCategories', () => {
         legend={{ ...DEFAULT_LEGEND, customMarkers: 'https://xyz.com/x.png' }}
       />
     );
-    const elements = document.querySelectorAll('[class*="markerIcon"]');
+    const elements = document.querySelectorAll('[class*="marker"]');
     getPalette(COLOR, 2).forEach((color, idx) => {
       expect(elements[idx]).toHaveStyle(`mask-image: url(https://xyz.com/x.png)`);
       expect(elements[idx]).toHaveStyle(`background-color: ${color}`);

--- a/packages/react-ui/__tests__/widgets/legend/LegendCategories.test.js
+++ b/packages/react-ui/__tests__/widgets/legend/LegendCategories.test.js
@@ -20,21 +20,22 @@ describe('LegendCategories', () => {
   });
   test('renders colors (CARTOColors) correctly', () => {
     render(<LegendCategories legend={DEFAULT_LEGEND} />);
-    const elements = document.querySelectorAll('[class*="circle"]');
+    const elements = document.querySelectorAll('[class*="markerCircle"]');
     getPalette(COLOR, 2).forEach((color, idx) =>
       expect(elements[idx]).toHaveStyle(`background-color: ${color}`)
     );
   });
   test('renders colors (hex) correctly', () => {
     render(<LegendCategories legend={{ ...DEFAULT_LEGEND, colors: ['#000', '#fff'] }} />);
-    const [firstCategory, secondCategory] =
-      document.querySelectorAll('[class*="circle"]');
+    const [firstCategory, secondCategory] = document.querySelectorAll(
+      '[class*="markerCircle"]'
+    );
     expect(firstCategory).toHaveStyle('background-color: #000;');
     expect(secondCategory).toHaveStyle('background-color: #fff;');
   });
   test('renders stroked colors correctly', () => {
     render(<LegendCategories legend={{ ...DEFAULT_LEGEND, isStrokeColor: true }} />);
-    const elements = document.querySelectorAll('[class*="circle"]');
+    const elements = document.querySelectorAll('[class*="markerCircle"]');
     getPalette(COLOR, 2).forEach((color, idx) =>
       expect(elements[idx]).toHaveStyle(`border-color: ${color}`)
     );

--- a/packages/react-ui/src/widgets/legend/LegendCategories.js
+++ b/packages/react-ui/src/widgets/legend/LegendCategories.js
@@ -66,8 +66,13 @@ const useStyles = makeStyles((theme) => ({
   marker: {
     whiteSpace: 'nowrap',
     display: 'block',
+    width: '12px',
+    height: '12px',
+    borderRadius: '50%',
     position: 'relative',
-
+    border: '2px solid transparent'
+  },
+  circle: {
     '&::after': {
       position: 'absolute',
       display: ({ isMax }) => (isMax ? 'block' : 'none'),
@@ -80,15 +85,9 @@ const useStyles = makeStyles((theme) => ({
       boxSizing: 'content-box'
     }
   },
-  markerCircle: {
-    width: '12px',
-    height: '12px',
-    border: '2px solid transparent',
-    borderRadius: '50%'
-  },
-  markerIcon: {
-    width: '16px',
-    height: '16px'
+  icon: {
+    maskRepeat: 'no-repeat',
+    maskSize: 'cover'
   },
   flexParent: {
     display: 'flex',
@@ -135,19 +134,12 @@ function Row({ label, isMax, isStrokeColor, color = '#000', icon }) {
           <Box
             mr={1.5}
             component='span'
-            className={[
-              classes.marker,
-              icon ? classes.markerIcon : classes.markerCircle
-            ].join(' ')}
+            className={[classes.marker, icon ? classes.icon : classes.circle].join(' ')}
             style={
               icon
                 ? {
                     backgroundColor: color,
-                    maskRepeat: 'no-repeat',
-                    maskSize: 'cover',
                     maskImage: `url(${icon})`,
-                    WebkitMaskRepeat: 'no-repeat',
-                    WebkitMaskSize: 'cover',
                     WebkitMaskImage: `url(${icon})`
                   }
                 : isStrokeColor

--- a/packages/react-ui/src/widgets/legend/LegendCategories.js
+++ b/packages/react-ui/src/widgets/legend/LegendCategories.js
@@ -4,7 +4,7 @@ import { getPalette } from '../../utils/palette';
 import PropTypes from 'prop-types';
 
 function LegendCategories({ legend }) {
-  const { labels = [], colors = [], isStrokeColor = false } = legend;
+  const { labels = [], colors = [], isStrokeColor = false, customMarkers } = legend;
 
   const palette = getPalette(colors, labels.length);
 
@@ -14,6 +14,9 @@ function LegendCategories({ legend }) {
       isMax={false}
       label={label}
       color={palette[idx]}
+      icon={
+        customMarkers && Array.isArray(customMarkers) ? customMarkers[idx] : customMarkers
+      }
       isStrokeColor={isStrokeColor}
     />
   ));
@@ -42,6 +45,10 @@ LegendCategories.propTypes = {
   legend: PropTypes.shape({
     labels: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
     colors: PropTypes.oneOfType([PropTypes.arrayOf(ColorType), PropTypes.string]),
+    customMarkers: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.string),
+      PropTypes.string
+    ]),
     isStrokeColor: PropTypes.bool
   }).isRequired
 };
@@ -56,14 +63,11 @@ const useStyles = makeStyles((theme) => ({
       '& $circle': {}
     }
   },
-  circle: {
+  marker: {
     whiteSpace: 'nowrap',
     display: 'block',
-    width: '12px',
-    height: '12px',
-    borderRadius: '50%',
     position: 'relative',
-    border: '2px solid transparent',
+
     '&::after': {
       position: 'absolute',
       display: ({ isMax }) => (isMax ? 'block' : 'none'),
@@ -75,6 +79,16 @@ const useStyles = makeStyles((theme) => ({
       borderRadius: '50%',
       boxSizing: 'content-box'
     }
+  },
+  markerCircle: {
+    width: '12px',
+    height: '12px',
+    border: '2px solid transparent',
+    borderRadius: '50%'
+  },
+  markerIcon: {
+    width: '16px',
+    height: '16px'
   },
   flexParent: {
     display: 'flex',
@@ -94,7 +108,7 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-function Row({ label, isMax, isStrokeColor, color = '#000' }) {
+function Row({ label, isMax, isStrokeColor, color = '#000', icon }) {
   const classes = useStyles({ isMax });
 
   const [showTooltip, setShowTooltip] = useState(false);
@@ -121,8 +135,25 @@ function Row({ label, isMax, isStrokeColor, color = '#000' }) {
           <Box
             mr={1.5}
             component='span'
-            className={classes.circle}
-            style={isStrokeColor ? { borderColor: color } : { backgroundColor: color }}
+            className={[
+              classes.marker,
+              icon ? classes.markerIcon : classes.markerCircle
+            ].join(' ')}
+            style={
+              icon
+                ? {
+                    backgroundColor: color,
+                    maskRepeat: 'no-repeat',
+                    maskSize: 'cover',
+                    maskImage: `url(${icon})`,
+                    WebkitMaskRepeat: 'no-repeat',
+                    WebkitMaskSize: 'cover',
+                    WebkitMaskImage: `url(${icon})`
+                  }
+                : isStrokeColor
+                ? { borderColor: color }
+                : { backgroundColor: color }
+            }
           />
         </Tooltip>
         <Typography ref={labelRef} variant='overline' className={classes.longTruncate}>


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/244132/implement-support-for-markers-in-builder-i-single-icon

Add support for rendering of 'masked colored icons' in `LegendCategories` widget instead of classic circles.

Rationale: This feature is needed in builder and it's simpler to implement here as we already use  `LegendCategories` as a whole.

Needed by: https://github.com/CartoDB/cloud-native/pull/8559

![image](https://user-images.githubusercontent.com/1507542/178751071-319022af-94c5-4970-b6aa-6a6b3c8a165c.png)

## Type of change

(choose one and remove the others)

- Feature

# Acceptance

-

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
