### PR TITLE
Adjustments in theme to fix uses cases in cloud-native 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Adjustments in theme to fix uses cases in cloud-native [#572](https://github.com/CartoDB/carto-react/pull/572)
 - Update design-system branch with master [#563](https://github.com/CartoDB/carto-react/pull/563)
 - Adjustments in theme to fix uses cases in cloud-native [#567](https://github.com/CartoDB/carto-react/pull/567)
 - Cherry pick from #531 PR [#564](https://github.com/CartoDB/carto-react/pull/564)

--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -58,7 +58,6 @@ export const dataDisplayOverrides = {
     defaultProps: {
       primaryTypographyProps: {
         variant: 'body2',
-        style: { fontWeight: themeTypography.fontWeightBold },
         noWrap: true
       },
       secondaryTypographyProps: { variant: 'caption' }
@@ -67,11 +66,13 @@ export const dataDisplayOverrides = {
   MuiListItemIcon: {
     styleOverrides: {
       root: {
-        minWidth: getSpacing(5.75),
-        marginLeft: getSpacing(0.75),
+        marginRight: getSpacing(1),
 
         '& .MuiSvgIcon-root': {
           fontSize: ICON_SIZE_M
+        },
+        '.MuiMenuItem-root.MuiButtonBase-root &': {
+          minWidth: getSpacing(2.25)
         }
       }
     }
@@ -80,8 +81,8 @@ export const dataDisplayOverrides = {
     styleOverrides: {
       root: {
         '& .MuiAvatar-root': {
-          height: getSpacing(4.5),
-          width: getSpacing(4.5)
+          height: getSpacing(4),
+          width: getSpacing(4)
         },
         '& .MuiSvgIcon-root': {
           fontSize: ICON_SIZE

--- a/packages/react-ui/src/theme/sections/components/navigation.js
+++ b/packages/react-ui/src/theme/sections/components/navigation.js
@@ -93,7 +93,7 @@ export const navigationOverrides = {
         '&.Mui-selected': {
           pointerEvents: 'none',
 
-          '& svg path': {
+          '& svg:not(.doNotFillIcon) path': {
             fill: commonPalette.primary.main
           }
         },

--- a/packages/react-ui/src/theme/sections/components/navigation.js
+++ b/packages/react-ui/src/theme/sections/components/navigation.js
@@ -9,6 +9,7 @@ export const navigationOverrides = {
     styleOverrides: {
       root: {
         ...themeTypography.body2,
+        minHeight: getSpacing(4),
         height: getSpacing(4),
         transition: 'background-color 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
 
@@ -41,6 +42,10 @@ export const navigationOverrides = {
         '& .MuiCheckbox-root, & > .MuiSvgIcon-root': {
           marginRight: getSpacing(1)
         }
+      },
+      dense: {
+        minHeight: getSpacing(3),
+        height: getSpacing(3)
       }
     }
   },

--- a/packages/react-ui/src/theme/sections/components/surfaces.js
+++ b/packages/react-ui/src/theme/sections/components/surfaces.js
@@ -1,5 +1,5 @@
 import { getSpacing } from '../../themeUtils';
-import { APPBAR_SIZE, APPBAR_SIZE_M, BREAKPOINTS } from '../../themeConstants';
+import { APPBAR_SIZE } from '../../themeConstants';
 import { commonPalette } from '../palette';
 import { themeShadows } from '../shadows';
 

--- a/packages/react-ui/src/widgets/legend/LegendCategories.js
+++ b/packages/react-ui/src/widgets/legend/LegendCategories.js
@@ -163,12 +163,16 @@ function Row({ label, isMax, isStrokeColor, color = '#000', icon, maskedIcon }) 
             }
           />
         </Tooltip>
-        <Typography ref={labelRef} variant='overline' className={classes.longTruncate}>
+        <Typography
+          ref={labelRef}
+          variant='overlineDelicate'
+          className={classes.longTruncate}
+        >
           {label}
         </Typography>
         <Typography
           ref={labelPhantomRef}
-          variant='overline'
+          variant='overlineDelicate'
           className={[classes.longTruncate, classes.titlePhantom].join(' ')}
         >
           {label}

--- a/packages/react-ui/src/widgets/legend/LegendIcon.js
+++ b/packages/react-ui/src/widgets/legend/LegendIcon.js
@@ -13,7 +13,7 @@ function LegendIcon({ legend }) {
       <Box mr={1.5} width={ICON_SIZE} height={ICON_SIZE}>
         <img src={icons[idx]} alt={label} width={ICON_SIZE} height={ICON_SIZE} />
       </Box>
-      <Typography variant='overline'>{label}</Typography>
+      <Typography variant='overlineDelicate'>{label}</Typography>
     </Grid>
   ));
 

--- a/packages/react-ui/storybook/stories/organisms/Menu.stories.js
+++ b/packages/react-ui/storybook/stories/organisms/Menu.stories.js
@@ -36,15 +36,9 @@ const options = {
 };
 export default options;
 
-const Template = ({ label, wrapped, disabled, ...args }) => {
-  const [value, setValue] = React.useState(0);
-
-  const handleChange = (event, newValue) => {
-    setValue(newValue);
-  };
-
+const Template = ({ label, ...args }) => {
   return (
-    <MenuList {...args} value={value} onChange={handleChange} aria-label='tabs example'>
+    <MenuList {...args}>
       <MenuItem>
         <ListItemIcon>
           <ContentCutOutlined />

--- a/packages/react-ui/storybook/stories/organisms/Menu.stories.js
+++ b/packages/react-ui/storybook/stories/organisms/Menu.stories.js
@@ -83,7 +83,7 @@ const Template = ({ label, wrapped, disabled, ...args }) => {
   );
 };
 
-const commonArgs = { label: 'Label', dense: true };
+const commonArgs = { label: 'Label', dense: false };
 
 export const Playground = Template.bind({});
 Playground.args = { ...commonArgs };

--- a/packages/react-ui/storybook/stories/organisms/Menu.stories.js
+++ b/packages/react-ui/storybook/stories/organisms/Menu.stories.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Divider, ListItemIcon, ListItemText, MenuItem, MenuList } from '@mui/material';
+import {
+  CloudOutlined,
+  ContentCopyOutlined,
+  ContentCutOutlined,
+  ContentPasteOutlined
+} from '@mui/icons-material';
+import Typography from '../../../src/components/atoms/Typography';
+
+const options = {
+  title: 'Organisms/Menu',
+  component: MenuList,
+  argTypes: {
+    label: {
+      control: {
+        type: 'text'
+      }
+    },
+    dense: {
+      defaultValue: false,
+      control: {
+        type: 'boolean'
+      }
+    }
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/nmaoLeo69xBJCHm9nc6lEV/CARTO-Components-1.0?node-id=1534%3A29229&t=0T8NJiytWngAdJeO-0'
+    },
+    status: {
+      type: 'inDevelopment'
+    }
+  }
+};
+export default options;
+
+const Template = ({ label, wrapped, disabled, ...args }) => {
+  const [value, setValue] = React.useState(0);
+
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+  };
+
+  return (
+    <MenuList {...args} value={value} onChange={handleChange} aria-label='tabs example'>
+      <MenuItem>
+        <ListItemIcon>
+          <ContentCutOutlined />
+        </ListItemIcon>
+        <ListItemText>{label}</ListItemText>
+        <Typography variant='body2' color='text.secondary'>
+          ⌘X
+        </Typography>
+      </MenuItem>
+      <MenuItem>
+        <ListItemIcon>
+          <ContentCopyOutlined />
+        </ListItemIcon>
+        <ListItemText>{label}</ListItemText>
+        <Typography variant='body2' color='text.secondary'>
+          ⌘C
+        </Typography>
+      </MenuItem>
+      <MenuItem>
+        <ListItemIcon>
+          <ContentPasteOutlined />
+        </ListItemIcon>
+        <ListItemText>{label}</ListItemText>
+        <Typography variant='body2' color='text.secondary'>
+          ⌘V
+        </Typography>
+      </MenuItem>
+      <Divider />
+      <MenuItem>
+        <ListItemIcon>
+          <CloudOutlined />
+        </ListItemIcon>
+        <ListItemText>{label}</ListItemText>
+      </MenuItem>
+    </MenuList>
+  );
+};
+
+const commonArgs = { label: 'Label', dense: true };
+
+export const Playground = Template.bind({});
+Playground.args = { ...commonArgs };


### PR DESCRIPTION
# Description

Shortcut: [#275482](https://app.shortcut.com/cartoteam/story/275482/builder-layers-panel)
sc: [sc-275482]

Includes
- Menu and ListItem components minimal redesign
- Tabs selected color fix
- Typography change in legends widgets