### PR TITLE
Fix/gmaps channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 1.4
 
+### 1.4.8 (2022-12-13)
+
+- Remove beta channel of `gmaps`.
+- 
 ### 1.4.7 (2022-11-18)
 
 - Fix `executeSQL` through **POST** request [#531](https://github.com/CartoDB/carto-react/pull/531)

--- a/packages/react-basemaps/src/basemaps/GoogleMap.js
+++ b/packages/react-basemaps/src/basemaps/GoogleMap.js
@@ -137,7 +137,7 @@ export function GoogleMap(props) {
       script.id = 'gmaps';
       script.async = true;
       script.type = `text/javascript`;
-      script.src = `https://maps.google.com/maps/api/js?v=beta&key=` + apiKey;
+      script.src = `https://maps.google.com/maps/api/js?key=` + apiKey;
       const headScript = document.getElementsByTagName(`script`)[0];
       headScript.parentNode.insertBefore(script, headScript);
       script.addEventListener(`load`, onLoad);

--- a/packages/react-workers/package.json
+++ b/packages/react-workers/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.9",
-    "@carto/react-core": "^1.4.7",
+    "@carto/react-core": "^1.4.8",
     "@turf/bbox-polygon": "^6.3.0",
     "@turf/boolean-intersects": "^6.3.0",
     "@turf/boolean-within": "^6.3.0",


### PR DESCRIPTION
Currently, C4R uses a beta channel of Google Maps and it's unstable and causes the load script to fail, we need to change to a stable channel.

![image (1)](https://user-images.githubusercontent.com/11427698/207342736-268c60c8-9082-48b4-91c1-24bf66814844.png)
