### PR TITLE
Fix legend when layer is outline Point

### DIFF
--- a/packages/react-ui/src/widgets/legend/LegendCategories.js
+++ b/packages/react-ui/src/widgets/legend/LegendCategories.js
@@ -80,6 +80,7 @@ const useStyles = makeStyles((theme) => ({
     position: 'relative'
   },
   circle: {
+    border: '2px solid transparent',
     '&::after': {
       position: 'absolute',
       display: ({ isMax }) => (isMax ? 'block' : 'none'),


### PR DESCRIPTION
# Description

Shortcut: ([link](https://app.shortcut.com/cartoteam/story/266499/ac-7xhfwyml-carto-3-legend-not-rendering-outline-point-values))

Was broken here: https://github.com/CartoDB/carto-react/pull/451


## Type of change

- Fix
