### PR TITLE
Refactor in react-workers to improve debugging DX

### DIFF
--- a/packages/react-workers/__tests__/methods.test.js
+++ b/packages/react-workers/__tests__/methods.test.js
@@ -1,0 +1,71 @@
+import {
+  getFormula,
+  getHistogram,
+  getGeojsonFeatures,
+  loadGeoJSONFeatures,
+  getRawFeatures
+} from '../src/workers/methods';
+import { sampleGeoJson } from './sampleGeojson';
+
+describe('Worker Methods', () => {
+  beforeEach(() => {
+    loadGeoJSONFeatures({ geojson: sampleGeoJson });
+    getGeojsonFeatures({
+      viewport: [
+        -119.8541879250893, 19.66738891368218, -61.31673251486329, 54.38309840045979
+      ],
+      geometry: null
+    });
+  });
+  describe('getFormula', () => {
+    it('counts features', () => {
+      expect(getFormula({ operation: 'count' })).toEqual({ value: 6 });
+    });
+    it('counts features with filter', () => {
+      expect(
+        getFormula({
+          filters: {
+            city: {
+              in: {
+                owner: 'widgetId1',
+                values: ['BOSTON']
+              }
+            }
+          },
+          operation: 'count'
+        })
+      ).toEqual({
+        value: 3
+      });
+    });
+  });
+  describe('getHistogram', () => {
+    it('creates histogram', () => {
+      expect(
+        getHistogram({
+          column: 'revenue',
+          operation: 'count',
+          ticks: [997472.3, 1716077, 2056468.7]
+        })
+      ).toEqual([0, 4, 2, 0]);
+    });
+  });
+  describe('getRawFeatures', () => {
+    it('returns all features properties', () => {
+      expect(getRawFeatures({})).toEqual({
+        currentPage: 0,
+        pages: 1,
+        totalCount: 6,
+        data: sampleGeoJson.features.map((f) => f.properties)
+      });
+    });
+    it('supports limit and returns paging info', () => {
+      expect(getRawFeatures({ limit: 3 })).toEqual({
+        currentPage: 0,
+        pages: 2,
+        totalCount: 6,
+        data: sampleGeoJson.features.slice(0, 3).map((f) => f.properties)
+      });
+    });
+  });
+});

