### PR TITLE
Fix gmaps mandatory callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix gmaps warning caused by callback now been mandatary from version >=3.51.6 [#581](https://github.com/CartoDB/carto-react/pull/581)
+
 ## 1.5
 
 ## 1.5.0-alpha.12 (2023-01-20)

--- a/packages/react-basemaps/src/basemaps/GoogleMap.js
+++ b/packages/react-basemaps/src/basemaps/GoogleMap.js
@@ -140,7 +140,7 @@ export function GoogleMap(props) {
       script.async = true;
       script.type = `text/javascript`;
 
-      let url = `https://maps.google.com/maps/api/js?key=${apiKey}`;
+      let url = `https://maps.google.com/maps/api/js?key=${apiKey}&callback=Function.prototype`;
       if (customVersion) url = `${url}&v=${customVersion}`;
       script.src = url;
       const headScript = document.getElementsByTagName(`script`)[0];


### PR DESCRIPTION
# Description

Since 2023-01-20 (version 3.51.6), synchronous load of google maps api throws this warning: "Loading the Google Maps JavaScript API without a callback is not supported". 

The reason is they have recently forced to specify the ‘callback’ parameter (callback: is the name of a global function to be called once the Maps JavaScript API loads completely)

## Type of change

- Fix

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
