### PR TITLE
SQL queryParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## Not released
-
+- Support for SQL queryParameters
 ## 1.4
 
 ### 1.4.0-alpha.1 (2022-07-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 
 ## Not released
-- Support for SQL queryParameters
+- Support for SQL queryParameters [#461](https://github.com/CartoDB/carto-react/pull/461)
+
 ## 1.4
 
 ### 1.4.0-alpha.3 (2022-07-22)

--- a/packages/react-api/__tests__/api/model.test.js
+++ b/packages/react-api/__tests__/api/model.test.js
@@ -21,7 +21,7 @@ describe('model', () => {
       expect(mockedMakeCall).toHaveBeenCalledWith({
         credentials: TABLE_SOURCE.credentials,
         opts: { method: 'GET' },
-        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=table&source=cartobq.public_account.seattle_collisions&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&filters=%7B%7D&filtersLogicalOperator=AND'
+        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=table&source=cartobq.public_account.seattle_collisions&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&filters=%7B%7D&queryParameters=undefined&filtersLogicalOperator=AND'
       });
     });
 
@@ -31,7 +31,7 @@ describe('model', () => {
       expect(mockedMakeCall).toHaveBeenCalledWith({
         credentials: TABLE_SOURCE.credentials,
         opts: { method: 'GET' },
-        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=query&source=SELECT+*+FROM+%60cartobq.public_account.seattle_collisions%60&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&filters=%7B%7D&filtersLogicalOperator=AND'
+        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=query&source=SELECT+*+FROM+%60cartobq.public_account.seattle_collisions%60&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&queryParameters=undefined&filters=%7B%7D&filtersLogicalOperator=AND'
       });
     });
 

--- a/packages/react-api/__tests__/api/model.test.js
+++ b/packages/react-api/__tests__/api/model.test.js
@@ -21,7 +21,7 @@ describe('model', () => {
       expect(mockedMakeCall).toHaveBeenCalledWith({
         credentials: TABLE_SOURCE.credentials,
         opts: { method: 'GET' },
-        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=table&source=cartobq.public_account.seattle_collisions&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&filters=%7B%7D&queryParameters=undefined&filtersLogicalOperator=AND'
+        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=table&source=cartobq.public_account.seattle_collisions&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&queryParameters=&filters=%7B%7D&filtersLogicalOperator=AND'
       });
     });
 
@@ -31,13 +31,14 @@ describe('model', () => {
       expect(mockedMakeCall).toHaveBeenCalledWith({
         credentials: TABLE_SOURCE.credentials,
         opts: { method: 'GET' },
-        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=query&source=SELECT+*+FROM+%60cartobq.public_account.seattle_collisions%60&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&filters=%7B%7D&queryParameters=undefined&filtersLogicalOperator=AND'
+        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=query&source=SELECT+*+FROM+%60cartobq.public_account.seattle_collisions%60&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&queryParameters=&filters=%7B%7D&filtersLogicalOperator=AND'
       });
     });
 
     test('works correctly when the source is very large', () => {
       const longQuerySource = {
         ...QUERY_SOURCE,
+        queryParameters: '',
         data: 'a'.repeat(2048)
       };
 
@@ -51,6 +52,7 @@ describe('model', () => {
             type: 'query',
             source: longQuerySource.data,
             params: JSON.stringify(DEFAULT_PARAMS),
+            queryParameters: '',
             filters: JSON.stringify(longQuerySource.filters),
             filtersLogicalOperator: longQuerySource.filtersLogicalOperator
           })

--- a/packages/react-api/__tests__/api/model.test.js
+++ b/packages/react-api/__tests__/api/model.test.js
@@ -1,5 +1,5 @@
 import { executeModel } from '../../src/api/model';
-import { QUERY_SOURCE, TABLE_SOURCE, TILESET_SOURCE } from '../dataMocks';
+import { QUERY_PARAMS_SOURCE, QUERY_SOURCE, TABLE_SOURCE, TILESET_SOURCE } from '../dataMocks';
 
 const mockedMakeCall = jest.fn();
 
@@ -38,7 +38,6 @@ describe('model', () => {
     test('works correctly when the source is very large', () => {
       const longQuerySource = {
         ...QUERY_SOURCE,
-        queryParameters: '',
         data: 'a'.repeat(2048)
       };
 
@@ -58,6 +57,17 @@ describe('model', () => {
           })
         },
         url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula'
+      });
+    });
+
+
+    test('works correctly when the source has queryParameters', () => {
+      executeModel({ model: 'formula', source: QUERY_PARAMS_SOURCE, params: DEFAULT_PARAMS });
+
+      expect(mockedMakeCall).toHaveBeenCalledWith({
+        credentials: TABLE_SOURCE.credentials,
+        opts: { method: 'GET' },
+        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=query&source=SELECT+*+FROM+%60cartobq.public_account.seattle_collisions%60+WHERE+time_column+%3E+%40start+AND+time_column+%3C+%40end&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&queryParameters=%7B%22start%22%3A%222019-01-01%22%2C%22end%22%3A%222019-01-02%22%7D&filters=%7B%7D&filtersLogicalOperator=AND'
       });
     });
 

--- a/packages/react-api/__tests__/api/model.test.js
+++ b/packages/react-api/__tests__/api/model.test.js
@@ -31,7 +31,7 @@ describe('model', () => {
       expect(mockedMakeCall).toHaveBeenCalledWith({
         credentials: TABLE_SOURCE.credentials,
         opts: { method: 'GET' },
-        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=query&source=SELECT+*+FROM+%60cartobq.public_account.seattle_collisions%60&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&queryParameters=undefined&filters=%7B%7D&filtersLogicalOperator=AND'
+        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=query&source=SELECT+*+FROM+%60cartobq.public_account.seattle_collisions%60&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&filters=%7B%7D&queryParameters=undefined&filtersLogicalOperator=AND'
       });
     });
 

--- a/packages/react-api/__tests__/dataMocks.js
+++ b/packages/react-api/__tests__/dataMocks.js
@@ -24,6 +24,20 @@ export const QUERY_SOURCE = {
   }
 };
 
+export const QUERY_PARAMS_SOURCE = {
+  type: 'query',
+  data: 'SELECT * FROM `cartobq.public_account.seattle_collisions` WHERE time_column > @start AND time_column < @end',
+  connection: 'carto-ps-bq-developers',
+  filters: {},
+  queryParameters: {'start': '2019-01-01', 'end': '2019-01-02'},
+  filtersLogicalOperator: 'AND',
+  credentials: {
+    accessToken: '__test_api_key__',
+    apiBaseUrl: 'https://gcp-us-east1.api.carto.com',
+    apiVersion: 'v3'
+  }
+};
+
 export const TILESET_SOURCE = {
   type: 'tileset',
   data: 'cartobq.public_account.pois',

--- a/packages/react-api/__tests__/hooks/useCartoLayerProps.test.js
+++ b/packages/react-api/__tests__/hooks/useCartoLayerProps.test.js
@@ -23,6 +23,7 @@ describe('useCartoLayerProps', () => {
       'connection',
       'credentials',
       'clientId',
+      'queryParameters',
       'filterRange',
       'updateTriggers',
       'getFilterValue',

--- a/packages/react-api/src/api/SQL.d.ts
+++ b/packages/react-api/src/api/SQL.d.ts
@@ -1,4 +1,4 @@
-import { Credentials, ExecuteSQLResponse, QueryParameter } from '../types';
+import { Credentials, ExecuteSQLResponse, QueryParameters } from '../types';
 import { FeatureCollection } from 'geojson';
 
 export function executeSQL<Response = FeatureCollection | {}[]>({
@@ -12,5 +12,5 @@ export function executeSQL<Response = FeatureCollection | {}[]>({
   query: string;
   connection?: string;
   opts?: unknown;
-  queryParameters?: QueryParameter[];
+  queryParameters?: QueryParameters;
 }): ExecuteSQLResponse<Response>;

--- a/packages/react-api/src/api/SQL.d.ts
+++ b/packages/react-api/src/api/SQL.d.ts
@@ -1,14 +1,16 @@
-import { Credentials, ExecuteSQLResponse } from '../types';
+import { Credentials, ExecuteSQLResponse, QueryParameter } from '../types';
 import { FeatureCollection } from 'geojson';
 
 export function executeSQL<Response = FeatureCollection | {}[]>({
   credentials,
   query,
   connection,
-  opts
+  opts,
+  queryParameters
 }: {
   credentials: Credentials;
   query: string;
   connection?: string;
   opts?: unknown;
+  queryParameters?: QueryParameter[];
 }): ExecuteSQLResponse<Response>;

--- a/packages/react-api/src/api/SQL.js
+++ b/packages/react-api/src/api/SQL.js
@@ -18,7 +18,7 @@ const DEFAULT_USER_COMPONENT_IN_URL = '{user}';
  * @param { string } props.query - SQL query to be executed
  * @param { string } props.connection - connection name required for CARTO cloud native
  * @param { Object } props.opts - Additional options for the HTTP request
- * @param { import('../types').QueryParameter[] } props.queryParameters - SQL query parameters
+ * @param { import('@deck.gl/carto').QueryParameters } props.queryParameters - SQL query parameters
  */
 export const executeSQL = async ({ credentials, query, connection, opts, queryParameters }) => {
   let response;

--- a/packages/react-api/src/api/SQL.js
+++ b/packages/react-api/src/api/SQL.js
@@ -18,8 +18,9 @@ const DEFAULT_USER_COMPONENT_IN_URL = '{user}';
  * @param { string } props.query - SQL query to be executed
  * @param { string } props.connection - connection name required for CARTO cloud native
  * @param { Object } props.opts - Additional options for the HTTP request
+ * @param { import('../types').QueryParameter[] } props.queryParameters - SQL query parameters
  */
-export const executeSQL = async ({ credentials, query, connection, opts }) => {
+export const executeSQL = async ({ credentials, query, connection, opts, queryParameters }) => {
   let response;
 
   if (!credentials) {
@@ -27,7 +28,7 @@ export const executeSQL = async ({ credentials, query, connection, opts }) => {
   }
 
   try {
-    const request = createRequest({ credentials, connection, query, opts });
+    const request = createRequest({ credentials, connection, query, opts, queryParameters });
     response = await fetch(request);
   } catch (error) {
     if (error.name === 'AbortError') throw error;
@@ -54,7 +55,7 @@ export const executeSQL = async ({ credentials, query, connection, opts }) => {
  * Create an 'SQL query' request
  * (using GET or POST request, depending on url size)
  */
-function createRequest({ credentials, connection, query, opts = {} }) {
+function createRequest({ credentials, connection, query, opts = {}, queryParameters = [] }) {
   const { abortController, ...otherOptions } = opts;
 
   const { apiVersion = API_VERSIONS.V2 } = credentials;
@@ -62,7 +63,8 @@ function createRequest({ credentials, connection, query, opts = {} }) {
   const rawParams = {
     client: CLIENT,
     q: query?.trim(),
-    ...otherOptions
+    ...otherOptions,
+    queryParameters: queryParameters ? JSON.stringify(queryParameters) : undefined
   };
 
   if (apiVersion === API_VERSIONS.V3) {

--- a/packages/react-api/src/api/common.js
+++ b/packages/react-api/src/api/common.js
@@ -28,7 +28,7 @@ export function checkCredentials(credentials) {
   }
 }
 
-export async function makeCall({ url, credentials, opts }) {
+export async function makeCall({ url, credentials, opts, queryParameters }) {
   let response;
   let data;
   try {
@@ -37,7 +37,8 @@ export async function makeCall({ url, credentials, opts }) {
         Authorization: `Bearer ${credentials.accessToken}`
       },
       signal: opts?.abortController?.signal,
-      ...opts?.otherOptions
+      queryParameters: queryParameters ? JSON.stringify(queryParameters) : undefined,
+      ...opts?.otherOptions,
     });
     data = await response.json();
   } catch (error) {

--- a/packages/react-api/src/api/common.js
+++ b/packages/react-api/src/api/common.js
@@ -28,7 +28,7 @@ export function checkCredentials(credentials) {
   }
 }
 
-export async function makeCall({ url, credentials, opts, queryParameters }) {
+export async function makeCall({ url, credentials, opts }) {
   let response;
   let data;
   try {
@@ -37,7 +37,6 @@ export async function makeCall({ url, credentials, opts, queryParameters }) {
         Authorization: `Bearer ${credentials.accessToken}`
       },
       signal: opts?.abortController?.signal,
-      queryParameters,
       ...opts?.otherOptions,
     });
     data = await response.json();

--- a/packages/react-api/src/api/common.js
+++ b/packages/react-api/src/api/common.js
@@ -37,7 +37,7 @@ export async function makeCall({ url, credentials, opts, queryParameters }) {
         Authorization: `Bearer ${credentials.accessToken}`
       },
       signal: opts?.abortController?.signal,
-      queryParameters: queryParameters ? JSON.stringify(queryParameters) : undefined,
+      queryParameters,
       ...opts?.otherOptions,
     });
     data = await response.json();

--- a/packages/react-api/src/api/model.js
+++ b/packages/react-api/src/api/model.js
@@ -14,7 +14,7 @@ const AVAILABLE_MODELS = ['category', 'histogram', 'formula', 'timeseries', 'ran
  * @param { object } props.source - source that owns the column
  * @param { object } props.params - widget's props
  * @param { object= } props.opts - Additional options for the HTTP request
- * @param { import('../types').QueryParameter[] } props.queryParameters - sql query parameters
+ * @param { import('@deck.gl/carto').QueryParameters } props.queryParameters - sql query parameters
  */
 export function executeModel(props) {
   assert(props.source, 'executeModel: missing source');

--- a/packages/react-api/src/api/model.js
+++ b/packages/react-api/src/api/model.js
@@ -51,7 +51,6 @@ export function executeModel(props) {
   };
 
   const isGet = url.length + JSON.stringify(queryParams).length <= URL_LENGTH;
-
   if (isGet) {
     url += '?' + new URLSearchParams(queryParams).toString();
   }
@@ -62,7 +61,6 @@ export function executeModel(props) {
       ...opts,
       method: isGet ? 'GET' : 'POST',
       ...(!isGet && { body: JSON.stringify(queryParams) })
-    },
-    queryParameters: queryParameters
+    }
   });
 }

--- a/packages/react-api/src/api/model.js
+++ b/packages/react-api/src/api/model.js
@@ -14,7 +14,6 @@ const AVAILABLE_MODELS = ['category', 'histogram', 'formula', 'timeseries', 'ran
  * @param { object } props.source - source that owns the column
  * @param { object } props.params - widget's props
  * @param { object= } props.opts - Additional options for the HTTP request
- * @param { import('@deck.gl/carto').QueryParameters } props.queryParameters - sql query parameters
  */
 export function executeModel(props) {
   assert(props.source, 'executeModel: missing source');
@@ -28,7 +27,7 @@ export function executeModel(props) {
     )}`
   );
 
-  const { source, model, params, queryParameters, opts } = props;
+  const { source, model, params, opts } = props;
 
   checkCredentials(source.credentials);
 
@@ -40,13 +39,13 @@ export function executeModel(props) {
 
   let url = `${source.credentials.apiBaseUrl}/v3/sql/${source.connection}/model/${model}`;
 
-  const { filters, filtersLogicalOperator, data, type } = source;
-
+  const { filters, filtersLogicalOperator, data, type } = source;  
+  const queryParameters = source.queryParameters ? JSON.stringify(source.queryParameters) : ''
   const queryParams = {
     type,
     source: data,
     params: JSON.stringify(params),
-    queryParameters: JSON.stringify(queryParameters),
+    queryParameters,
     filters: JSON.stringify(filters),
     filtersLogicalOperator
   };
@@ -56,7 +55,6 @@ export function executeModel(props) {
   if (isGet) {
     url += '?' + new URLSearchParams(queryParams).toString();
   }
-
   return makeCall({
     url,
     credentials: source.credentials,
@@ -64,6 +62,7 @@ export function executeModel(props) {
       ...opts,
       method: isGet ? 'GET' : 'POST',
       ...(!isGet && { body: JSON.stringify(queryParams) })
-    }
+    },
+    queryParameters: queryParameters
   });
 }

--- a/packages/react-api/src/api/model.js
+++ b/packages/react-api/src/api/model.js
@@ -14,6 +14,7 @@ const AVAILABLE_MODELS = ['category', 'histogram', 'formula', 'timeseries', 'ran
  * @param { object } props.source - source that owns the column
  * @param { object } props.params - widget's props
  * @param { object= } props.opts - Additional options for the HTTP request
+ * @param { import('../types').QueryParameter[] } props.queryParameters - sql query parameters
  */
 export function executeModel(props) {
   assert(props.source, 'executeModel: missing source');
@@ -27,7 +28,7 @@ export function executeModel(props) {
     )}`
   );
 
-  const { source, model, params, opts } = props;
+  const { source, model, params, queryParameters, opts } = props;
 
   checkCredentials(source.credentials);
 
@@ -45,6 +46,7 @@ export function executeModel(props) {
     type,
     source: data,
     params: JSON.stringify(params),
+    queryParameters: JSON.stringify(queryParameters),
     filters: JSON.stringify(filters),
     filtersLogicalOperator
   };

--- a/packages/react-api/src/api/stats.js
+++ b/packages/react-api/src/api/stats.js
@@ -37,7 +37,7 @@ export async function getStats(props) {
   } else {
     const url = buildUrl(source, column);
 
-    return makeCall({ url, credentials: source.credentials, opts });
+    return makeCall({ url, credentials: source.credentials, opts, queryParameters: source.queryParameters });
   }
 }
 

--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -76,6 +76,7 @@ export default function useCartoLayerProps({
     connection: source?.connection,
     credentials: source?.credentials,
     clientId: 'carto-for-react',
+    queryParameters: source?.queryParameters,
     ...dataFilterExtensionProps,
     ...maskExtensionProps,
     extensions

--- a/packages/react-api/src/types.d.ts
+++ b/packages/react-api/src/types.d.ts
@@ -1,5 +1,6 @@
 import { DataFilterExtension, MaskExtension } from '@deck.gl/extensions';
 import { MAP_TYPES, API_VERSIONS } from '@deck.gl/carto';
+import { QueryParameters } from '@deck.gl/carto';
 import { FeatureCollection } from 'geojson';
 
 interface CredentialsCarto2 {
@@ -19,18 +20,12 @@ interface CredentialsCarto3 {
 
 export type Credentials = CredentialsCarto2 | CredentialsCarto3;
 
-export type QueryParameter = {
-  value: string | number;
-  name?: string;
-  type?: string;
-};
-
 export type SourceProps = {
   data: string;
   type: MAP_TYPES.QUERY | MAP_TYPES.TABLE | MAP_TYPES.TILESET;
   connection?: string;
   credentials: Credentials;
-  queryParameters: QueryParameter[];
+  queryParameters: QueryParameters;
 };
 
 export type LayerConfig = {

--- a/packages/react-api/src/types.d.ts
+++ b/packages/react-api/src/types.d.ts
@@ -19,11 +19,18 @@ interface CredentialsCarto3 {
 
 export type Credentials = CredentialsCarto2 | CredentialsCarto3;
 
+export type QueryParameter = {
+  value: string | number;
+  name?: string;
+  type?: string;
+};
+
 export type SourceProps = {
   data: string;
   type: MAP_TYPES.QUERY | MAP_TYPES.TABLE | MAP_TYPES.TILESET;
   connection?: string;
   credentials: Credentials;
+  queryParameters: QueryParameter[];
 };
 
 export type LayerConfig = {

--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -193,6 +193,7 @@ export const createCartoSlice = (initialState) => {
  * @param {Object} credentials - (optional) Custom credentials to be used in the source
  * @param {string} connection - connection name for carto 3 source
  * @param {FiltersLogicalOperators} filtersLogicalOperator - logical operator that defines how filters for different columns are joined together
+ * @param {import('@carto/react-api/types').QueryParameter[]} queryParameters - SQL query parameters
  */
 export const addSource = ({
   id,
@@ -200,10 +201,11 @@ export const addSource = ({
   type,
   credentials,
   connection,
-  filtersLogicalOperator = FiltersLogicalOperators.AND
+  filtersLogicalOperator = FiltersLogicalOperators.AND,
+  queryParameters = []
 }) => ({
   type: 'carto/addSource',
-  payload: { id, data, type, credentials, connection, filtersLogicalOperator }
+  payload: { id, data, type, credentials, connection, filtersLogicalOperator, queryParameters }
 });
 
 /**

--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -193,7 +193,7 @@ export const createCartoSlice = (initialState) => {
  * @param {Object} credentials - (optional) Custom credentials to be used in the source
  * @param {string} connection - connection name for carto 3 source
  * @param {FiltersLogicalOperators} filtersLogicalOperator - logical operator that defines how filters for different columns are joined together
- * @param {import('@carto/react-api/types').QueryParameter[]} queryParameters - SQL query parameters
+ * @param {import('@deck.gl/carto').QueryParameters} queryParameters - SQL query parameters
  */
 export const addSource = ({
   id,


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/245734/add-parametrized-queries-support-to-cartoreact
RFC: https://github.com/CartoDB/carto-react/issues/456

## Type of change

- Feature

# Acceptance

We should be able to send `queryParameters` along the following methods:

> SQL - executeSQL
> Hooks - useCartoLayerProps
> cartoSlice - addSource
> model - executeModel
> stats - getStats

