### PR TITLE
Add title in LegendWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## Not released
-
+- Add title in LegendWidget [#466](https://github.com/CartoDB/carto-react/pull/466)
 ## 1.4
 
 ### 1.4.0-alpha.5 (2022-09-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 - Add title in LegendWidget [#466](https://github.com/CartoDB/carto-react/pull/466)
+
 ## 1.4
 
 ### 1.4.0-alpha.5 (2022-09-02)

--- a/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
+++ b/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
@@ -53,7 +53,8 @@ function LegendWidgetUI({
   onChangeCollapsed,
   onChangeVisibility,
   onChangeOpacity,
-  onChangeLegendRowCollapsed
+  onChangeLegendRowCollapsed,
+  title
 }) {
   const classes = useStyles();
   const isSingle = layers.length === 1;
@@ -64,6 +65,7 @@ function LegendWidgetUI({
         isSingle={isSingle}
         collapsed={collapsed}
         onChangeCollapsed={onChangeCollapsed}
+        title={title}
       >
         <LegendRows
           layers={layers}
@@ -82,7 +84,8 @@ LegendWidgetUI.defaultProps = {
   layers: [],
   customLegendTypes: {},
   customLayerOptions: {},
-  collapsed: false
+  collapsed: false,
+  title: 'Layers'
 };
 
 LegendWidgetUI.propTypes = {
@@ -94,7 +97,8 @@ LegendWidgetUI.propTypes = {
   onChangeCollapsed: PropTypes.func,
   onChangeLegendRowCollapsed: PropTypes.func,
   onChangeVisibility: PropTypes.func,
-  onChangeOpacity: PropTypes.func
+  onChangeOpacity: PropTypes.func,
+  title: PropTypes.string
 };
 
 export default LegendWidgetUI;
@@ -124,7 +128,7 @@ const useStylesLegendContainer = makeStyles((theme) => ({
   }
 }));
 
-function LegendContainer({ isSingle, children, collapsed, onChangeCollapsed }) {
+function LegendContainer({ isSingle, children, collapsed, onChangeCollapsed, title }) {
   const wrapper = createRef();
   const classes = useStylesLegendContainer({
     collapsed
@@ -155,7 +159,7 @@ function LegendContainer({ isSingle, children, collapsed, onChangeCollapsed }) {
           endIcon={<LayersIcon />}
           onClick={handleExpandClick}
         >
-          <Typography variant='subtitle1'>Layers</Typography>
+          <Typography variant='subtitle1'>{title}</Typography>
         </Button>
       </Grid>
     </>

--- a/packages/react-widgets/src/widgets/LegendWidget.js
+++ b/packages/react-widgets/src/widgets/LegendWidget.js
@@ -8,6 +8,7 @@ import sortLayers from './utils/sortLayers';
 /**
  * Renders a <LegendWidget /> component
  * @param  {object} props
+ * @param  {string} [props.title] - Title of the widget
  * @param  {string} [props.className] - CSS class name
  * @param  {Object.<string, function>} [props.customLayerOptions] - Allow to add custom controls to a legend item to tweak the associated layer
  * @param  {Object.<string, function>} [props.customLegendTypes] - Allow to customise by default legend types that can be rendered
@@ -19,7 +20,8 @@ function LegendWidget({
   customLayerOptions,
   customLegendTypes,
   initialCollapsed,
-  layerOrder = []
+  layerOrder = [],
+  title
 }) {
   const dispatch = useDispatch();
   const layers = useSelector((state) =>
@@ -63,6 +65,7 @@ function LegendWidget({
 
   return (
     <LegendWidgetUI
+      title={title}
       className={className}
       customLegendTypes={customLegendTypes}
       customLayerOptions={customLayerOptions}
@@ -77,6 +80,7 @@ function LegendWidget({
 }
 
 LegendWidget.propTypes = {
+  title: PropTypes.string,
   className: PropTypes.string,
   customLegendTypes: PropTypes.objectOf(PropTypes.func),
   initialCollapsed: PropTypes.bool,


### PR DESCRIPTION
## Description

Shortcut: https://app.shortcut.com/cartoteam/story/257017/customizable-legendwidget-title

**Background**
Currently, the legend has always the Layers title.

**Problem**
In some project design we could need to change this title for other.

Designers are making designs with other titles. For example, for Spanish designs: Capas or Leyenda.
If we make an application in Spanish we don't have the chance to make the modification.
If we make a multi-language app we don't have the possibility to change the title according to the language.

**Solution**
Add an optional title property with 'Layers' as a default value to LegendWidget.

## Type of change

- Feature

# Acceptance

Please describe how to validate the feature or fix

**In your App**
1. Go to your **LegendWidget** usage and add **title** property:

The specified **title** should display in the toggle button of the LegendWidget.
If an empty string or null value are provided, there is not title to display. The button should appear without text.

```
<LegendWidget
  title={'Map Legend'}
  className={classes.legend}
/>
```

2. Check the legend of your application map in the browser:

![image](https://user-images.githubusercontent.com/10684269/189867793-7498654e-dcd0-490c-8963-6f23ed4e2455.png)