### PR TITLE
Fix unselected row in Category Widget

### DIFF
--- a/packages/react-ui/src/widgets/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI.js
@@ -32,21 +32,21 @@ const useStyles = makeStyles((theme) => ({
     cursor: 'pointer',
     flexWrap: 'nowrap',
 
-    '&:hover .progressbar div': {
+    '&:hover $progressbar div': {
       backgroundColor: theme.palette.secondary.dark
     }
   },
 
   element: {
-    '&.unselected': {
+    '&$unselected': {
       color: theme.palette.text.disabled,
 
-      '& .progressbar div': {
+      '& $progressbar div': {
         backgroundColor: theme.palette.text.disabled
       }
     },
 
-    '&.rest .progressbar div': {
+    '&$rest $progressbar div': {
       backgroundColor: theme.palette.text.disabled
     }
   },


### PR DESCRIPTION
# Description

Shortcut: (#291684](https://app.shortcut.com/cartoteam/story/291684/category-widget-ui-glitch))
[sc-291684]

The category widget is not greying out the non-selected categories.

## Type of change

- Fix