### PR TITLE
Fix how time series widget manages time zones

### DIFF
--- a/packages/react-widgets/src/widgets/TimeSeriesWidget.js
+++ b/packages/react-widgets/src/widgets/TimeSeriesWidget.js
@@ -18,6 +18,10 @@ import { columnAggregationOn } from './utils/propTypesFns';
 import useWidgetFetch from '../hooks/useWidgetFetch';
 import WidgetWithAlert from './utils/WidgetWithAlert';
 
+function getUTCTime (date) { 
+  return date.getTime() - (date.getTimezoneOffset() * 60000); 
+};
+
 // Due to the widget groups the data by a certain stepSize, when filtering
 // the filter applied must be a range that represent the grouping range.
 // For example, if you group the data by day, the range must
@@ -145,7 +149,7 @@ function TimeSeriesWidget({
             id: dataSource,
             column,
             type: FilterTypes.TIME,
-            values: [timeWindow.map((date) => date.getTime?.() || date)],
+            values: [timeWindow.map((date) => date instanceof Date ? getUTCTime(date) : date)],
             owner: id
           })
         );


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/261050/ac-7xhfwyml-carto-3-timeseries-filtering-makes-geometries-disappear

There is a problem on how we deal with dates on the time series widget. Sometimes we're receiving dates with time zones, and we're ignoring them when calling the `toDate()` function. I've added a new function so that we can get the number of milliseconds since the ECMAScript epoch, adding the proper amount of time that corresponds to the time zone.

## Type of change

(choose one and remove the others)

- [x] Fix
- Feature
- Refactor
- Tests
- Documentation

# Acceptance

Please describe how to validate the feature or fix

1. Add a time series widgets to a map created using a dataset containing dates with timezones.
2. Configure the time series widget to filter by hour/minutes.
3. Check that the dataset values are filtered correctly.

In order to complete the acceptance in CARTO 3 we have to complete the same steps from Builder.

# Basic checklist

- [x] Good PR name
- [x] Shortcut link
- [ ] Changelog entry
- [ ] Just one issue per PR
- [ ] GitHub labels
- [ ] Proper status & reviewers
- [ ] Tests
- [ ] Documentation
