### PR TITLE
Inputs size to small by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Inputs size to small by default [#556](https://github.com/CartoDB/carto-react/pull/556)
 - New color variant in FAB button [#554](https://github.com/CartoDB/carto-react/pull/554)
 - Adjustments in theme to fix uses cases in cloud-native [#553](https://github.com/CartoDB/carto-react/pull/553/)
 - Default props of core components to meet the common use case [#552](https://github.com/CartoDB/carto-react/pull/552/)

--- a/packages/react-ui/src/components/atoms/SelectField.js
+++ b/packages/react-ui/src/components/atoms/SelectField.js
@@ -33,6 +33,7 @@ const SelectField = forwardRef(
         SelectProps={{
           multiple: multiple,
           displayEmpty: !!placeholder,
+          size: size,
           renderValue: (selected) => {
             if (selected.length === 0) {
               return (

--- a/packages/react-ui/src/components/atoms/SelectField.js
+++ b/packages/react-ui/src/components/atoms/SelectField.js
@@ -85,13 +85,13 @@ const SelectField = forwardRef(
 
 SelectField.defaultProps = {
   multiple: false,
-  size: 'medium'
+  size: 'small'
 };
 SelectField.propTypes = {
   items: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,
-      id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
+      value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
     })
   ).isRequired,
   placeholder: PropTypes.string.isRequired,

--- a/packages/react-ui/src/theme/sections/components/forms.js
+++ b/packages/react-ui/src/theme/sections/components/forms.js
@@ -64,7 +64,8 @@ export const formsOverrides = {
         shrink: true
       },
       SelectProps: {
-        IconComponent: ArrowDropIcon
+        IconComponent: ArrowDropIcon,
+        size: 'small'
       }
     },
     styleOverrides: {

--- a/packages/react-ui/src/theme/sections/components/forms.js
+++ b/packages/react-ui/src/theme/sections/components/forms.js
@@ -58,6 +58,7 @@ export const formsOverrides = {
   MuiTextField: {
     defaultProps: {
       fullWidth: true,
+      size: 'small',
 
       InputLabelProps: {
         shrink: true
@@ -379,7 +380,8 @@ export const formsOverrides = {
   MuiSelect: {
     defaultProps: {
       IconComponent: ArrowDropIcon,
-      fullWidth: true
+      fullWidth: true,
+      size: 'small'
     },
 
     styleOverrides: {
@@ -398,7 +400,7 @@ export const formsOverrides = {
         },
 
         // Variants
-        '&.MuiOutlinedInput-root': {
+        '&.MuiOutlinedInput-root, &.MuiFilledInput-root': {
           padding: 0
         },
         '&.MuiFilledInput-root, &.MuiInput-underline': {
@@ -421,9 +423,10 @@ export const formsOverrides = {
               paddingLeft: 0
             }
           },
-          '&.MuiOutlinedInput-root.MuiInputBase-sizeSmall': {
-            padding: 0
-          },
+          '&.MuiOutlinedInput-root.MuiInputBase-sizeSmall, &.MuiFilledInput-root.MuiInputBase-sizeSmall':
+            {
+              padding: 0
+            },
           '& .MuiSelect-icon': {
             right: getSpacing(1.5)
           }

--- a/packages/react-ui/src/types.d.ts
+++ b/packages/react-ui/src/types.d.ts
@@ -217,7 +217,7 @@ export interface SelectFieldProps extends TextFieldProps {
   items: [
     {
       label: string;
-      id: string | number;
+      value: string | number;
     }
   ];
   multiple?: boolean;

--- a/packages/react-ui/storybook/stories/atoms/SelectField.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/SelectField.stories.js
@@ -108,7 +108,7 @@ const menuItemsLong = [
 
 const PlaygroundTemplate = (args) => <SelectField {...args} items={menuItems} />;
 
-const VariantsTemplate = ({ label, required, placeholder, size, ...rest }) => {
+const VariantsTemplate = ({ label, required, placeholder, ...rest }) => {
   const classes = useStyles();
 
   return (
@@ -123,7 +123,6 @@ const VariantsTemplate = ({ label, required, placeholder, size, ...rest }) => {
             label={label}
             variant='filled'
             placeholder={placeholder}
-            size={size}
             items={menuItems}
           />
         </Box>
@@ -138,7 +137,6 @@ const VariantsTemplate = ({ label, required, placeholder, size, ...rest }) => {
             label={label}
             variant='outlined'
             placeholder={placeholder}
-            size={size}
             items={menuItems}
           />
         </Box>
@@ -153,7 +151,6 @@ const VariantsTemplate = ({ label, required, placeholder, size, ...rest }) => {
             label={label}
             variant='standard'
             placeholder={placeholder}
-            size={size}
             items={menuItems}
           />
         </Box>

--- a/packages/react-ui/storybook/stories/atoms/SelectField.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/SelectField.stories.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Box, Grid, MenuItem, TextField } from '@mui/material';
+import { Box, Grid, MenuItem, Select, TextField } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import Typography from '../../../src/components/atoms/Typography';
 import SelectField from '../../../src/components/atoms/SelectField';
@@ -108,7 +108,7 @@ const menuItemsLong = [
 
 const PlaygroundTemplate = (args) => <SelectField {...args} items={menuItems} />;
 
-const VariantsTemplate = ({ label, required, placeholder, ...rest }) => {
+const VariantsTemplate = ({ label, required, placeholder, size, ...rest }) => {
   const classes = useStyles();
 
   return (
@@ -123,6 +123,7 @@ const VariantsTemplate = ({ label, required, placeholder, ...rest }) => {
             label={label}
             variant='filled'
             placeholder={placeholder}
+            size={size}
             items={menuItems}
           />
         </Box>
@@ -137,6 +138,7 @@ const VariantsTemplate = ({ label, required, placeholder, ...rest }) => {
             label={label}
             variant='outlined'
             placeholder={placeholder}
+            size={size}
             items={menuItems}
           />
         </Box>
@@ -151,6 +153,7 @@ const VariantsTemplate = ({ label, required, placeholder, ...rest }) => {
             label={label}
             variant='standard'
             placeholder={placeholder}
+            size={size}
             items={menuItems}
           />
         </Box>
@@ -216,7 +219,14 @@ const LabelAndHelperTextTemplate = ({ label, placeholder, helperText, ...rest })
   );
 };
 
-const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest }) => {
+const SizeTemplate = ({
+  label,
+  placeholder,
+  defaultValue,
+  helperText,
+  size,
+  ...rest
+}) => {
   const [fixedValue, setFixedValue] = useState('Twenty');
   const [fixedValue2, setFixedValue2] = useState('Ten');
   const [fixedValue3, setFixedValue3] = useState('Thirty');
@@ -244,6 +254,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             items={menuItems}
+            size={size}
           />
         </Grid>
         <Grid item xs={3}>
@@ -253,6 +264,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             items={menuItems}
+            size={size}
           />
         </Grid>
         <Grid item xs={3}>
@@ -262,6 +274,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             items={menuItems}
+            size={size}
           />
         </Grid>
       </Grid>
@@ -271,31 +284,31 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
           <Typography>Empty</Typography>
         </Grid>
         <Grid item xs={3}>
-          <TextField select {...rest} variant='filled' label={label}>
+          <Select select {...rest} variant='filled' label={label} size={size}>
             {menuItems.map((option) => (
               <MenuItem key={option.label} value={option.label}>
                 {option.label}
               </MenuItem>
             ))}
-          </TextField>
+          </Select>
         </Grid>
         <Grid item xs={3}>
-          <TextField select {...rest} variant='outlined' label={label}>
+          <Select select {...rest} variant='outlined' label={label} size={size}>
             {menuItems.map((option) => (
               <MenuItem key={option.label} value={option.label}>
                 {option.label}
               </MenuItem>
             ))}
-          </TextField>
+          </Select>
         </Grid>
         <Grid item xs={3}>
-          <TextField select {...rest} variant='standard' label={label}>
+          <Select select {...rest} variant='standard' label={label} size={size}>
             {menuItems.map((option) => (
               <MenuItem key={option.label} value={option.label}>
                 {option.label}
               </MenuItem>
             ))}
-          </TextField>
+          </Select>
         </Grid>
       </Grid>
 
@@ -311,6 +324,9 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             select
             value={fixedValue}
             onChange={handleChange}
+            SelectProps={{
+              size: size
+            }}
           >
             {menuItems.map((option) => (
               <MenuItem key={option.label} value={option.label}>
@@ -327,6 +343,9 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             select
             value={fixedValue2}
             onChange={handleChange2}
+            SelectProps={{
+              size: size
+            }}
           >
             {menuItems.map((option) => (
               <MenuItem key={option.label} value={option.label}>
@@ -343,6 +362,9 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             select
             value={fixedValue3}
             onChange={handleChange3}
+            SelectProps={{
+              size: size
+            }}
           >
             {menuItems.map((option) => (
               <MenuItem key={option.label} value={option.label}>
@@ -364,6 +386,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             focused
+            size={size}
             items={menuItems}
           />
         </Grid>
@@ -374,6 +397,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             focused
+            size={size}
             items={menuItems}
           />
         </Grid>
@@ -384,6 +408,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             focused
+            size={size}
             items={menuItems}
           />
         </Grid>
@@ -400,6 +425,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             disabled
+            size={size}
             items={menuItems}
           />
         </Grid>
@@ -410,6 +436,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             disabled
+            size={size}
             items={menuItems}
           />
         </Grid>
@@ -420,6 +447,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             disabled
+            size={size}
             items={menuItems}
           />
         </Grid>
@@ -437,6 +465,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             placeholder={placeholder}
             helperText={helperText}
             error
+            size={size}
             items={menuItems}
           />
         </Grid>
@@ -448,6 +477,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             placeholder={placeholder}
             helperText={helperText}
             error
+            size={size}
             items={menuItems}
           />
         </Grid>
@@ -459,6 +489,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             placeholder={placeholder}
             helperText={helperText}
             error
+            size={size}
             items={menuItems}
           />
         </Grid>
@@ -597,7 +628,7 @@ export const LabelAndHelperText = LabelAndHelperTextTemplate.bind({});
 LabelAndHelperText.args = { ...commonArgs };
 
 export const Medium = SizeTemplate.bind({});
-Medium.args = { ...commonArgs, ...sizeArgs };
+Medium.args = { ...commonArgs, ...sizeArgs, size: 'medium' };
 Medium.argTypes = disabledControlsSizeArgTypes;
 
 export const Small = SizeTemplate.bind({});

--- a/packages/react-ui/storybook/stories/atoms/SelectField.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/SelectField.stories.js
@@ -284,7 +284,7 @@ const SizeTemplate = ({
           <Typography>Empty</Typography>
         </Grid>
         <Grid item xs={3}>
-          <Select select {...rest} variant='filled' label={label} size={size}>
+          <Select {...rest} variant='filled' label={label} size={size}>
             {menuItems.map((option) => (
               <MenuItem key={option.label} value={option.label}>
                 {option.label}
@@ -293,7 +293,7 @@ const SizeTemplate = ({
           </Select>
         </Grid>
         <Grid item xs={3}>
-          <Select select {...rest} variant='outlined' label={label} size={size}>
+          <Select {...rest} variant='outlined' label={label} size={size}>
             {menuItems.map((option) => (
               <MenuItem key={option.label} value={option.label}>
                 {option.label}
@@ -302,7 +302,7 @@ const SizeTemplate = ({
           </Select>
         </Grid>
         <Grid item xs={3}>
-          <Select select {...rest} variant='standard' label={label} size={size}>
+          <Select {...rest} variant='standard' label={label} size={size}>
             {menuItems.map((option) => (
               <MenuItem key={option.label} value={option.label}>
                 {option.label}

--- a/packages/react-ui/storybook/stories/atoms/Text-area.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/Text-area.stories.js
@@ -509,7 +509,7 @@ export const LabelAndHelperText = LabelAndHelperTextTemplate.bind({});
 LabelAndHelperText.args = { ...commonArgs };
 
 export const Medium = SizeTemplate.bind({});
-Medium.args = { ...commonArgs, ...sizeArgs };
+Medium.args = { ...commonArgs, ...sizeArgs, size: 'medium' };
 Medium.argTypes = disabledControlsSizeArgTypes;
 
 export const Small = SizeTemplate.bind({});

--- a/packages/react-ui/storybook/stories/atoms/Text-field.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/Text-field.stories.js
@@ -760,7 +760,7 @@ export const PrefixAndSuffix = PrefixAndSuffixTemplate.bind({});
 PrefixAndSuffix.args = { ...commonArgs };
 
 export const Medium = SizeTemplate.bind({});
-Medium.args = { ...commonArgs, ...sizeArgs };
+Medium.args = { ...commonArgs, ...sizeArgs, size: 'medium' };
 Medium.argTypes = disabledControlsSizeArgTypes;
 
 export const Small = SizeTemplate.bind({});

--- a/packages/react-ui/storybook/stories/molecules/Autocomplete.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/Autocomplete.stories.js
@@ -88,7 +88,7 @@ const AutocompleteTemplate = ({ disabled, size, ...args }) => {
             getOptionLabel={(option) => option.title}
             disabled={disabled}
             renderInput={(params) => (
-              <TextField {...args} {...params} label='Basic autocomplete' />
+              <TextField {...args} {...params} size={size} label='Basic autocomplete' />
             )}
             size={size}
           />
@@ -101,7 +101,7 @@ const AutocompleteTemplate = ({ disabled, size, ...args }) => {
             getOptionLabel={(option) => option.title}
             disabled={disabled}
             renderInput={(params) => (
-              <TextField {...args} {...params} label='Grouped autocomplete' />
+              <TextField {...args} {...params} size={size} label='Grouped autocomplete' />
             )}
             size={size}
           />
@@ -116,7 +116,12 @@ const AutocompleteTemplate = ({ disabled, size, ...args }) => {
             getOptionLabel={(option) => option.title}
             disabled={disabled}
             renderInput={(params) => (
-              <TextField {...args} {...params} label='Multiple autocomplete' />
+              <TextField
+                {...args}
+                {...params}
+                size={size}
+                label='Multiple autocomplete'
+              />
             )}
             size={size}
           />
@@ -131,5 +136,5 @@ export const Playground = Template.bind({});
 export const Default = AutocompleteTemplate.bind({});
 Default.args = {};
 
-export const Small = AutocompleteTemplate.bind({});
-Small.args = { size: 'small' };
+export const Medium = AutocompleteTemplate.bind({});
+Medium.args = { size: 'medium' };

--- a/packages/react-ui/storybook/stories/molecules/UploadField.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/UploadField.stories.js
@@ -463,7 +463,7 @@ export const LabelAndHelperText = LabelAndHelperTextTemplate.bind({});
 LabelAndHelperText.args = { ...commonArgs };
 
 export const Medium = SizeTemplate.bind({});
-Medium.args = { ...commonArgs, ...sizeArgs };
+Medium.args = { ...commonArgs, ...sizeArgs, size: 'medium' };
 Medium.argTypes = disabledControlsSizeArgTypes;
 
 export const Small = SizeTemplate.bind({});


### PR DESCRIPTION
# Description

Shortcut: [#277277](https://app.shortcut.com/cartoteam/story/277277/components-appbar)
[sc-277277]

Ths PR includes:
- Inptus with size small by default (applies to TextField, Textarea, Select, Search, UploadField and Autocomplete)
- Select:
    - fix in padding (filled variant)
    - fix a types error
