### PR TITLE
Adjustments in theme to fix uses cases in cloud-native

### DIFF
--- a/packages/react-ui/src/theme/sections/components/forms.js
+++ b/packages/react-ui/src/theme/sections/components/forms.js
@@ -494,6 +494,9 @@ export const formsOverrides = {
         '& .MuiInputBase-sizeSmall .MuiAutocomplete-endAdornment': {
           top: 0,
           right: getSpacing(0.75)
+        },
+        '& .MuiFormLabel-root': {
+          pointerEvents: 'auto'
         }
       },
 


### PR DESCRIPTION
# Description

Shortcut: [#286618](https://app.shortcut.com/cartoteam/story/286618/cloudnative-ci-e2e-errors)
sc: [sc-286618]

Includes
- Autocomplete: enable click on label