### PR TITLE
Fix queryParameters support in RangeWidget and HistogramWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Missing implementation for support `queryParameters` in `stats` request [#517](https://github.com/CartoDB/carto-react/pull/517)
 - AnimatedNumber component with hook wrapping `animateValue` [#509](https://github.com/CartoDB/carto-react/pull/509)
 - Implement ComparativeFormulaWidgetUI [#504](https://github.com/CartoDB/carto-react/pull/504)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- Missing implementation for support `queryParameters` in `stats` request [#517](https://github.com/CartoDB/carto-react/pull/517)
+- Fix missing implementation in stats to support `queryParameters` in RangeWidget and HistogramWidget [#517](https://github.com/CartoDB/carto-react/pull/517)
 - AnimatedNumber component with hook wrapping `animateValue` [#509](https://github.com/CartoDB/carto-react/pull/509)
 - Implement ComparativeFormulaWidgetUI [#504](https://github.com/CartoDB/carto-react/pull/504)
 

--- a/packages/react-api/src/api/stats.js
+++ b/packages/react-api/src/api/stats.js
@@ -37,7 +37,12 @@ export async function getStats(props) {
   } else {
     const url = buildUrl(source, column);
 
-    return makeCall({ url, credentials: source.credentials, opts, queryParameters: source.queryParameters });
+    return makeCall({
+      url,
+      credentials: source.credentials,
+      opts,
+      queryParameters: source.queryParameters
+    });
   }
 }
 
@@ -53,6 +58,10 @@ function buildUrl(source, column) {
 
   if (isQuery) {
     url.searchParams.set('q', source.data);
+
+    if (source.queryParameters) {
+      url.searchParams.set('queryParameters', JSON.stringify(source.queryParameters));
+    }
   }
 
   return url;


### PR DESCRIPTION
# Description
`<RangeWidget />` and `<HistogramWidget />` use `stats` endpoint to retrieve the data. That's function support queryParameters but we had not implemented.

## Type of change

- Fix

