### PR TITLE
New color variant in FAB button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- New color variant in FAB button [#554](https://github.com/CartoDB/carto-react/pull/554)
 - Adjustments in theme to fix uses cases in cloud-native [#553](https://github.com/CartoDB/carto-react/pull/553/)
 - Default props of core components to meet the common use case [#552](https://github.com/CartoDB/carto-react/pull/552/)
 - Chip component adapted to the new design system [#551](https://github.com/CartoDB/carto-react/pull/551/)

--- a/packages/react-ui/src/theme/carto-theme.d.ts
+++ b/packages/react-ui/src/theme/carto-theme.d.ts
@@ -129,3 +129,10 @@ declare module '@mui/material/Button' {
     default: true;
   }
 }
+
+// Update the FAB's color prop options
+declare module '@mui/material/Fab' {
+  interface FabPropsColorOverrides {
+    default: true;
+  }
+}

--- a/packages/react-ui/src/theme/sections/components/buttons.js
+++ b/packages/react-ui/src/theme/sections/components/buttons.js
@@ -428,6 +428,10 @@ export const buttonsOverrides = {
 
   // FAB button
   MuiFab: {
+    defaultProps: {
+      color: 'primary'
+    },
+
     styleOverrides: {
       root: {
         '&:focus': {
@@ -485,7 +489,26 @@ export const buttonsOverrides = {
         '&:hover': {
           backgroundColor: commonPalette.secondary.light
         }
-      }
+      },
+
+      variants: [
+        // Custom color and its variants
+        {
+          props: { color: 'default' },
+          style: {
+            color: commonPalette.text.primary,
+            backgroundColor: commonPalette.background.paper,
+
+            '&.Mui-disabled': {
+              color: commonPalette.text.disabled,
+              backgroundColor: commonPalette.action.disabledBackground
+            },
+            '&:hover, &:focus-visible': {
+              backgroundColor: commonPalette.default.light
+            }
+          }
+        }
+      ]
     }
   }
 };

--- a/packages/react-ui/src/theme/sections/components/buttons.js
+++ b/packages/react-ui/src/theme/sections/components/buttons.js
@@ -433,7 +433,7 @@ export const buttonsOverrides = {
     },
 
     styleOverrides: {
-      root: {
+      root: ({ ownerState }) => ({
         '&:focus': {
           boxShadow: themeShadows[6]
         },
@@ -454,8 +454,17 @@ export const buttonsOverrides = {
           '& .MuiSvgIcon-root': {
             marginRight: getSpacing(1.5)
           }
-        }
-      },
+        },
+
+        ...(ownerState.color === 'default' && {
+          color: commonPalette.text.primary,
+          backgroundColor: commonPalette.background.paper,
+
+          '&:hover, &:focus-visible': {
+            backgroundColor: commonPalette.default.light
+          }
+        })
+      }),
 
       sizeSmall: {
         width: getSpacing(4),
@@ -489,26 +498,7 @@ export const buttonsOverrides = {
         '&:hover': {
           backgroundColor: commonPalette.secondary.light
         }
-      },
-
-      variants: [
-        // Custom color and its variants
-        {
-          props: { color: 'default' },
-          style: {
-            color: commonPalette.text.primary,
-            backgroundColor: commonPalette.background.paper,
-
-            '&.Mui-disabled': {
-              color: commonPalette.text.disabled,
-              backgroundColor: commonPalette.action.disabledBackground
-            },
-            '&:hover, &:focus-visible': {
-              backgroundColor: commonPalette.default.light
-            }
-          }
-        }
-      ]
+      }
     }
   }
 };

--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -383,7 +383,8 @@ export const dataDisplayOverrides = {
     styleOverrides: {
       root: {
         color: commonPalette.secondary.contrastText,
-        backgroundColor: commonPalette.secondary.main
+        backgroundColor: commonPalette.secondary.main,
+        border: 'none'
       },
       img: {
         // border: `1px solid ${commonPalette.default.outlinedBorder}` TODO fix the background color overlap

--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -383,8 +383,7 @@ export const dataDisplayOverrides = {
     styleOverrides: {
       root: {
         color: commonPalette.secondary.contrastText,
-        backgroundColor: commonPalette.secondary.main,
-        border: 'none'
+        backgroundColor: commonPalette.secondary.main
       },
       img: {
         // border: `1px solid ${commonPalette.default.outlinedBorder}` TODO fix the background color overlap

--- a/packages/react-ui/src/theme/sections/components/navigation.js
+++ b/packages/react-ui/src/theme/sections/components/navigation.js
@@ -48,7 +48,6 @@ export const navigationOverrides = {
   // Tabs
   MuiTabs: {
     defaultProps: {
-      iconPosition: 'start',
       TabIndicatorProps: {
         classes: {
           colorPrimary: 'colorPrimary'

--- a/packages/react-ui/storybook/stories/molecules/FAB.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/FAB.stories.js
@@ -14,10 +14,9 @@ const options = {
       }
     },
     color: {
-      defaultValue: 'primary',
       control: {
         type: 'select',
-        options: ['primary', 'secondary']
+        options: ['primary', 'secondary', 'default']
       }
     },
     size: {
@@ -126,5 +125,8 @@ PrimaryColor.args = { color: 'primary' };
 
 export const SecondaryColor = Template.bind({});
 SecondaryColor.args = { color: 'secondary' };
+
+export const DefaultColor = Template.bind({});
+DefaultColor.args = { color: 'default' };
 
 export const Sizes = SizeTemplate.bind({});


### PR DESCRIPTION
# Description

Shortcut: [#275436](https://app.shortcut.com/cartoteam/story/275436/workspace-maps)
[sc-275436]

New color variant added in FAB button.

We had this pending task in the [DS](https://www.figma.com/file/nmaoLeo69xBJCHm9nc6lEV/CARTO-Components-1.0?node-id=1534%3A28898&t=HI1Xd9yGuft4g9kq-0), right now would be nice to add it, to finish maps page visual fixes.

This PR also should fix a runtime error in Tabs, regarding iconPosition prop.
