### PR TITLE
Do not create fresh loaders array on every frame

### DIFF
--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -8,6 +8,8 @@ import { getMaskExtensionProps } from './maskExtensionUtil';
 import FeaturesDroppedLoader from './FeaturesDroppedLoader';
 import { CLIENT_ID } from '../api/common';
 
+const LOADERS = [FeaturesDroppedLoader];
+
 export default function useCartoLayerProps({
   source,
   layerConfig,
@@ -53,7 +55,7 @@ export default function useCartoLayerProps({
     ...(viewportFeatures && {
       onViewportLoad,
       fetch,
-      loaders: [FeaturesDroppedLoader],
+      loaders: LOADERS,
       onDataLoad
     })
   };


### PR DESCRIPTION
Same fix as in Builder: https://github.com/CartoDB/cloud-native/pull/10952
