### PR TITLE
Use unique feature id from tileset if provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Use unique feature id from tileset if provided [#463](https://github.com/CartoDB/carto-react/pull/463)
+
 ## 1.4
 
 ### 1.4.0-alpha.4 (2022-08-02)

--- a/packages/react-core/__tests__/filters/tileFeatures.test.js
+++ b/packages/react-core/__tests__/filters/tileFeatures.test.js
@@ -1,5 +1,6 @@
 import { TILE_FORMATS } from '@deck.gl/carto';
 import { geojsonToBinary } from '@loaders.gl/gis';
+import { PagesSharp } from '@material-ui/icons';
 import { tileFeatures } from '../../src';
 import * as transformToTileCoords from '../../src/utils/transformToTileCoords';
 
@@ -350,7 +351,58 @@ describe('viewport features with binary mode', () => {
   });
 
   describe('uniqueIdProperty is undefined', () => {
-    describe('dataset has cartodb_id field', () => {
+    describe('tiles provide unique id field', () => {
+      test('linestrings', () => {
+        const linestrings = [...Array(3)].map((_, i) => ({
+          type: 'Feature',
+          geometry: {
+            type: 'LineString',
+            // prettier-ignore
+            coordinates: [[0, 0], [0, 1], [1, 2]]
+          },
+          properties: {
+            other_prop: i
+          }
+        }));
+
+        // Two tiles, linestrings[0] is present in both
+        const binaryData1 = geojsonToBinary([linestrings[0], linestrings[1]]);
+        // @ts-ignore
+        binaryData1.lines.fields = [{ id: 100 }, { id: 101 }];
+
+        const binaryData2 = geojsonToBinary([linestrings[0], linestrings[2]]);
+        // @ts-ignore
+        binaryData2.lines.fields = [{ id: 100 }, { id: 102 }];
+
+        const mockedTiles = [
+          {
+            isVisible: true,
+            data: binaryData1,
+            bbox: { west, east, north, south }
+          },
+          {
+            isVisible: true,
+            data: binaryData2,
+            bbox: { west, east, north, south }
+          }
+        ];
+
+        const properties = tileFeatures({
+          tiles: mockedTiles,
+          viewport,
+          uniqueIdProperty: undefined
+        });
+
+        // prettier-ignore
+        expect(properties).toEqual([
+          { 'other_prop': 0 },
+          { 'other_prop': 1 },
+          { 'other_prop': 2 }
+        ]);
+      });
+    });
+
+    describe('features have cartodb_id field', () => {
       test('points', () => {
         const points = [...Array(3)].map((_, i) => ({
           type: 'Feature',
@@ -386,7 +438,7 @@ describe('viewport features with binary mode', () => {
       });
     });
 
-    describe('dataset has geoid field', () => {
+    describe('features have geoid field', () => {
       test('points', () => {
         const points = [...Array(3)].map((_, i) => ({
           type: 'Feature',
@@ -422,7 +474,7 @@ describe('viewport features with binary mode', () => {
       });
     });
 
-    describe('dataset has no cartodb_id or geoid fields', () => {
+    describe('no explicit id field', () => {
       test('points', () => {
         const points = [...Array(3)].map((_, i) => ({
           type: 'Feature',

--- a/packages/react-core/__tests__/filters/tileFeatures.test.js
+++ b/packages/react-core/__tests__/filters/tileFeatures.test.js
@@ -1,6 +1,5 @@
 import { TILE_FORMATS } from '@deck.gl/carto';
 import { geojsonToBinary } from '@loaders.gl/gis';
-import { PagesSharp } from '@material-ui/icons';
 import { tileFeatures } from '../../src';
 import * as transformToTileCoords from '../../src/utils/transformToTileCoords';
 

--- a/packages/react-core/src/filters/tileFeaturesGeometries.js
+++ b/packages/react-core/src/filters/tileFeaturesGeometries.js
@@ -48,8 +48,9 @@ function getFeatureId(data, startIndex) {
 
 function getPropertiesFromTile(data, startIndex) {
   const featureId = getFeatureId(data, startIndex);
-  const { properties, numericProps } = data;
+  const { properties, numericProps, fields } = data;
   const result = {
+    uniqueId: fields?.[featureId]?.id,
     properties: properties[featureId],
     numericProps: {}
   };
@@ -69,6 +70,10 @@ function parseProperties(tileProps) {
 function getUniquePropertyValue(tileProps, uniqueIdProperty, map) {
   if (uniqueIdProperty) {
     return getValueFromTileProps(tileProps, uniqueIdProperty);
+  }
+
+  if (tileProps.uniqueId) {
+    return tileProps.uniqueId;
   }
 
   const artificialId = map.size + 1; // a counter, assumed as a valid new id


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/253930/unique-id-property-from-fields

Modify the feature filter for tiles to take into account the newly provided explicit unique ID, so features are properly identified and not counted multiple times if they intersect multiple tiles.

## Type of change

- Fix
