### PR TITLE
Fix disableElevation default prop

### DIFF
--- a/packages/react-ui/src/theme/sections/components/buttons.js
+++ b/packages/react-ui/src/theme/sections/components/buttons.js
@@ -13,8 +13,7 @@ export const buttonsOverrides = {
   // Button Base
   MuiButtonBase: {
     defaultProps: {
-      disableRipple: true,
-      disableElevation: true
+      disableRipple: true
     },
 
     styleOverrides: {
@@ -29,6 +28,10 @@ export const buttonsOverrides = {
 
   // Button
   MuiButton: {
+    defaultProps: {
+      disableElevation: true
+    },
+
     styleOverrides: {
       root: ({ ownerState }) => ({
         maxWidth: '192px',


### PR DESCRIPTION
Move default prop to Button, as it looks it's not available in ButtonBase.

Detected in cloud-native integration, with runtime error:
![image](https://user-images.githubusercontent.com/458196/205354001-a73653de-8c12-47b9-b73a-929588464b6e.png)

Ref: 
- https://mui.com/material-ui/api/button/
- https://mui.com/material-ui/api/button-base/
