### PR TITLE
Convert isDroppingFeatures to Boolean

### DIFF
--- a/packages/react-api/src/hooks/FeaturesDroppedLoader.js
+++ b/packages/react-api/src/hooks/FeaturesDroppedLoader.js
@@ -7,7 +7,8 @@ export default {
   // By only specifying `carto-vector-tile` the SpatialIndexLayer will not use this loader
   mimeTypes: ['application/vnd.carto-vector-tile'],
   parse: async (arrayBuffer, options, context) => {
-    const isDroppingFeatures = context.response.headers['features-dropped-from-tile'];
+    const isDroppingFeatures =
+      context.response.headers['features-dropped-from-tile'] === 'true';
     const result = await context.parse(arrayBuffer, options, context);
     return result ? { ...result, isDroppingFeatures } : null;
   }


### PR DESCRIPTION
Follow up to https://github.com/CartoDB/carto-react/pull/561

Loader is returning `'true'|'false'` rather than `true|false`