### PR TITLE
release 1.4.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Not released
 
+## 1.4
+
+### 1.4.0-alpha.1 (2022-07-13)
+
 - LegendCategories: support for custom markers [#451](https://github.com/CartoDB/carto-react/pull/451)
 
-## 1.4
 ## 1.3
 
 ### 1.3.0 (2022-07-11)

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "1.3.0"
+  "version": "1.4.0-alpha.1"
 }

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-api",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "CARTO for React - Api",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -64,9 +64,9 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^1.3.0",
-    "@carto/react-redux": "^1.3.0",
-    "@carto/react-workers": "^1.3.0",
+    "@carto/react-core": "^1.4.0-alpha.1",
+    "@carto/react-redux": "^1.4.0-alpha.1",
+    "@carto/react-workers": "^1.4.0-alpha.1",
     "@deck.gl/carto": "^8.8.0",
     "@deck.gl/core": "^8.8.0",
     "@deck.gl/extensions": "^8.8.0",

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-auth",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "CARTO for React - Auth",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -64,7 +64,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^1.3.0",
+    "@carto/react-core": "^1.4.0-alpha.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   }

--- a/packages/react-basemaps/package.json
+++ b/packages/react-basemaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-basemaps",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "CARTO for React - Basemaps",
   "keywords": [
     "carto",
@@ -64,7 +64,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^1.3.0",
+    "@carto/react-core": "^1.4.0-alpha.1",
     "@deck.gl/google-maps": "^8.8.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-core",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "CARTO for React - Core",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-redux",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "CARTO for React - Redux",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -63,8 +63,8 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^1.3.0",
-    "@carto/react-workers": "^1.3.0",
+    "@carto/react-core": "^1.4.0-alpha.1",
+    "@carto/react-workers": "^1.4.0-alpha.1",
     "@deck.gl/carto": "^8.8.0",
     "@deck.gl/core": "^8.8.0",
     "@reduxjs/toolkit": "^1.5.0"

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-ui",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "CARTO for React - UI",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -75,7 +75,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^1.3.0",
+    "@carto/react-core": "^1.4.0-alpha.1",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-widgets",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "CARTO for React - Widgets",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -65,11 +65,11 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-api": "^1.3.0",
-    "@carto/react-core": "^1.3.0",
-    "@carto/react-redux": "^1.3.0",
-    "@carto/react-ui": "^1.3.0",
-    "@carto/react-workers": "^1.3.0",
+    "@carto/react-api": "^1.4.0-alpha.1",
+    "@carto/react-core": "^1.4.0-alpha.1",
+    "@carto/react-redux": "^1.4.0-alpha.1",
+    "@carto/react-ui": "^1.4.0-alpha.1",
+    "@carto/react-workers": "^1.4.0-alpha.1",
     "@deck.gl/core": "^8.8.0",
     "@deck.gl/layers": "^8.8.0",
     "@material-ui/core": "^4.11.3",

--- a/packages/react-workers/package.json
+++ b/packages/react-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-workers",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.1",
   "description": "CARTO for React - Workers",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.9",
-    "@carto/react-core": "^1.3.0",
+    "@carto/react-core": "^1.4.0-alpha.1",
     "@turf/bbox-polygon": "^6.3.0",
     "@turf/boolean-intersects": "^6.3.0",
     "@turf/boolean-within": "^6.3.0",


### PR DESCRIPTION
Release  1.4.0-alpha.1 with following CRs: 

* https://github.com/CartoDB/carto-react/pull/451