### PR TITLE
Improve typing for FeatureSelectionWidget

### DIFF
--- a/packages/react-widgets/src/types.d.ts
+++ b/packages/react-widgets/src/types.d.ts
@@ -108,3 +108,10 @@ export type WidgetWithAlert = {
   droppingFeaturesAlertProps?: object;
   children?: React.ReactNode;
 }
+
+export type FeatureSelectionWidget = {
+  className?: string;
+  selectionModes?: string[],
+  editModes?: string[],
+  tooltipPlacement?: string,
+}

--- a/packages/react-widgets/src/widgets/FeatureSelectionWidget.js
+++ b/packages/react-widgets/src/widgets/FeatureSelectionWidget.js
@@ -113,8 +113,6 @@ function FeatureSelectionWidget({
 FeatureSelectionWidget.defaultProps = {
   selectionModes: Object.values(FEATURE_SELECTION_MODES),
   editModes: Object.values(EDIT_MODES_KEYS),
-  defaultSelectedMode: Object.values(FEATURE_SELECTION_MODES)[0],
-  defaultEnabled: FeatureSelectionWidgetUI.defaultProps.enabled,
   tooltipPlacement: FeatureSelectionWidgetUI.defaultProps.tooltipPlacement
 };
 
@@ -124,11 +122,6 @@ FeatureSelectionWidget.propTypes = {
     PropTypes.oneOf(Object.values(FEATURE_SELECTION_MODES))
   ),
   editModes: PropTypes.arrayOf(PropTypes.oneOf(Object.values(EDIT_MODES_KEYS))),
-  defaultEnabled: FeatureSelectionWidgetUI.propTypes.enabled,
-  defaultSelectedMode: PropTypes.oneOf([
-    ...Object.values(FEATURE_SELECTION_MODES),
-    ...Object.values(EDIT_MODES_KEYS)
-  ]),
   tooltipPlacement: FeatureSelectionWidgetUI.propTypes.tooltipPlacement
 };
 


### PR DESCRIPTION
# Description

Just fixing a little thing I remarked when playing with this widget (finally proposing a builder-only solution).
- clear obsolete PropTypes
- add a TypeScript declaration