### PR TITLE
Replace kebab-case properties in styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Replace kebab-case properties in styles [#530](https://github.com/CartoDB/carto-react/pull/530)
 - New design system in priority 1 components [#523](https://github.com/CartoDB/carto-react/pull/523)
 - Breaking changes in Mui v5: components [#518](https://github.com/CartoDB/carto-react/pull/518)
 - Breaking changes in Mui v5: styles and theme [#514](https://github.com/CartoDB/carto-react/pull/514/)

--- a/packages/react-ui/src/theme/sections/cssBaseline.js
+++ b/packages/react-ui/src/theme/sections/cssBaseline.js
@@ -9,7 +9,7 @@ export const CssBaseline = {
     width: '5px'
   },
   '*::-webkit-scrollbar-track': {
-    '-webkit-box-shadow': 'none',
+    boxShadow: 'none',
     background: 'transparent'
   },
   '*::-webkit-scrollbar-thumb': {
@@ -20,7 +20,8 @@ export const CssBaseline = {
 
   // iOS Search clear button
   'input[type="search"]::-webkit-search-cancel-button': {
-    '-webkit-appearance': 'none',
+    WebkitAppearance: 'none',
+    appearance: 'none',
     height: getSpacing(2),
     width: getSpacing(2),
     display: 'block',


### PR DESCRIPTION
# Description

Shortcut: [#270596](https://app.shortcut.com/cartoteam/story/270596/core-replace-kebab-cases-for-standard-css-properties-in-c4r)
[sc-270596]

Fix warnings related to kebab-case style properties.