--- a/packages/react-workers/__tests__/sampleGeojson.js
+++ b/packages/react-workers/__tests__/sampleGeojson.js
@@ -1,0 +1,126 @@
+// first 6 rows from carto-dev-data.public.retail_stores
+export const sampleGeoJson = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: {
+        cartodb_id: 302,
+        storetype: 'Drugstore',
+        address: '146 TREMONT ST',
+        city: 'BOSTON',
+        state: 'MA',
+        zip: '2111',
+        store_id: 439,
+        revenue: 1301427,
+        size_m2: 846,
+        longitude: -71.0643,
+        latitude: 42.35392
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: [-71.0643, 42.35392]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: {
+        cartodb_id: 342,
+        storetype: 'Drugstore',
+        address: '702 WASHINGTON ST',
+        city: 'BOSTON',
+        state: 'MA',
+        zip: '2111',
+        store_id: 445,
+        revenue: 1646773,
+        size_m2: 809,
+        longitude: -71.06158,
+        latitude: 42.35157
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: [-71.06158, 42.35157]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: {
+        cartodb_id: 337,
+        storetype: 'Drugstore',
+        address: '340-350 LONGWOOD AVE',
+        city: 'BOSTON',
+        state: 'MA',
+        zip: '2115',
+        store_id: 443,
+        revenue: 1449786,
+        size_m2: 129,
+        longitude: -71.10695,
+        latitude: 42.33785
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: [-71.10695, 42.33785]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: {
+        cartodb_id: 322,
+        storetype: 'Drugstore',
+        address: '1513 DORCHESTER AVE',
+        city: 'DORCHESTER',
+        state: 'MA',
+        zip: '2122',
+        store_id: 442,
+        revenue: 1876776,
+        size_m2: 954,
+        longitude: -71.05945,
+        latitude: 42.29802
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: [-71.05945, 42.29802]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: {
+        cartodb_id: 321,
+        storetype: 'Drugstore',
+        address: '605 WASHINGTON ST',
+        city: 'DORCHESTER',
+        state: 'MA',
+        zip: '2124',
+        store_id: 441,
+        revenue: 1254145,
+        size_m2: 737,
+        longitude: -71.07176,
+        latitude: 42.29212
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: [-71.07176, 42.29212]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: {
+        cartodb_id: 310,
+        storetype: 'Drugstore',
+        address: '1614 BLUE HILL AVE',
+        city: 'MATTAPAN',
+        state: 'MA',
+        zip: '2126',
+        store_id: 440,
+        revenue: 1866052,
+        size_m2: 103,
+        longitude: -71.09276,
+        latitude: 42.26986
+      },
+      geometry: {
+        type: 'Point',
+        coordinates: [-71.09276, 42.26986]
+      }
+    }
+  ]
+};

--- a/packages/react-workers/src/workers/features.worker.js
+++ b/packages/react-workers/src/workers/features.worker.js
@@ -1,324 +1,42 @@
-import {
-  tileFeatures,
-  geojsonFeatures,
-  aggregationFunctions,
-  _applyFilters,
-  histogram,
-  scatterPlot,
-  groupValuesByColumn,
-  groupValuesByDateColumn,
-  AggregationTypes
-} from '@carto/react-core';
-import { InvalidColumnError } from '@carto/react-core/';
-import { applySorting } from '../utils/sorting';
 import { Methods } from '../workerMethods';
+import {
+  getTileFeatures,
+  getFormula,
+  getHistogram,
+  getCategories,
+  getScatterPlot,
+  getTimeSeries,
+  getRawFeatures,
+  getRange,
+  loadTiles,
+  loadGeoJSONFeatures,
+  getGeojsonFeatures
+} from './methods';
 
-let currentFeatures;
-let currentGeoJSON;
-let currentTiles;
-
-onmessage = ({ data: { method, ...params } }) => {
-  switch (method) {
-    case Methods.TILE_FEATURES:
-      getTileFeatures(params);
-      break;
-    case Methods.FEATURES_FORMULA:
-      getFormula(params);
-      break;
-    case Methods.FEATURES_HISTOGRAM:
-      getHistogram(params);
-      break;
-    case Methods.FEATURES_CATEGORY:
-      getCategories(params);
-      break;
-    case Methods.FEATURES_SCATTERPLOT:
-      getScatterPlot(params);
-      break;
-    case Methods.FEATURES_TIME_SERIES:
-      getTimeSeries(params);
-      break;
-    case Methods.FEATURES_RAW:
-      getRawFeatures(params);
-      break;
-    case Methods.FEATURES_RANGE:
-      getRange(params);
-      break;
-    case Methods.LOAD_TILES:
-      loadTiles(params);
-      break;
-    case Methods.LOAD_GEOJSON_FEATURES:
-      loadGeoJSONFeatures(params);
-      break;
-    case Methods.GEOJSON_FEATURES:
-      getGeojsonFeatures(params);
-      break;
-    default:
-      throw new Error('Invalid worker method');
-  }
+export const methodMap = {
+  [Methods.TILE_FEATURES]: getTileFeatures,
+  [Methods.FEATURES_FORMULA]: getFormula,
+  [Methods.FEATURES_HISTOGRAM]: getHistogram,
+  [Methods.FEATURES_CATEGORY]: getCategories,
+  [Methods.FEATURES_SCATTERPLOT]: getScatterPlot,
+  [Methods.FEATURES_TIME_SERIES]: getTimeSeries,
+  [Methods.FEATURES_RAW]: getRawFeatures,
+  [Methods.FEATURES_RANGE]: getRange,
+  [Methods.LOAD_TILES]: loadTiles,
+  [Methods.LOAD_GEOJSON_FEATURES]: loadGeoJSONFeatures,
+  [Methods.GEOJSON_FEATURES]: getGeojsonFeatures
 };
 
-function getTileFeatures({
-  viewport,
-  geometry,
-  uniqueIdProperty,
-  tileFormat,
-  geoColumName,
-  spatialIndex
-}) {
-  currentFeatures = tileFeatures({
-    tiles: currentTiles,
-    viewport,
-    geometry,
-    uniqueIdProperty,
-    tileFormat,
-    geoColumName,
-    spatialIndex
-  });
-  postMessage({ result: true });
-}
-
-function loadTiles({ tiles }) {
-  currentTiles = tiles;
-  postMessage({ result: true });
-}
-
-function loadGeoJSONFeatures({ geojson }) {
-  currentGeoJSON = geojson;
-  postMessage({ result: true });
-}
-
-function getGeojsonFeatures({ viewport, geometry, uniqueIdProperty }) {
-  if (currentGeoJSON) {
-    currentFeatures = geojsonFeatures({
-      geojson: currentGeoJSON,
-      viewport,
-      geometry,
-      uniqueIdProperty
-    });
-  }
-  postMessage({ result: true });
-}
-
-function getFormula({
-  filters,
-  filtersLogicalOperator,
-  operation,
-  column,
-  joinOperation
-}) {
-  let result = null;
-
-  if (currentFeatures) {
-    const targetOperation = aggregationFunctions[operation];
-
-    const isCount = operation === AggregationTypes.COUNT;
-
-    // If the operation isn't count, we need to assert the column
-    // If the operation is count, the column can be undefined
-    if (!isCount || (isCount && column)) {
-      assertColumn(column);
+onmessage = ({ data: { method, ...params } }) => {
+  try {
+    const methodFn = methodMap[method];
+    if (!methodFn) {
+      throw new Error(`Invalid react-workers method: ${methodFn}`);
     }
-
-    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
-
-    if (filteredFeatures.length === 0 && !isCount) {
-      result = { value: null };
-    } else {
-      result = { value: targetOperation(filteredFeatures, column, joinOperation) };
-    }
+    const result = methodFn(params);
+    postMessage({ result: result === undefined ? true : result });
+  } catch (error) {
+    postMessage({ error: String(error) });
+    console.error(error);
   }
-
-  postMessage({ result });
-}
-
-function getHistogram({
-  filters,
-  filtersLogicalOperator,
-  operation,
-  column,
-  ticks,
-  joinOperation
-}) {
-  let result = null;
-
-  if (currentFeatures) {
-    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
-
-    assertColumn(column);
-
-    result = histogram({
-      data: filteredFeatures,
-      valuesColumns: normalizeColumns(column),
-      joinOperation,
-      ticks,
-      operation
-    });
-  }
-
-  postMessage({ result });
-}
-
-function getCategories({
-  filters,
-  filtersLogicalOperator,
-  operation,
-  column,
-  operationColumn,
-  joinOperation
-}) {
-  let result = null;
-
-  if (currentFeatures) {
-    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
-
-    assertColumn(column, operationColumn);
-
-    const groups = groupValuesByColumn({
-      data: filteredFeatures,
-      valuesColumns: normalizeColumns(operationColumn),
-      joinOperation,
-      keysColumn: column,
-      operation
-    });
-
-    result = groups || [];
-  }
-
-  postMessage({ result });
-}
-
-function getScatterPlot({
-  filters,
-  filtersLogicalOperator,
-  xAxisColumn,
-  yAxisColumn,
-  xAxisJoinOperation,
-  yAxisJoinOperation
-}) {
-  let result = [];
-  if (currentFeatures) {
-    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
-
-    assertColumn(xAxisColumn, yAxisColumn);
-
-    result = scatterPlot({
-      data: filteredFeatures,
-      xAxisColumns: normalizeColumns(xAxisColumn),
-      xAxisJoinOperation,
-      yAxisColumns: normalizeColumns(yAxisColumn),
-      yAxisJoinOperation
-    });
-  }
-
-  postMessage({ result });
-}
-
-function getTimeSeries({
-  filters,
-  filtersLogicalOperator,
-  column,
-  stepSize,
-  operation,
-  operationColumn,
-  joinOperation
-}) {
-  let result = [];
-
-  if (currentFeatures) {
-    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
-
-    assertColumn(operationColumn, column);
-
-    const groups = groupValuesByDateColumn({
-      data: filteredFeatures,
-      valuesColumns: normalizeColumns(operationColumn),
-      keysColumn: column,
-      groupType: stepSize,
-      operation,
-      joinOperation
-    });
-
-    result = groups || [];
-  }
-
-  postMessage({ result });
-}
-
-function getRange({ filters, filtersLogicalOperator, column }) {
-  let result = null;
-
-  if (currentFeatures) {
-    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
-
-    assertColumn(column);
-
-    result = {
-      min: aggregationFunctions.min(filteredFeatures, column),
-      max: aggregationFunctions.max(filteredFeatures, column)
-    };
-  }
-
-  postMessage({ result });
-}
-
-// See sorting details in utils/sorting.js
-function getRawFeatures({
-  filters,
-  filtersLogicalOperator,
-  limit = 10,
-  page = 0,
-  sortBy,
-  sortByDirection = 'asc',
-  sortByColumnType
-}) {
-  let data = [];
-  let numberPages = 0;
-  let totalCount = 0;
-
-  if (currentFeatures) {
-    data = applySorting(getFilteredFeatures(filters, filtersLogicalOperator), {
-      sortBy,
-      sortByDirection,
-      sortByColumnType
-    });
-
-    totalCount = data.length;
-
-    if (limit) {
-      numberPages = Math.ceil(data.length / limit);
-      data = applyPagination(data, { limit, page });
-    }
-  }
-
-  postMessage({
-    result: { data, currentPage: page, pages: numberPages, totalCount }
-  });
-}
-
-function applyPagination(features, { limit, page }) {
-  return features.slice(limit * Math.max(0, page), limit * Math.max(1, page + 1));
-}
-
-function getFilteredFeatures(filters = {}, filtersLogicalOperator) {
-  return _applyFilters(currentFeatures, filters, filtersLogicalOperator);
-}
-
-function assertColumn(...columnArgs) {
-  // This check can only be done if there're features
-  if (currentFeatures.length) {
-    // Due to the multiple column shape, we normalise it as an array with normalizeColumns
-    const columns = Array.from(new Set(columnArgs.map(normalizeColumns).flat()));
-
-    const featureKeys = Object.keys(currentFeatures[0]);
-
-    const invalidColumns = columns.filter((column) => !featureKeys.includes(column));
-
-    if (invalidColumns.length) {
-      throw new InvalidColumnError(`Missing column(s): ${invalidColumns.join(', ')}`);
-    }
-  }
-}
-
-function normalizeColumns(columns) {
-  return Array.isArray(columns) ? columns : typeof columns === 'string' ? [columns] : [];
-}
+};

--- a/packages/react-workers/src/workers/methods.js
+++ b/packages/react-workers/src/workers/methods.js
@@ -1,0 +1,281 @@
+import {
+  tileFeatures,
+  geojsonFeatures,
+  aggregationFunctions,
+  _applyFilters,
+  histogram,
+  scatterPlot,
+  groupValuesByColumn,
+  groupValuesByDateColumn,
+  AggregationTypes
+} from '@carto/react-core';
+import { InvalidColumnError } from '@carto/react-core/';
+import { applySorting } from '../utils/sorting';
+
+let currentFeatures;
+let currentGeoJSON;
+let currentTiles;
+
+export function getTileFeatures({
+  viewport,
+  geometry,
+  uniqueIdProperty,
+  tileFormat,
+  geoColumName,
+  spatialIndex
+}) {
+  currentFeatures = tileFeatures({
+    tiles: currentTiles,
+    viewport,
+    geometry,
+    uniqueIdProperty,
+    tileFormat,
+    geoColumName,
+    spatialIndex
+  });
+  return true;
+}
+
+export function loadTiles({ tiles }) {
+  currentTiles = tiles;
+  return true;
+}
+
+export function loadGeoJSONFeatures({ geojson }) {
+  currentGeoJSON = geojson;
+  return true;
+}
+
+export function getGeojsonFeatures({ viewport, geometry, uniqueIdProperty }) {
+  if (currentGeoJSON) {
+    currentFeatures = geojsonFeatures({
+      geojson: currentGeoJSON,
+      viewport,
+      geometry,
+      uniqueIdProperty
+    });
+  }
+  return true;
+}
+
+export function getFormula({
+  filters,
+  filtersLogicalOperator,
+  operation,
+  column,
+  joinOperation
+}) {
+  let result = null;
+
+  if (currentFeatures) {
+    const targetOperation = aggregationFunctions[operation];
+
+    const isCount = operation === AggregationTypes.COUNT;
+
+    // If the operation isn't count, we need to assert the column
+    // If the operation is count, the column can be undefined
+    if (!isCount || (isCount && column)) {
+      assertColumn(column);
+    }
+
+    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
+
+    if (filteredFeatures.length === 0 && !isCount) {
+      result = { value: null };
+    } else {
+      result = { value: targetOperation(filteredFeatures, column, joinOperation) };
+    }
+  }
+
+  return result;
+}
+
+export function getHistogram({
+  filters,
+  filtersLogicalOperator,
+  operation,
+  column,
+  ticks,
+  joinOperation
+}) {
+  let result = null;
+
+  if (currentFeatures) {
+    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
+
+    assertColumn(column);
+
+    result = histogram({
+      data: filteredFeatures,
+      valuesColumns: normalizeColumns(column),
+      joinOperation,
+      ticks,
+      operation
+    });
+  }
+
+  return result;
+}
+
+export function getCategories({
+  filters,
+  filtersLogicalOperator,
+  operation,
+  column,
+  operationColumn,
+  joinOperation
+}) {
+  let result = null;
+
+  if (currentFeatures) {
+    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
+
+    assertColumn(column, operationColumn);
+
+    const groups = groupValuesByColumn({
+      data: filteredFeatures,
+      valuesColumns: normalizeColumns(operationColumn),
+      joinOperation,
+      keysColumn: column,
+      operation
+    });
+
+    result = groups || [];
+  }
+
+  return result;
+}
+
+export function getScatterPlot({
+  filters,
+  filtersLogicalOperator,
+  xAxisColumn,
+  yAxisColumn,
+  xAxisJoinOperation,
+  yAxisJoinOperation
+}) {
+  let result = [];
+  if (currentFeatures) {
+    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
+
+    assertColumn(xAxisColumn, yAxisColumn);
+
+    result = scatterPlot({
+      data: filteredFeatures,
+      xAxisColumns: normalizeColumns(xAxisColumn),
+      xAxisJoinOperation,
+      yAxisColumns: normalizeColumns(yAxisColumn),
+      yAxisJoinOperation
+    });
+  }
+
+  return result;
+}
+
+export function getTimeSeries({
+  filters,
+  filtersLogicalOperator,
+  column,
+  stepSize,
+  operation,
+  operationColumn,
+  joinOperation
+}) {
+  let result = [];
+
+  if (currentFeatures) {
+    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
+
+    assertColumn(operationColumn, column);
+
+    const groups = groupValuesByDateColumn({
+      data: filteredFeatures,
+      valuesColumns: normalizeColumns(operationColumn),
+      keysColumn: column,
+      groupType: stepSize,
+      operation,
+      joinOperation
+    });
+
+    result = groups || [];
+  }
+
+  return result;
+}
+
+export function getRange({ filters, filtersLogicalOperator, column }) {
+  let result = null;
+
+  if (currentFeatures) {
+    const filteredFeatures = getFilteredFeatures(filters, filtersLogicalOperator);
+
+    assertColumn(column);
+
+    result = {
+      min: aggregationFunctions.min(filteredFeatures, column),
+      max: aggregationFunctions.max(filteredFeatures, column)
+    };
+  }
+
+  return result;
+}
+
+// See sorting details in utils/sorting.js
+export function getRawFeatures({
+  filters,
+  filtersLogicalOperator,
+  limit = 10,
+  page = 0,
+  sortBy,
+  sortByDirection = 'asc',
+  sortByColumnType
+}) {
+  let data = [];
+  let numberPages = 0;
+  let totalCount = 0;
+
+  if (currentFeatures) {
+    data = applySorting(getFilteredFeatures(filters, filtersLogicalOperator), {
+      sortBy,
+      sortByDirection,
+      sortByColumnType
+    });
+
+    totalCount = data.length;
+
+    if (limit) {
+      numberPages = Math.ceil(data.length / limit);
+      data = applyPagination(data, { limit, page });
+    }
+  }
+
+  return { data, currentPage: page, pages: numberPages, totalCount };
+}
+
+function applyPagination(features, { limit, page }) {
+  return features.slice(limit * Math.max(0, page), limit * Math.max(1, page + 1));
+}
+
+function getFilteredFeatures(filters = {}, filtersLogicalOperator) {
+  return _applyFilters(currentFeatures, filters, filtersLogicalOperator);
+}
+
+function assertColumn(...columnArgs) {
+  // This check can only be done if there're features
+  if (currentFeatures.length) {
+    // Due to the multiple column shape, we normalise it as an array with normalizeColumns
+    const columns = Array.from(new Set(columnArgs.map(normalizeColumns).flat()));
+
+    const featureKeys = Object.keys(currentFeatures[0]);
+
+    const invalidColumns = columns.filter((column) => !featureKeys.includes(column));
+
+    if (invalidColumns.length) {
+      throw new InvalidColumnError(`Missing column(s): ${invalidColumns.join(', ')}`);
+    }
+  }
+}
+
+function normalizeColumns(columns) {
+  return Array.isArray(columns) ? columns : typeof columns === 'string' ? [columns] : [];
+}


### PR DESCRIPTION
Rationale:  `worker-loader` produces incorrect source-maps for `features.worker.js`.
By moving "business" code to "methods.js", this PR enables source-inspection and and debugging code in DevTools of said "business" functions. Also allows easier and cleaner testing.

Refactor: 
 * move functional core of react-workers to generic (testable/importable) module. 
 * factor-out "worker"-specific code to from core functions
 * add skeleton for unit-tests

