### PR TITLE
Add FeaturesDroppedLoader to extract header value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 1.5
 
+## 1.5.0-alpha.11 (2023-01-12)
+
+- Remove custom fetch function. Fixes issues with icon loading and FillStyleExtensions
+
 ## 1.5.0-alpha.10 (2023-01-04)
 
 - Allow to use custom version explicitly in GoogleMap (not 'beta' by default now) [#550](https://github.com/CartoDB/carto-react/pull/550)

--- a/packages/react-api/__tests__/hooks/useCartoLayerProps.test.js
+++ b/packages/react-api/__tests__/hooks/useCartoLayerProps.test.js
@@ -13,6 +13,7 @@ describe('useCartoLayerProps', () => {
       'binary',
       'onViewportLoad',
       'fetch',
+      'loaders',
       'onDataLoad',
       'id',
       'visible',

--- a/packages/react-api/src/hooks/FeaturesDroppedLoader.js
+++ b/packages/react-api/src/hooks/FeaturesDroppedLoader.js
@@ -1,0 +1,13 @@
+export default {
+  name: 'FeaturesDroppedLoader',
+  module: 'carto',
+  category: 'geometry',
+  extensions: [],
+  // By only specifying `carto-vector-tile` the SpatialIndexLayer will not use this loader
+  mimeTypes: ['application/vnd.carto-vector-tile'],
+  parse: async (arrayBuffer, options, context) => {
+    const isDroppingFeatures = context.response.headers['features-dropped-from-tile'];
+    const result = await context.parse(arrayBuffer, options, context);
+    return result ? { ...result, isDroppingFeatures } : null;
+  }
+};

--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -5,6 +5,7 @@ import useGeojsonFeatures from './useGeojsonFeatures';
 import useTileFeatures from './useTileFeatures';
 import { getDataFilterExtensionProps } from './dataFilterExtensionUtil';
 import { getMaskExtensionProps } from './maskExtensionUtil';
+import FeaturesDroppedLoader from './FeaturesDroppedLoader';
 
 export default function useCartoLayerProps({
   source,
@@ -51,6 +52,7 @@ export default function useCartoLayerProps({
     ...(viewportFeatures && {
       onViewportLoad,
       fetch,
+      loaders: [FeaturesDroppedLoader],
       onDataLoad
     })
   };

--- a/packages/react-api/src/hooks/useTileFeatures.js
+++ b/packages/react-api/src/hooks/useTileFeatures.js
@@ -132,11 +132,7 @@ export default function useTileFeatures({
   const fetch = useCallback(
     (...args) => {
       stopAnyCompute();
-
-      if (spatialIndex) {
-        return Layer.defaultProps.fetch.value(...args);
-      }
-      return customFetch(...args);
+      return Layer.defaultProps.fetch.value(...args);
     },
     [stopAnyCompute, spatialIndex]
   );
@@ -155,19 +151,6 @@ export default function useTileFeatures({
 
   return [onDataLoad, onViewportLoad, fetch];
 }
-
-// WORKAROUND: To read headers and know if the tile is dropping features.
-const customFetch = async (url, { layer, loaders, loadOptions, signal }) => {
-  loadOptions = loadOptions || layer.getLoadOptions();
-  loaders = loaders || layer.props.loaders;
-
-  const headers = loadOptions.fetch.headers;
-  const response = await fetch(url, { signal, headers });
-  const isDroppingFeatures =
-    response.headers.get('Features-Dropped-From-Tile') === 'true';
-  const result = await parse(response, loaders, loadOptions);
-  return result ? { ...result, isDroppingFeatures } : null;
-};
 
 const getColumnNameFromGeoColumn = (geoColumn) => {
   const parts = geoColumn.split(':');

--- a/packages/react-api/src/index.js
+++ b/packages/react-api/src/index.js
@@ -4,6 +4,7 @@ export { getStats as _getStats } from './api/stats';
 export { getTileJson as _getTileJson } from './api/tilejson';
 export { executeModel as _executeModel } from './api/model';
 
+export { default as FeaturesDroppedLoader } from './hooks/FeaturesDroppedLoader';
 export { default as useCartoLayerProps } from './hooks/useCartoLayerProps';
 
 export { getDataFilterExtensionProps } from './hooks/dataFilterExtensionUtil';


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/268367/header-reading-loader-mode-in-deck-gl
- Update loaders.gl to include header reading functionality
- Use custom loader to parse out header to avoid having to invoke custom fetch function

## Type of change

- Refactor

# Acceptance

I have struggled to link the C4R codebase to another project, and had to test by copying files across into a modified project. For full acceptance it would be good for someone with more experience working with C4R to try linking in this modified code into an existing app to verify the feature dropping behavior works as expected