### PR TITLE
Fix executeModel with POST method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix `executeModel` through **POST** request [#525](https://github.com/CartoDB/carto-react/pull/525)
+
 ## 1.5
 
 ### 1.5.0-alpha.6 (2022-11-02)

--- a/packages/react-api/__tests__/api/model.test.js
+++ b/packages/react-api/__tests__/api/model.test.js
@@ -1,5 +1,10 @@
 import { executeModel } from '../../src/api/model';
-import { QUERY_PARAMS_SOURCE, QUERY_SOURCE, TABLE_SOURCE, TILESET_SOURCE } from '../dataMocks';
+import {
+  QUERY_PARAMS_SOURCE,
+  QUERY_SOURCE,
+  TABLE_SOURCE,
+  TILESET_SOURCE
+} from '../dataMocks';
 
 const mockedMakeCall = jest.fn();
 
@@ -50,9 +55,8 @@ describe('model', () => {
           body: JSON.stringify({
             type: 'query',
             source: longQuerySource.data,
-            params: JSON.stringify(DEFAULT_PARAMS),
-            queryParameters: '',
-            filters: JSON.stringify(longQuerySource.filters),
+            params: DEFAULT_PARAMS,
+            filters: longQuerySource.filters,
             filtersLogicalOperator: longQuerySource.filtersLogicalOperator
           })
         },
@@ -60,9 +64,12 @@ describe('model', () => {
       });
     });
 
-
     test('works correctly when the source has queryParameters', () => {
-      executeModel({ model: 'formula', source: QUERY_PARAMS_SOURCE, params: DEFAULT_PARAMS });
+      executeModel({
+        model: 'formula',
+        source: QUERY_PARAMS_SOURCE,
+        params: DEFAULT_PARAMS
+      });
 
       expect(mockedMakeCall).toHaveBeenCalledWith({
         credentials: TABLE_SOURCE.credentials,

--- a/packages/react-api/src/api/common.js
+++ b/packages/react-api/src/api/common.js
@@ -31,13 +31,21 @@ export function checkCredentials(credentials) {
 export async function makeCall({ url, credentials, opts }) {
   let response;
   let data;
+  const isPost = opts?.method === 'POST';
   try {
     response = await fetch(url.toString(), {
       headers: {
-        Authorization: `Bearer ${credentials.accessToken}`
+        Authorization: `Bearer ${credentials.accessToken}`,
+        ...(isPost ? { 'Content-Type': 'application/json' } : {})
       },
+      ...(isPost
+        ? {
+            method: opts?.method,
+            body: opts?.body
+          }
+        : {}),
       signal: opts?.abortController?.signal,
-      ...opts?.otherOptions,
+      ...opts?.otherOptions
     });
     data = await response.json();
   } catch (error) {

--- a/packages/react-api/src/api/model.js
+++ b/packages/react-api/src/api/model.js
@@ -52,7 +52,7 @@ export function executeModel(props) {
     filtersLogicalOperator
   };
 
-  const isGet = false && url.length + JSON.stringify(queryParams).length <= URL_LENGTH;
+  const isGet = url.length + JSON.stringify(queryParams).length <= URL_LENGTH;
   if (isGet) {
     url += '?' + new URLSearchParams(queryParams).toString();
   } else {

--- a/packages/react-api/src/api/model.js
+++ b/packages/react-api/src/api/model.js
@@ -39,9 +39,11 @@ export function executeModel(props) {
 
   let url = `${source.credentials.apiBaseUrl}/v3/sql/${source.connection}/model/${model}`;
 
-  const { filters, filtersLogicalOperator, data, type } = source;  
-  const queryParameters = source.queryParameters ? JSON.stringify(source.queryParameters) : ''
-  const queryParams = {
+  const { filters, filtersLogicalOperator, data, type } = source;
+  const queryParameters = source.queryParameters
+    ? JSON.stringify(source.queryParameters)
+    : '';
+  let queryParams = {
     type,
     source: data,
     params: JSON.stringify(params),
@@ -50,9 +52,13 @@ export function executeModel(props) {
     filtersLogicalOperator
   };
 
-  const isGet = url.length + JSON.stringify(queryParams).length <= URL_LENGTH;
+  const isGet = false && url.length + JSON.stringify(queryParams).length <= URL_LENGTH;
   if (isGet) {
     url += '?' + new URLSearchParams(queryParams).toString();
+  } else {
+    queryParams.params = params;
+    queryParams.filters = filters;
+    queryParams.queryParameters = source.queryParameters;
   }
   return makeCall({
     url,


### PR DESCRIPTION
# Description

Issue: #524

executeModel was not using `opts`. Attributes **method** and **body** were not being passed on `fetch` call.

## Type of change

- Fix

