### PR TITLE
Adjustments in theme to fix uses cases in cloud-native

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -45,8 +45,9 @@ We have this kind of rules in buttons to cover the common use cases:
 
 `svg path { fill: currentColor }`
 
-In case you don't need the icon to be filled, you can apply this class to the svg parent:
-`.doNotFillIcon`
+In case you don't need the icon to be filled, you can apply this class to the svg parent: `.doNotFillIcon`
+
+`<CloseIcon className="doNotFillIcon" />`
 
 ## Typography
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -27,6 +27,8 @@ We have a new custom spacing constant in carto-theme, `spacingValue`, which you 
 
 Note that if you're using `calc()` in your styles, you can keep using `theme.spacing()` as usual.
 
+`theme.spacingValue * 2`
+
 Needed changes:
 
 1. Change `${theme.spacing(xx)}px` by `${theme.spacing(xx)}`. It means, without the `px` ending, since in Mui v5 it is appended to the end of the string by default.
@@ -36,6 +38,15 @@ Tip: An easy search to catch up this, would be `)}px`
 2. Change `-theme.spacing(xx)` by `theme.spacing(-xx)`. It means, move the negative symbol inside the function.
 
 Tip: An easy search to catch up this, would be `-theme.spacing(`
+
+## Icons
+
+We have this kind of rules in buttons to cover the common use cases:
+
+`svg path { fill: currentColor }`
+
+In case you don't need the icon to be filled, you can apply this class to the svg parent:
+`.doNotFillIcon`
 
 ## Typography
 

--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -173,6 +173,10 @@ export const dataDisplayOverrides = {
     }
   },
   MuiDialogTitle: {
+    defaultProps: {
+      variant: 'subtitle1'
+    },
+
     styleOverrides: {
       root: {
         padding: getSpacing(3, 3, 2)
@@ -191,6 +195,12 @@ export const dataDisplayOverrides = {
   MuiDialogContentText: {
     defaultProps: {
       variant: 'body2'
+    },
+
+    styleOverrides: {
+      root: {
+        color: commonPalette.text.primary
+      }
     }
   },
 

--- a/packages/react-ui/src/theme/sections/components/feedback.js
+++ b/packages/react-ui/src/theme/sections/components/feedback.js
@@ -1,7 +1,7 @@
 export const feedbackOverrides = {
   // SnackBar
-  MuiSnackBar: {
-    DefaultProps: {
+  MuiSnackbar: {
+    defaultProps: {
       anchorOrigin: {
         vertical: 'bottom',
         horizontal: 'center'

--- a/packages/react-ui/storybook/stories/molecules/Snackbar.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/Snackbar.stories.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import { Button, IconButton, Snackbar } from '@mui/material';
+import { CloseOutlined } from '@mui/icons-material';
+
+const options = {
+  title: 'Molecules/Snackbar',
+  component: Snackbar,
+  argTypes: {
+    message: {
+      control: {
+        type: 'text'
+      }
+    }
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/nmaoLeo69xBJCHm9nc6lEV/CARTO-Components-1.0?node-id=3840%3A74274&t=8yIyrIS5EqFhj2RB-0'
+    },
+    status: {
+      type: 'inDevelopment'
+    }
+  }
+};
+export default options;
+
+const Template = ({ message, ...args }) => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleClick = () => {
+    setOpen(true);
+  };
+
+  const handleClose = (event, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  const action = (
+    <>
+      <Button color='secondary' variant='text' onClick={handleClose}>
+        Undo
+      </Button>
+      <IconButton aria-label='close' color='inherit' onClick={handleClose}>
+        <CloseOutlined />
+      </IconButton>
+    </>
+  );
+
+  return (
+    <>
+      <Button onClick={handleClick}>Open snackbar</Button>
+      <Snackbar open={open} onClose={handleClose} message={message} action={action} />
+    </>
+  );
+};
+
+const AutoHideTemplate = ({ message, ...args }) => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleClick = () => {
+    setOpen(true);
+  };
+
+  const handleClose = (event, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  const action = (
+    <>
+      <Button color='secondary' variant='text' onClick={handleClose}>
+        Undo
+      </Button>
+    </>
+  );
+
+  return (
+    <>
+      <Button onClick={handleClick}>Open snackbar</Button>
+      <Snackbar
+        open={open}
+        autoHideDuration={3000}
+        message={message}
+        action={action}
+        onClose={handleClose}
+      />
+    </>
+  );
+};
+
+const commonArgs = { message: 'This is an inline content snackbar' };
+
+export const Playground = Template.bind({});
+Playground.args = { ...commonArgs };
+
+export const AutoHide = AutoHideTemplate.bind({});
+AutoHide.args = { ...commonArgs };


### PR DESCRIPTION
# Description

Shortcut: [#280106](https://app.shortcut.com/cartoteam/story/280106/workflows-general-dragging-area)
sc: [sc-280106]

Includes
- Snackbar default props fix and basic story added
- Dialog tweaks in default props and styles
- Added some help in the upgrade file that we are using in CN migration and will be helpful to PS