### PR TITLE
Comparative Formula Widget

### DIFF
--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -72,7 +72,8 @@
     "webpack-cli": "^4.5.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.13.9"
+    "@babel/runtime": "^7.13.9",
+    "use-animate-number": "^1.0.5"
   },
   "peerDependencies": {
     "@carto/react-core": "^1.5.0-alpha.4",

--- a/packages/react-ui/src/custom-components/AnimatedNumber.js
+++ b/packages/react-ui/src/custom-components/AnimatedNumber.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import useAnimateNumber from 'use-animate-number';
+
+function countDecimals(n) {
+  if (Math.floor(n) === n) return 0;
+  return String(n).split('.')[1]?.length || 0;
+}
+
+function AnimatedNumber({ enabled, value, options, formatter }) {
+  const defaultOptions = {
+    direct: true,
+    decimals: countDecimals(value),
+    disabled: enabled === false || value === null || value === undefined
+  };
+  const [animated] = useAnimateNumber(value, { ...defaultOptions, ...options });
+  return <span>{formatter ? formatter(animated) : animated}</span>;
+}
+
+AnimatedNumber.displayName = 'AnimatedNumber';
+AnimatedNumber.defaultProps = {
+  enabled: true,
+  value: 0,
+  options: {},
+  formatter: null
+};
+
+export const animationOptionsPropTypes = PropTypes.shape({
+  duration: PropTypes.number,
+  enterance: PropTypes.bool,
+  direct: PropTypes.bool,
+  disabled: PropTypes.bool,
+  decimals: PropTypes.number
+});
+
+AnimatedNumber.propTypes = {
+  enabled: PropTypes.bool,
+  value: PropTypes.number.isRequired,
+  options: animationOptionsPropTypes,
+  formatter: PropTypes.func
+};
+
+export default AnimatedNumber;

--- a/packages/react-ui/src/index.d.ts
+++ b/packages/react-ui/src/index.d.ts
@@ -22,6 +22,7 @@ import { CHART_TYPES } from './widgets/TimeSeriesWidgetUI/utils/constants';
 import TableWidgetUI from './widgets/TableWidgetUI/TableWidgetUI';
 import NoDataAlert from './widgets/NoDataAlert';
 import FeatureSelectionWidgetUI from './widgets/FeatureSelectionWidgetUI';
+import ComparativeFormulaWidgetUI from './widgets/ComparativeFormulaWidgetUI';
 
 export {
   cartoThemeOptions,
@@ -42,6 +43,7 @@ export {
   TableWidgetUI,
   LegendWidgetUI,
   RangeWidgetUI,
+  ComparativeFormulaWidgetUI,
   LEGEND_TYPES,
   NoDataAlert,
   LegendCategories,

--- a/packages/react-ui/src/index.js
+++ b/packages/react-ui/src/index.js
@@ -14,6 +14,7 @@ import ScatterPlotWidgetUI from './widgets/ScatterPlotWidgetUI';
 import TimeSeriesWidgetUI from './widgets/TimeSeriesWidgetUI/TimeSeriesWidgetUI';
 import FeatureSelectionWidgetUI from './widgets/FeatureSelectionWidgetUI';
 import RangeWidgetUI from './widgets/RangeWidgetUI';
+import ComparativeFormulaWidgetUI from './widgets/ComparativeFormulaWidgetUI';
 import { CHART_TYPES } from './widgets/TimeSeriesWidgetUI/utils/constants';
 import TableWidgetUI from './widgets/TableWidgetUI/TableWidgetUI';
 import NoDataAlert from './widgets/NoDataAlert';
@@ -42,6 +43,7 @@ export {
   ScatterPlotWidgetUI,
   TimeSeriesWidgetUI,
   FeatureSelectionWidgetUI,
+  ComparativeFormulaWidgetUI,
   CHART_TYPES as TIME_SERIES_CHART_TYPES,
   TableWidgetUI,
   LegendWidgetUI,

--- a/packages/react-ui/src/types.d.ts
+++ b/packages/react-ui/src/types.d.ts
@@ -188,3 +188,39 @@ export type LegendRamp = {
     colors?: string | string[] | number[][];
   };
 };
+
+export type AnimationOptions = Partial<{
+  duration: number;
+  enterance: boolean;
+  direct: boolean;
+  disabled: boolean;
+  decimals: number;
+}>;
+
+type AnimatedNumber = {
+  enabled: boolean;
+  value: number;
+  options?: AnimationOptions;
+  formatter: (n: number) => React.ReactNode;
+};
+
+export type FormulaLabels = {
+  prefix?: React.ReactNode;
+  suffix?: React.ReactNode;
+  note?: React.ReactNode;
+};
+
+export type FormulaColors = {
+  [key in keyof FormulaLabels]?: string;
+} & {
+  value?: string;
+};
+
+export type ComparativeFormulaWidgetUI = {
+  data: number[];
+  labels?: FormulaLabels[];
+  colors?: FormulaColors[];
+  animated?: boolean;
+  animationOptions?: AnimationOptions;
+  formatter?: (n: number) => React.ReactNode;
+};

--- a/packages/react-ui/src/widgets/ComparativeFormulaWidgetUI.js
+++ b/packages/react-ui/src/widgets/ComparativeFormulaWidgetUI.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box, makeStyles, Typography } from '@material-ui/core';
+import { useTheme } from '@material-ui/core';
+import AnimatedNumber, {
+  animationOptionsPropTypes
+} from '../custom-components/AnimatedNumber';
+
+const IDENTITY_FN = (v) => v;
+const EMPTY_ARRAY = [];
+
+const useStyles = makeStyles((theme) => ({
+  formulaChart: {},
+  formulaGroup: {
+    '& + $formulaGroup': {
+      marginTop: theme.spacing(2)
+    }
+  },
+  firstLine: {
+    margin: 0,
+    ...theme.typography.h5,
+    fontWeight: Number(theme.typography.fontWeightMedium),
+    color: theme.palette.text.primary,
+    display: 'flex'
+  },
+  unit: {
+    marginLeft: theme.spacing(0.5)
+  },
+  unitBefore: {
+    marginLeft: 0,
+    marginRight: theme.spacing(0.5)
+  },
+  note: {
+    display: 'inline-block',
+    marginTop: theme.spacing(0.5)
+  }
+}));
+
+function ComparativeFormulaWidgetUI({
+  data = EMPTY_ARRAY,
+  labels = EMPTY_ARRAY,
+  colors = EMPTY_ARRAY,
+  animated = true,
+  animationOptions,
+  formatter = IDENTITY_FN
+}) {
+  const theme = useTheme();
+  const classes = useStyles();
+
+  function getColor(index) {
+    return colors[index] || {};
+  }
+  function getLabel(index) {
+    return labels[index] || {};
+  }
+
+  return (
+    <div className={classes.formulaChart}>
+      {data
+        .filter((n) => n !== undefined)
+        .map((d, i) => (
+          <div className={classes.formulaGroup} key={i}>
+            <div className={classes.firstLine}>
+              {getLabel(i).prefix ? (
+                <Box color={getColor(i).prefix || theme.palette.text.secondary}>
+                  <Typography
+                    color='inherit'
+                    component='span'
+                    variant='subtitle2'
+                    className={[classes.unit, classes.unitBefore].join(' ')}
+                  >
+                    {getLabel(i).prefix}
+                  </Typography>
+                </Box>
+              ) : null}
+              <Box color={getColor(i).value}>
+                <AnimatedNumber
+                  value={d || 0}
+                  enabled={animated}
+                  options={animationOptions}
+                  formatter={formatter}
+                />
+              </Box>
+              {getLabel(i).suffix ? (
+                <Box color={getColor(i).suffix || theme.palette.text.secondary}>
+                  <Typography
+                    color='inherit'
+                    component='span'
+                    variant='subtitle2'
+                    className={classes.unit}
+                  >
+                    {getLabel(i).suffix}
+                  </Typography>
+                </Box>
+              ) : null}
+            </div>
+            {getLabel(i).note ? (
+              <Box color={getColor(i).note}>
+                <Typography className={classes.note} color='inherit' variant='caption'>
+                  {getLabel(i).note}
+                </Typography>
+              </Box>
+            ) : null}
+          </div>
+        ))}
+    </div>
+  );
+}
+
+ComparativeFormulaWidgetUI.displayName = 'ComparativeFormulaWidgetUI';
+ComparativeFormulaWidgetUI.defaultProps = {
+  data: EMPTY_ARRAY,
+  labels: EMPTY_ARRAY,
+  colors: EMPTY_ARRAY,
+  animated: true,
+  animationOptions: {},
+  formatter: IDENTITY_FN
+};
+
+const formulaLabelsPropTypes = PropTypes.shape({
+  prefix: PropTypes.string,
+  suffix: PropTypes.string,
+  note: PropTypes.string
+});
+
+const formulaColorsPropTypes = PropTypes.shape({
+  prefix: PropTypes.string,
+  suffix: PropTypes.string,
+  note: PropTypes.string,
+  value: PropTypes.string
+});
+
+ComparativeFormulaWidgetUI.propTypes = {
+  data: PropTypes.arrayOf(PropTypes.number),
+  labels: PropTypes.arrayOf(formulaLabelsPropTypes),
+  colors: PropTypes.arrayOf(formulaColorsPropTypes),
+  animated: PropTypes.bool,
+  animationOptions: animationOptionsPropTypes,
+  formatter: PropTypes.func
+};
+
+export default ComparativeFormulaWidgetUI;

--- a/packages/react-ui/storybook/stories/widgetsUI/ComparativeFormulaWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/ComparativeFormulaWidgetUI.stories.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import ComparativeFormulaWidgetUI from '../../../src/widgets/ComparativeFormulaWidgetUI';
+
+const options = {
+  title: 'Custom Components/ComparativeFormulaWidgetUI',
+  component: ComparativeFormulaWidgetUI
+};
+
+export default options;
+
+const Template = (args) => <ComparativeFormulaWidgetUI {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  data: [1245, 3435.9],
+  labels: [
+    { prefix: '$', suffix: ' sales', note: 'label 1' },
+    { prefix: '$', suffix: ' sales', note: 'label 2' }
+  ],
+  colors: [{ note: '#ff9900' }, { note: '#6732a8' }]
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -17667,6 +17667,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-animate-number@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/use-animate-number/-/use-animate-number-1.0.5.tgz#c224fd3ce81d0b563a5215d714aaa98ad8c67470"
+  integrity sha512-zAavKn83Z6V6wlatpEp+fmbAS6vMA3tISudw04eSeyXc0AZG98JDDK1U+gmMxV/oATcub+ijgrENMPqHue+SiA==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
# Description

This PR implements part of the work proposed in RFC #479 

Changes added in this PR include:
* A new widget called `ComparativeFormulaWidgetUI` in the `widgets` folder
* A small npm package added to `dependencies` of `packages/react-ui/package.json` used for animations
* A new component called `AnimatedNumber` in the `custom-components` folder. This component uses the `use-animated-number` npm package and abstracts away the logic for animating a changing number that is required for both formula widget and category widget, removing almost entirely the need for `useEffect` in UI components.
* Typescript typings for both `AnimatedNumber` and `ComparativeFormulaWidgetUI`
* Prop-types validation for both `AnimatedNumber` and `ComparativeFormulaWidgetUI`
* A basic storybook story for `ComparativeFormulaWidgetUI` where all prop combinations can be tested and tweaked. A screenshot of this storybook is added as visual feedback.

![Captura de pantalla 2022-10-24 a las 14 20 04](https://user-images.githubusercontent.com/6652814/197525404-75d70e7f-05cd-487a-b23e-957b0875b433.png)

## Type of change

- Feature

# Acceptance

How to validate the feature:

1. Open the local storybook running `yarn storybook:start` in the `react-ui` folder.
2. Pick a set of properties to use for testing by tweaking the storybook configuration.
3. Use this set of properties to render a `ComparativeFormulaWidgetUI` in your sample project, by importing `ComparativeFormulaWidgetUI` from `@carto/react-ui`. You can use [this branch](https://github.com/CartoDB/carto-react-template/tree/feature/comparative-widgets) of `carto-react-template` to skip this step if you want, as a test screen is already setup there. Bear in mind that if this feature is not published to npm you will have to link your local version of `@carto/react-*` packages with `yarn link`.
4. Check that the rendered version of the widget in your sample project looks the same as it looks in the storybook.

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
