### PR TITLE
AnimatedNumber component with hook wrapping `animateValue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- AnimatedNumber component with hook wrapping `animateValue` [#509](https://github.com/CartoDB/carto-react/pull/509)
+
 ## 1.5
 
 ### 1.5.0-alpha.4 (2022-10-14)

--- a/packages/react-ui/src/custom-components/AnimatedNumber.js
+++ b/packages/react-ui/src/custom-components/AnimatedNumber.js
@@ -7,7 +7,7 @@ import useAnimatedNumber from '../hooks/useAnimatedNumber';
  * @param {Object} props
  * @param {boolean} props.enabled
  * @param {number} props.value
- * @param {{ duration?: number; animateOnMount?: boolean; }} [props.options]
+ * @param {{ duration?: number; animateOnMount?: boolean; initialValue?: number }} [props.options]
  * @param {(n: number) => React.ReactNode} [props.formatter]
  */
 function AnimatedNumber({ enabled, value, options, formatter }) {
@@ -29,7 +29,8 @@ AnimatedNumber.defaultProps = {
 
 export const animationOptionsPropTypes = PropTypes.shape({
   duration: PropTypes.number,
-  animateOnMount: PropTypes.bool
+  animateOnMount: PropTypes.bool,
+  initialValue: PropTypes.number
 });
 
 AnimatedNumber.propTypes = {

--- a/packages/react-ui/src/custom-components/AnimatedNumber.js
+++ b/packages/react-ui/src/custom-components/AnimatedNumber.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import useAnimatedNumber from '../hooks/useAnimatedNumber';
+
+/**
+ * Renders a <AnimatedNumber /> widget
+ * @param {Object} props
+ * @param {boolean} props.enabled
+ * @param {number} props.value
+ * @param {{ duration?: number; animateOnMount?: boolean; }} [props.options]
+ * @param {(n: number) => React.ReactNode} [props.formatter]
+ */
+function AnimatedNumber({ enabled, value, options, formatter }) {
+  const defaultOptions = {
+    animateOnMount: true,
+    disabled: enabled === false || value === null || value === undefined
+  };
+  const animated = useAnimatedNumber(value, { ...defaultOptions, ...options });
+  return <span>{formatter ? formatter(animated) : animated}</span>;
+}
+
+AnimatedNumber.displayName = 'AnimatedNumber';
+AnimatedNumber.defaultProps = {
+  enabled: true,
+  value: 0,
+  options: {},
+  formatter: null
+};
+
+export const animationOptionsPropTypes = PropTypes.shape({
+  duration: PropTypes.number,
+  animateOnMount: PropTypes.bool
+});
+
+AnimatedNumber.propTypes = {
+  enabled: PropTypes.bool,
+  value: PropTypes.number.isRequired,
+  options: animationOptionsPropTypes,
+  formatter: PropTypes.func
+};
+
+export default AnimatedNumber;

--- a/packages/react-ui/src/hooks/useAnimatedNumber.js
+++ b/packages/react-ui/src/hooks/useAnimatedNumber.js
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from "react";
+import { animateValue } from '../widgets/utils/animations';
+
+/**
+ * React hook to handle animating value changes over time, abstracting the necesary state, refs and effects
+ * @param {number} value 
+ * @param {{ disabled?: boolean; duration?: number; animateOnMount?: boolean }} [options] 
+ */
+export default function useAnimatedNumber(value, options = {}) {
+  const { disabled, duration, animateOnMount } = options;
+
+  // starting with a -1 to supress a typescript warning
+  const requestAnimationFrameRef = useRef(-1); 
+
+  // if we want to run the animation on mount, we set the start value as 0 and animate to the start value
+  const [animatedValue, setAnimatedValue] = useState(() => animateOnMount ? 0 : value);
+
+  useEffect(() => {
+    if (!disabled) {
+      animateValue({
+        start: animatedValue || 0,
+        end: value,
+        duration: duration || 500, // 500ms
+        drawFrame: (val) => setAnimatedValue(val),
+        requestRef: requestAnimationFrameRef
+      });
+    } else {
+      setAnimatedValue(value)
+    }
+
+    return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      cancelAnimationFrame(requestAnimationFrameRef.current);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, disabled, duration]);
+
+  return animatedValue;
+};

--- a/packages/react-ui/src/hooks/useAnimatedNumber.js
+++ b/packages/react-ui/src/hooks/useAnimatedNumber.js
@@ -9,8 +9,8 @@ import { animateValue } from '../widgets/utils/animations';
 export default function useAnimatedNumber(value, options = {}) {
   const { disabled, duration, animateOnMount, initialValue = 0 } = options;
 
-  // starting with a -1 to supress a typescript warning
-  const requestAnimationFrameRef = useRef(-1); 
+  /** @type {any} */
+  const requestAnimationFrameRef = useRef(); 
 
   // if we want to run the animation on mount, we set the starting value of the animated number as 0 (or the number in `initialValue`) and animate to the target value from there
   const [animatedValue, setAnimatedValue] = useState(() => animateOnMount ? initialValue : value);

--- a/packages/react-ui/src/hooks/useAnimatedNumber.js
+++ b/packages/react-ui/src/hooks/useAnimatedNumber.js
@@ -4,21 +4,21 @@ import { animateValue } from '../widgets/utils/animations';
 /**
  * React hook to handle animating value changes over time, abstracting the necesary state, refs and effects
  * @param {number} value 
- * @param {{ disabled?: boolean; duration?: number; animateOnMount?: boolean }} [options] 
+ * @param {{ disabled?: boolean; duration?: number; animateOnMount?: boolean; initialValue?: number; }} [options] 
  */
 export default function useAnimatedNumber(value, options = {}) {
-  const { disabled, duration, animateOnMount } = options;
+  const { disabled, duration, animateOnMount, initialValue = 0 } = options;
 
   // starting with a -1 to supress a typescript warning
   const requestAnimationFrameRef = useRef(-1); 
 
-  // if we want to run the animation on mount, we set the start value as 0 and animate to the start value
-  const [animatedValue, setAnimatedValue] = useState(() => animateOnMount ? 0 : value);
+  // if we want to run the animation on mount, we set the starting value of the animated number as 0 (or the number in `initialValue`) and animate to the target value from there
+  const [animatedValue, setAnimatedValue] = useState(() => animateOnMount ? initialValue : value);
 
   useEffect(() => {
     if (!disabled) {
       animateValue({
-        start: animatedValue || 0,
+        start: animatedValue,
         end: value,
         duration: duration || 500, // 500ms
         drawFrame: (val) => setAnimatedValue(val),

--- a/packages/react-ui/src/types.d.ts
+++ b/packages/react-ui/src/types.d.ts
@@ -192,6 +192,7 @@ export type LegendRamp = {
 export type AnimationOptions = {
   duration?: number;
   animateOnMount?: boolean;
+  initialValue?: number
 };
 
 export type AnimatedNumber = {

--- a/packages/react-ui/src/types.d.ts
+++ b/packages/react-ui/src/types.d.ts
@@ -188,3 +188,15 @@ export type LegendRamp = {
     colors?: string | string[] | number[][];
   };
 };
+
+export type AnimationOptions = {
+  duration?: number;
+  animateOnMount?: boolean;
+};
+
+export type AnimatedNumber = {
+  enabled: boolean;
+  value: number;
+  options?: AnimationOptions;
+  formatter: (n: number) => React.ReactNode;
+};


### PR DESCRIPTION
# Description

This is a follow up of the changes proposed in RFC #479 and the discussion originated from PR #504. This PR extracts the new animation component used in comparative widgets that wraps around the `animateValue` function in `utils` folder.

The changes included in this PR are the following:
- implement `useAnimatedNumber` hook based on `animateValue` util, encapsulating state, refs and effects
- implement `<AnimatedNumber />` component as a simple interface to render the results of `useAnimatedNumber` hook.
- provide JSDoc documentation for both `AnimatedNumber` and `useAnimatedNumber`
- provide TS typings for both `AnimatedNumber` and `useAnimatedNumber`

## Type of change

(choose one and remove the others)

- Feature

# Acceptance

As with other comparative widget PRs, you can use [this branch](https://github.com/CartoDB/carto-react-template/tree/feature/comparative-widgets) of `carto-react-template` to test the behaviour of `ComparativeFormulaWidgetUI` and `ComparativeCategoryWidgetUI`. Both widgets have been uptaded with the changes necesary in their respective branches.

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
