### PR TITLE
Fix ComparativeCategoryWidgetUI tooltip formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- fix category tooltip formatter [#579](https://github.com/CartoDB/carto-react/pull/579)
+
 ## 1.5
 
 ## 1.5.0-alpha.12 (2023-01-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- fix category tooltip formatter [#579](https://github.com/CartoDB/carto-react/pull/579)
+- Fix ComparativeCategoryWidgetUI tooltip formatter [#579](https://github.com/CartoDB/carto-react/pull/579)
 
 ## 1.5
 

--- a/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/CategoryItem.js
+++ b/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/CategoryItem.js
@@ -59,7 +59,7 @@ function ComparativeCategoryTooltip({ item, index, names, formatter = IDENTITY_F
           <Box flexGrow={1}></Box>
           <Box ml={1} px={1} bgcolor={numberColor} color='white' borderRadius={2}>
             <Typography color='inherit' variant='caption'>
-              {signText}{formatter(Math.abs(compareValue))}%
+              {signText}{formatter(Math.abs(compareValue))}
             </Typography>
           </Box>
         </Box>
@@ -85,7 +85,8 @@ const StyledTooltip = withStyles((theme) => ({
   tooltip: {
     color: theme.palette.common.white,
     maxWidth: 260,
-    marginBottom: 0
+    marginBottom: 0,
+    overflow: 'hidden'
   }
 }))(Tooltip);
 

--- a/packages/react-ui/storybook/stories/widgetsUI/ComparativeCategoryWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/ComparativeCategoryWidgetUI.stories.js
@@ -44,5 +44,5 @@ Default.args = {
   labels: ['label 1', 'label 2', 'label 3', 'label 4', 'label 5', 'label 6'],
   colors: ['#f27', '#fa0', '#32a852'],
   maxItems: 3,
-  tooltipFormatter: n => Number(n).toFixed(2)
+  tooltipFormatter: n => `${Number(n).toFixed(2)}%`
 };


### PR DESCRIPTION
# Description

This PR includes a fix for the tooltip content and formatter in the comparative category widget.

When not applying a `tooltipFormatter`, the tooltip in category widget looks like this:
<img width="313" alt="Screenshot 2023-01-20 at 2 52 07 PM" src="https://user-images.githubusercontent.com/6652814/213723307-674efbe2-c522-40d2-84e5-a7995d8e04a0.png">

When applying the default % formatter in the ps projects, the tooltip look like this (with two % symbols):
<img width="262" alt="Screenshot 2023-01-20 at 2 59 49 PM" src="https://user-images.githubusercontent.com/6652814/213723555-26a9611f-48fc-422c-850f-c387d7968f5b.png">

This PR removes the '%' symbol from the code, leaving that to the tooltipFormatter. It also applies a `overflow: hidden` to the tooltip wrapper so content does not overflow like in this first image.

## Type of change

- Fix

# Acceptance

- Tooltip should not show overflown content
- Tooltip should not add a % symbol by default

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
