### PR TITLE
Fix Support MVT in FeaturesDroppedLoader

### DIFF
--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -70,6 +70,7 @@
     "@deck.gl/carto": "^8.8.23",
     "@deck.gl/core": "^8.8.23",
     "@deck.gl/extensions": "^8.8.23",
+    "@loaders.gl/mvt": "^3.2.10",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-redux": "^7.2.2",

--- a/packages/react-api/src/hooks/FeaturesDroppedLoader.js
+++ b/packages/react-api/src/hooks/FeaturesDroppedLoader.js
@@ -1,3 +1,5 @@
+import { MVTWorkerLoader } from '@loaders.gl/mvt';
+
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {
   name: 'FeaturesDroppedLoader',
@@ -5,11 +7,14 @@ export default {
   category: 'geometry',
   extensions: [],
   // By only specifying `carto-vector-tile` the SpatialIndexLayer will not use this loader
-  mimeTypes: ['application/vnd.carto-vector-tile'],
+  mimeTypes: ['application/vnd.carto-vector-tile', ...MVTWorkerLoader.mimeTypes],
   parse: async (arrayBuffer, options, context) => {
     const isDroppingFeatures =
       context.response.headers['features-dropped-from-tile'] === 'true';
-    const result = await context.parse(arrayBuffer, options, context);
+    const isMVT = MVTWorkerLoader.mimeTypes.includes(options.mimeType);
+    const result = isMVT
+      ? await context.parse(arrayBuffer, MVTWorkerLoader, options, context)
+      : await context.parse(arrayBuffer, options, context);
     return result ? { ...result, isDroppingFeatures } : null;
   }
 };


### PR DESCRIPTION
# Description

Needed to land https://github.com/CartoDB/cloud-native/pull/10764

We missed handling loading of MVT tiles. The loader is enhanced to support the MVT loading depending on the mimetype. Note on the added dependency, this is already being pulled in as part of deck's `MVTLayer`, the reference in `package.json` just makes it explicit.

## Type of change

(choose one and remove the others)

- Fix

# Acceptance

Please describe how to validate the feature or fix

1. Include dependency in Builder
2. Successfully load any MVT dataset (tilesets in BQ or dynamic tiles in PG) https://docs.google.com/spreadsheets/d/1TzWn-GjEUuMDPuNv09YCKZ2yLM6zMvbfcQB_BrZTKrQ/edit#gid=0


# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
