### PR TITLE
Add bearer token in headers instead of using query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Requests to CARTO APIs V3 will be authorized through the Authorization header instead of using a query param [#592](https://github.com/CartoDB/carto-react/pull/592)
+
 ## 1.5
 
 ### 1.5.0 (2023-01-31)

--- a/packages/react-api/src/api/SQL.js
+++ b/packages/react-api/src/api/SQL.js
@@ -108,13 +108,14 @@ function createRequest({
   });
 
   const isGet = getUrl.length < REQUEST_GET_MAX_URL_LENGTH;
-  if (isGet && apiVersion !== API_VERSIONS.V3) {
-    return getRequest(getUrl, requestOpts);
-  }
-  if (isGet && apiVersion === API_VERSIONS.V3) {
-    return getRequest(getUrl, requestOpts, {
-      Authorization: `Bearer ${credentials.accessToken}`
-    });
+  if (isGet) {
+    if (apiVersion === API_VERSIONS.V3) {
+      return getRequest(getUrl, requestOpts, {
+        Authorization: `Bearer ${credentials.accessToken}`
+      });
+    } else {
+      return getRequest(getUrl, requestOpts);
+    }
   }
 
   // Post request
@@ -129,9 +130,12 @@ function createRequest({
     connection,
     parameters: urlParamsForPost
   });
-  return postRequest(postUrl, payload, requestOpts, {
-    Authorization: `Bearer ${credentials.accessToken}`
-  });
+  if (apiVersion === API_VERSIONS.V3) {
+    return postRequest(postUrl, payload, requestOpts, {
+      Authorization: `Bearer ${credentials.accessToken}`
+    });
+  }
+  return postRequest(postUrl, payload, requestOpts);
 }
 
 /**

--- a/packages/react-core/src/utils/requestsUtils.js
+++ b/packages/react-core/src/utils/requestsUtils.js
@@ -6,11 +6,12 @@ export const REQUEST_GET_MAX_URL_LENGTH = 2048;
 /**
  * Simple GET request
  */
-export function getRequest(url, opts) {
+export function getRequest(url, opts, headers = {}) {
   return new Request(url, {
     method: 'GET',
     headers: {
-      Accept: 'application/json'
+      Accept: 'application/json',
+      ...headers
     },
     ...opts
   });
@@ -19,12 +20,13 @@ export function getRequest(url, opts) {
 /**
  * Simple POST request
  */
-export function postRequest(url, payload, opts) {
+export function postRequest(url, payload, opts, headers = {}) {
   return new Request(url, {
     method: 'POST',
     headers: {
       Accept: 'application/json',
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      ...headers
     },
     body: JSON.stringify(payload),
     ...opts


### PR DESCRIPTION
# Description

Shortcut: (https://app.shortcut.com/cartoteam/story/285013/sql-api-requests-in-c4r-passing-the-token-in-the-url)

We noticed that requests to the APIs V3 were including the authorization token as a query parameter instead of using a header. This change should change this behaviour.

## Type of change

(choose one and remove the others)

- Fix
- [x] Feature
- Refactor
- Tests
- Documentation

# Acceptance

1. Create a React project and add the @carto/react-api dependency
2. Call to the `executeSQL()` method using both a simple query and a complex one that will be performed through a POST request
3. Check that the GET request contains the authorization token in the request's headers:
<img width="655" alt="Screenshot 2023-02-02 at 14 59 57" src="https://user-images.githubusercontent.com/56086628/216344904-6e26635e-3458-41fb-88fc-21e4eddb1241.png">

4. Check that the POST request contains the authorization token in the request's headers:
<img width="624" alt="Screenshot 2023-02-02 at 14 59 39" src="https://user-images.githubusercontent.com/56086628/216344817-9e4a318c-4229-4f87-97bd-df9d21dab006.png">


# Basic checklist

- [x] Good PR name
- [x] Shortcut link
- [x] Changelog entry
- [x] Just one issue per PR
- [x] GitHub labels
- [x] Proper status & reviewers
- [ ] Tests
- [x] Documentation
