### PR TITLE
react-workers: getFeaturesRaw returns full features with geometry if asked

### DIFF
--- a/packages/react-core/src/filters/geojsonFeatures.d.ts
+++ b/packages/react-core/src/filters/geojsonFeatures.d.ts
@@ -1,11 +1,12 @@
 import { FeatureCollection, Geometry } from 'geojson';
-import { Viewport, TileFeaturesResponse } from '../types';
+import { Viewport, TileFeaturesResponse, ResultFormat } from '../types';
 
 type GeojsonFeaturesArgs = {
   geojson: FeatureCollection,
   viewport: Viewport,
   geometry?: Geometry
   uniqueIdProperty?: string
+  resultFormat?: ResultFormat
 }
 
 export function geojsonFeatures(arg: GeojsonFeaturesArgs): TileFeaturesResponse;

--- a/packages/react-core/src/filters/geojsonFeatures.js
+++ b/packages/react-core/src/filters/geojsonFeatures.js
@@ -1,7 +1,14 @@
 import intersects from '@turf/boolean-intersects';
+import { ResultFormat } from '../types';
 import { getGeometryToIntersect } from './tileFeatures';
 
-export function geojsonFeatures({ geojson, viewport, geometry, uniqueIdProperty }) {
+export function geojsonFeatures({
+  geojson,
+  viewport,
+  geometry,
+  uniqueIdProperty,
+  resultFormat
+}) {
   let uniqueIdx = 0;
   // Map is used to cache multi geometries. Only a sucessfull intersect by multipolygon
   const map = new Map();
@@ -16,7 +23,10 @@ export function geojsonFeatures({ geojson, viewport, geometry, uniqueIdProperty 
       ? feature.properties[uniqueIdProperty]
       : ++uniqueIdx;
     if (!map.has(uniqueId) && intersects(geometryToIntersect, feature)) {
-      map.set(uniqueId, feature.properties);
+      map.set(
+        uniqueId,
+        resultFormat === ResultFormat.GeoJsonFeature ? feature : feature.properties
+      );
     }
   }
 

--- a/packages/react-core/src/filters/tileFeatures.js
+++ b/packages/react-core/src/filters/tileFeatures.js
@@ -14,7 +14,8 @@ export function tileFeatures({
   uniqueIdProperty,
   tileFormat,
   geoColumName,
-  spatialIndex
+  spatialIndex,
+  resultFormat
 }) {
   const geometryToIntersect = getGeometryToIntersect(viewport, geometry);
 
@@ -34,6 +35,7 @@ export function tileFeatures({
     tiles,
     tileFormat,
     geometryToIntersect,
-    uniqueIdProperty
+    uniqueIdProperty,
+    resultFormat
   });
 }

--- a/packages/react-core/src/filters/tileFeaturesGeometries.d.ts
+++ b/packages/react-core/src/filters/tileFeaturesGeometries.d.ts
@@ -1,11 +1,12 @@
 import { TILE_FORMATS } from '@deck.gl/carto';
 import { Feature, Polygon, MultiPolygon } from 'geojson';
-import { TileFeaturesResponse } from "../types";
+import { ResultFormat, TileFeaturesResponse } from "../types";
 
 export default function tileFeaturesGeometries(arg: {
   tiles: any;
   tileFormat: TILE_FORMATS;
   geometryToIntersect: Feature<Polygon | MultiPolygon>;
   uniqueIdProperty?: string;
+  resultFormat?: ResultFormat
 }): TileFeaturesResponse;
 

--- a/packages/react-core/src/index.js
+++ b/packages/react-core/src/index.js
@@ -36,6 +36,7 @@ export {
 
 export { tileFeatures } from './filters/tileFeatures';
 export { geojsonFeatures } from './filters/geojsonFeatures';
+export { ResultFormat } from './types'
 
 export { GroupDateTypes } from './operations/constants/GroupDateTypes';
 export { groupValuesByDateColumn } from './operations/groupByDate';

--- a/packages/react-core/src/types.d.ts
+++ b/packages/react-core/src/types.d.ts
@@ -33,6 +33,11 @@ export type TileFeatures = {
   tileFormat: TILE_FORMATS;
   geoColumName?: string;
   spatialIndex?: SpatialIndex;
+  resultFormat?: ResultFormat
 };
 
+export enum ResultFormat {
+  OnlyProperties = 'OnlyProperties',
+  GeoJsonFeature = 'GeoJsonFeature'
+}
 export type TileFeaturesResponse = Record<string, unknown>[] | [];

--- a/packages/react-core/src/types.js
+++ b/packages/react-core/src/types.js
@@ -1,0 +1,4 @@
+export const ResultFormat = Object.freeze({
+  OnlyProperties: 'OnlyProperties',
+  GeoJsonFeature: 'GeoJsonFeature'
+});

--- a/packages/react-widgets/src/models/TableModel.js
+++ b/packages/react-widgets/src/models/TableModel.js
@@ -7,7 +7,15 @@ export function getTable(props) {
 
 function fromLocal(props) {
   // Injecting sortByColumnType externally from metadata gives better results. It allows to avoid deriving type from row value itself (with potential null values)
-  const { source, rowsPerPage, page, sortBy, sortDirection, sortByColumnType } = props;
+  const {
+    source,
+    rowsPerPage,
+    page,
+    sortBy,
+    sortDirection,
+    sortByColumnType,
+    resultFormat
+  } = props;
 
   return executeTask(source.id, Methods.FEATURES_RAW, {
     filters: source.filters,
@@ -16,6 +24,7 @@ function fromLocal(props) {
     page,
     sortBy,
     sortByDirection: sortDirection,
-    sortByColumnType
+    sortByColumnType,
+    resultFormat
   });
 }

--- a/packages/react-workers/__tests__/methods.test.js
+++ b/packages/react-workers/__tests__/methods.test.js
@@ -1,3 +1,4 @@
+import { ResultFormat } from '@carto/react-core';
 import {
   getFormula,
   getHistogram,
@@ -57,6 +58,14 @@ describe('Worker Methods', () => {
         pages: 1,
         totalCount: 6,
         data: sampleGeoJson.features.map((f) => f.properties)
+      });
+    });
+    it('returns whole features with geometry resultFormat=GeoJsonFeature', () => {
+      expect(getRawFeatures({ resultFormat: ResultFormat.GeoJsonFeature })).toEqual({
+        currentPage: 0,
+        pages: 1,
+        totalCount: 6,
+        data: sampleGeoJson.features
       });
     });
     it('supports limit and returns paging info', () => {

--- a/packages/react-workers/src/utils/sorting.js
+++ b/packages/react-workers/src/utils/sorting.js
@@ -30,7 +30,9 @@ export function applySorting(
     sortByDirection,
     columnDataType: sortByColumnType
   });
-  return features.sort(sortFn);
+  return features.sort(
+    isGeoJsonFeature(features[0]) ? (a, b) => sortFn(a.properties, b.properties) : sortFn
+  );
 }
 
 // Aux
@@ -76,4 +78,8 @@ function normalizeSortByOptions({ sortBy, sortByDirection, columnDataType }) {
     }
     return sortByEl;
   });
+}
+
+function isGeoJsonFeature(v) {
+  return v && v.type === 'Feature' && v.properties && typeof v.properties === 'object';
 }


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/epic/274603

* react-workers - `getFeaturesRaw` returns full features with geometry if asked

* Store geometry in calculations of visible features for later use when exporting data.

# Type of change

- Feature


# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
