### PR TITLE
Provide unified clientId for metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Provide unified CLIENT_ID for metrics [#591](https://github.com/CartoDB/carto-react/pull/591)
+
 ## 1.5
 
 ### 1.5.0 (2023-01-31)

--- a/packages/react-api/__tests__/api/tilejson.test.js
+++ b/packages/react-api/__tests__/api/tilejson.test.js
@@ -1,5 +1,6 @@
 import { getTileJson } from '../../src/api/tilejson';
 import { MAP_TYPES, API_VERSIONS } from '@deck.gl/carto';
+import { CLIENT_ID } from '@carto/react-api/api/common';
 
 const mockedFetchLayerData = jest.fn();
 
@@ -35,7 +36,7 @@ describe('tilejson', () => {
       const tilejson = await getTileJson({ source });
 
       expect(mockedFetchLayerData).toBeCalledWith({
-        clientId: 'carto-for-react',
+        clientId: CLIENT_ID,
         connection: '__test_connection__',
         credentials: {
           accessToken: '__test_api_key__',

--- a/packages/react-api/__tests__/api/tilejson.test.js
+++ b/packages/react-api/__tests__/api/tilejson.test.js
@@ -1,6 +1,5 @@
 import { getTileJson } from '../../src/api/tilejson';
 import { MAP_TYPES, API_VERSIONS } from '@deck.gl/carto';
-import { CLIENT_ID } from '@carto/react-api/api/common';
 
 const mockedFetchLayerData = jest.fn();
 
@@ -36,7 +35,7 @@ describe('tilejson', () => {
       const tilejson = await getTileJson({ source });
 
       expect(mockedFetchLayerData).toBeCalledWith({
-        clientId: CLIENT_ID,
+        clientId: 'carto-for-react', // hardcoded as no neeed to export CLIENT_ID from '@carto/react-api/api/common';
         connection: '__test_connection__',
         credentials: {
           accessToken: '__test_api_key__',

--- a/packages/react-api/src/api/SQL.js
+++ b/packages/react-api/src/api/SQL.js
@@ -2,9 +2,8 @@ import { encodeParameter, getRequest, postRequest } from '@carto/react-core';
 import { REQUEST_GET_MAX_URL_LENGTH } from '@carto/react-core';
 import { API_VERSIONS } from '@deck.gl/carto';
 
-import { dealWithApiError } from './common';
+import { dealWithApiError, CLIENT_ID } from './common';
 
-const CLIENT = 'carto-react';
 const DEFAULT_USER_COMPONENT_IN_URL = '{user}';
 
 /**
@@ -79,7 +78,7 @@ function createRequest({
   const { apiVersion = API_VERSIONS.V2 } = credentials;
 
   const rawParams = {
-    client: CLIENT,
+    client: CLIENT_ID,
     q: query?.trim(),
     ...otherOptions
   };
@@ -117,7 +116,7 @@ function createRequest({
   // Post request
   const urlParamsForPost =
     apiVersion === API_VERSIONS.V3
-      ? [`access_token=${credentials.accessToken}`, `client=${CLIENT}`]
+      ? [`access_token=${credentials.accessToken}`, `client=${CLIENT_ID}`]
       : null;
 
   const payload = {

--- a/packages/react-api/src/api/common.js
+++ b/packages/react-api/src/api/common.js
@@ -60,3 +60,5 @@ export async function makeCall({ url, credentials, opts }) {
 
   return data;
 }
+
+export const CLIENT_ID = 'carto-for-react';

--- a/packages/react-api/src/api/tilejson.js
+++ b/packages/react-api/src/api/tilejson.js
@@ -1,4 +1,4 @@
-import { checkCredentials } from './common';
+import { checkCredentials, CLIENT_ID } from './common';
 import { MAP_TYPES, API_VERSIONS, fetchLayerData, FORMATS } from '@deck.gl/carto';
 import { _assert as assert } from '@carto/react-core/';
 
@@ -30,7 +30,7 @@ export async function getTileJson(props) {
     connection: source.connection,
     credentials: source.credentials,
     format: FORMATS.TILEJSON,
-    clientId: 'carto-for-react'
+    clientId: CLIENT_ID
   });
 
   assert(format === FORMATS.TILEJSON, 'getTileJson: data is not a tilejson');

--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -6,6 +6,7 @@ import useTileFeatures from './useTileFeatures';
 import { getDataFilterExtensionProps } from './dataFilterExtensionUtil';
 import { getMaskExtensionProps } from './maskExtensionUtil';
 import FeaturesDroppedLoader from './FeaturesDroppedLoader';
+import { CLIENT_ID } from '../api/common';
 
 export default function useCartoLayerProps({
   source,
@@ -77,7 +78,7 @@ export default function useCartoLayerProps({
     type: source?.type,
     connection: source?.connection,
     credentials: source?.credentials,
-    clientId: 'carto-for-react',
+    clientId: CLIENT_ID,
     queryParameters: source?.queryParameters,
     ...dataFilterExtensionProps,
     ...maskExtensionProps,


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/288237

Unified to 'carto-for-react', vs previous inconsistent 'carto-react' / 'carto-for-react' when calling SQL & MAP apis

## Type of change

- Fix


# Acceptance
-

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
