### PR TITLE
fix(react-ui-docs): Fix typo in Carto for React link

### DIFF
--- a/packages/react-ui/README.md
+++ b/packages/react-ui/README.md
@@ -14,4 +14,4 @@
 
 Package with UI components, based on MaterialUI + a CARTO theme
 
-See the official doc & reference at [CARTO for React](https://docs.carto.com/react/)
+See the official doc & reference at [CARTO for React](https://docs.carto.com/development-tools/carto-for-react)


### PR DESCRIPTION
# Description

Shortcut: https://github.com/CartoDB/carto-react/tree/master/packages/react-ui

Please include a summary of the change. If required, also include relevant info about motivation and context... And if PR includes UI elements (or if it helps for understanding it), please add extra files: snapshots, videos...

## Type of change

- Documentation

# Acceptance

Please describe how to validate the feature or fix

1. go to react-ui docs
2. click the CARTO for React link
3. on master, the link returns `404`

# Basic checklist

- Good PR name ✅ 
- Shortcut link✅ 
- Changelog entry 🚫
- Just one issue per PR 🚫
- GitHub labels
- Proper status & reviewers 
- Tests 🚫 
- Documentation ✅ 
