### PR TITLE
Adjustments in theme to fix uses cases in cloud-native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+-Adjustments in theme to fix uses cases in cloud-native [#567](https://github.com/CartoDB/carto-react/pull/567)
+
 - Cherry pick from #531 PR [#564](https://github.com/CartoDB/carto-react/pull/564)
 - Widgets adapted to the new design system [#562](https://github.com/CartoDB/carto-react/pull/562)
 - Adjustments in theme to fix uses cases in cloud-native [#560](https://github.com/CartoDB/carto-react/pull/560)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Not released
 
--Adjustments in theme to fix uses cases in cloud-native [#567](https://github.com/CartoDB/carto-react/pull/567)
-
+- Adjustments in theme to fix uses cases in cloud-native [#567](https://github.com/CartoDB/carto-react/pull/567)
 - Cherry pick from #531 PR [#564](https://github.com/CartoDB/carto-react/pull/564)
 - Widgets adapted to the new design system [#562](https://github.com/CartoDB/carto-react/pull/562)
 - Adjustments in theme to fix uses cases in cloud-native [#560](https://github.com/CartoDB/carto-react/pull/560)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -21,9 +21,21 @@ Also added some files for shared constants (`themeConstants.js`) and useful func
 
 Removed unused custom `createTheme` function in `carto-theme.js`.
 
+## theme.spacing
+
 We have a new custom spacing constant in carto-theme, `spacingValue`, which you should use instead of the common `theme.spacing()` function in cases where you need to do value calculations, because since Mui v5, theme.spacing is no longer a number, but a string in this format: `number + px`.
 
 Note that if you're using `calc()` in your styles, you can keep using `theme.spacing()` as usual.
+
+Needed changes:
+
+1. Change `${theme.spacing(xx)}px` by `${theme.spacing(xx)}`. It means, without the `px` ending, since in Mui v5 it is appended to the end of the string by default.
+
+Tip: An easy search to catch up them, would be `)}px`
+
+2. Change `-theme.spacing(xx)` by `theme.spacing(-xx)`. It means, move the negative symbol inside the function.
+
+An easy search would be `-theme.spacing(`
 
 ## Typography
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -31,11 +31,11 @@ Needed changes:
 
 1. Change `${theme.spacing(xx)}px` by `${theme.spacing(xx)}`. It means, without the `px` ending, since in Mui v5 it is appended to the end of the string by default.
 
-Tip: An easy search to catch up them, would be `)}px`
+Tip: An easy search to catch up this, would be `)}px`
 
 2. Change `-theme.spacing(xx)` by `theme.spacing(-xx)`. It means, move the negative symbol inside the function.
 
-An easy search would be `-theme.spacing(`
+Tip: An easy search to catch up this, would be `-theme.spacing(`
 
 ## Typography
 

--- a/packages/react-ui/src/theme/sections/components/forms.js
+++ b/packages/react-ui/src/theme/sections/components/forms.js
@@ -536,12 +536,16 @@ export const formsOverrides = {
         '&:hover': {
           backgroundColor: commonPalette.action.hover
         },
+        '&.MuiSwitch-switchBase input': {
+          top: getSpacing(1),
+          left: getSpacing(1)
+        },
         '&.Mui-checked': {
           transform: 'translate(0, -8px)',
           color: commonPalette.common.white,
 
-          '& input': {
-            left: getSpacing(-1.5)
+          '&.MuiSwitch-switchBase input': {
+            left: 0
           },
           '& + .MuiSwitch-track': {
             opacity: 1,

--- a/packages/react-ui/src/theme/sections/components/forms.js
+++ b/packages/react-ui/src/theme/sections/components/forms.js
@@ -335,8 +335,11 @@ export const formsOverrides = {
           {
             marginTop: 0
           },
-        '& .MuiSvgIcon-root': {
+        '& .MuiSvgIcon-root, & svg': {
           fontSize: ICON_SIZE,
+          width: ICON_SIZE,
+          minWidth: ICON_SIZE,
+          height: ICON_SIZE,
           color: commonPalette.text.secondary
         },
         '.Mui-disabled &': {

--- a/packages/react-ui/src/theme/sections/typography.js
+++ b/packages/react-ui/src/theme/sections/typography.js
@@ -97,10 +97,10 @@ const baseTypography = {
   },
   overline: {
     fontFamily: 'Inter, sans-serif',
-    fontWeight: 600,
+    fontWeight: 500,
     fontSize: getPixelToRem(10),
     lineHeight: 1.2,
-    letterSpacing: '2px',
+    letterSpacing: '1.2px',
     textTransform: 'uppercase'
   }
 };

--- a/packages/react-ui/src/widgets/NoDataAlert.js
+++ b/packages/react-ui/src/widgets/NoDataAlert.js
@@ -7,6 +7,7 @@ function AlertBody({ color = undefined, children }) {
   return children ? (
     <Box mt={0.5}>
       <Typography
+        component='div'
         variant='caption'
         color={color || 'inherit'}
         style={{ fontWeight: 'normal' }}

--- a/packages/react-ui/storybook/stories/widgetsUI/NoDataAlert.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/NoDataAlert.stories.js
@@ -1,5 +1,5 @@
-import { NoDataAlert } from '@carto/react-ui';
 import React from 'react';
+import NoDataAlert from '../../../src/widgets/NoDataAlert';
 import { buildReactPropsAsString } from '../../utils';
 
 const options = {
@@ -35,7 +35,7 @@ Empty.parameters = buildReactPropsAsString({}, 'NoDataAlert');
 
 export const CustomTexts = Template.bind({});
 const CustomTextsProps = {
-  titlee: 'Example',
+  title: 'Example',
   body: "Hey, I've modified the NoDataAlert component"
 };
 CustomTexts.args = CustomTextsProps;


### PR DESCRIPTION
# Description

Shortcut: [#283096](https://app.shortcut.com/cartoteam/story/283096/workflows-panels)
sc: [sc-283096]

Includes
- Design change in overline typography variant
- Fix switch clickable area when is not wrapped by a label
- MuiInputAdornment icon size
- Widgets NoDataAvailable fix in caption line height and story
- Added some help in the upgrade file that we are using in CN migration and will be helpful to PS.