### PR TITLE
Add sortByColumnType param to fix number sorting in TableWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Add optional sortByColumnType param to fix number sorting in TableWidget [#593](https://github.com/CartoDB/carto-react/pull/593)
 - Requests to CARTO APIs V3 will be authorized through the Authorization header instead of using a query param [#592](https://github.com/CartoDB/carto-react/pull/592)
 - Provide unified CLIENT_ID for metrics [#591](https://github.com/CartoDB/carto-react/pull/591)
 

--- a/packages/react-widgets/src/models/TableModel.js
+++ b/packages/react-widgets/src/models/TableModel.js
@@ -6,7 +6,7 @@ export function getTable(props) {
 }
 
 function fromLocal(props) {
-  const { source, rowsPerPage, page, sortBy, sortDirection } = props;
+  const { source, rowsPerPage, page, sortBy, sortDirection, sortByColumnType } = props;
 
   return executeTask(source.id, Methods.FEATURES_RAW, {
     filters: source.filters,
@@ -14,6 +14,7 @@ function fromLocal(props) {
     limit: rowsPerPage,
     page,
     sortBy,
-    sortByDirection: sortDirection
+    sortByDirection: sortDirection,
+    sortByColumnType
   });
 }

--- a/packages/react-widgets/src/models/TableModel.js
+++ b/packages/react-widgets/src/models/TableModel.js
@@ -6,6 +6,7 @@ export function getTable(props) {
 }
 
 function fromLocal(props) {
+  // Injecting sortByColumnType externally from metadata gives better results. It allows to avoid deriving type from row value itself (with potential null values)
   const { source, rowsPerPage, page, sortBy, sortDirection, sortByColumnType } = props;
 
   return executeTask(source.id, Methods.FEATURES_RAW, {

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -45,6 +45,7 @@ function TableWidget({
   const [page, setPage] = useState(0);
 
   const [sortBy, setSortBy] = useState(undefined);
+  const [sortByColumnType, setSortByColumnType] = useState(undefined);
   const [sortDirection, setSortDirection] = useState('asc');
 
   const {
@@ -60,7 +61,8 @@ function TableWidget({
       rowsPerPage,
       page,
       sortBy,
-      sortDirection
+      sortDirection,
+      sortByColumnType
     },
     global,
     onError
@@ -80,6 +82,12 @@ function TableWidget({
   const handleRowsPerPageChange = (newRowsPerPage) => {
     setRowsPerPage(newRowsPerPage);
     if (onPageSizeChange) onPageSizeChange(newRowsPerPage);
+  };
+
+  const handleSortBy = (newSortBy) => {
+    setSortBy(newSortBy);
+    const column = columns.find((c) => c.field === newSortBy);
+    setSortByColumnType(column?.type);
   };
 
   return (
@@ -104,7 +112,7 @@ function TableWidget({
             sorting
             sortBy={sortBy}
             sortDirection={sortDirection}
-            onSetSortBy={setSortBy}
+            onSetSortBy={handleSortBy}
             onSetSortDirection={setSortDirection}
             height={height}
             dense={dense}

--- a/packages/react-workers/src/utils/sorting.js
+++ b/packages/react-workers/src/utils/sorting.js
@@ -6,7 +6,7 @@ import { firstBy } from 'thenby';
  * @param {object} [sortOptions]
  * @param {string | string[] | object[]} [sortOptions.sortBy] - One or more columns to sort by
  * @param {string} [sortOptions.sortByDirection] - Direction by the columns will be sorted
- * @param {string} [sortOptions.sortByColumnType] - Column type
+ * @param {('number'|'string'|'date')} [sortOptions.sortByColumnType] - Column type
  */
 export function applySorting(
   features,

--- a/packages/react-workers/src/utils/sorting.js
+++ b/packages/react-workers/src/utils/sorting.js
@@ -25,11 +25,10 @@ export function applySorting(
   if (!isValidSortBy) {
     throw new Error('Sorting options are bad formatted');
   }
-  const isNumberColumn = sortByColumnType === 'integer' || sortByColumnType === 'float';
   const sortFn = createSortFn({
     sortBy,
     sortByDirection,
-    columnDataType: isNumberColumn ? 'number' : sortByColumnType
+    columnDataType: sortByColumnType
   });
   return features.sort(sortFn);
 }

--- a/packages/react-workers/src/workers/features.worker.js
+++ b/packages/react-workers/src/workers/features.worker.js
@@ -268,7 +268,8 @@ function getRawFeatures({
   limit = 10,
   page = 0,
   sortBy,
-  sortByDirection = 'asc'
+  sortByDirection = 'asc',
+  sortByColumnType
 }) {
   let data = [];
   let numberPages = 0;
@@ -277,7 +278,8 @@ function getRawFeatures({
   if (currentFeatures) {
     data = applySorting(getFilteredFeatures(filters, filtersLogicalOperator), {
       sortBy,
-      sortByDirection
+      sortByDirection,
+      sortByColumnType
     });
 
     totalCount = data.length;


### PR DESCRIPTION
# TableWidget - sortByColumnType param + number format

Shortcut: https://app.shortcut.com/cartoteam/story/286648/ac-x5e68ikj-table-widget-ordering-is-wrong-for-numeric-data-type-column

TableWidget accepts a new `sortByColumnType` parameter, if its value is ~**integer** or **float**~ 'number' we will apply number sorting


https://user-images.githubusercontent.com/9006480/216548142-20af37be-0c81-4af0-830c-1fdec6b7b4b5.mov



## Type of change

- Fix

# Acceptance

Sorting by a number column should work properly