### PR TITLE
Add npm version to storybook UI

### DIFF
--- a/packages/react-ui/storybook/.storybook/manager.js
+++ b/packages/react-ui/storybook/.storybook/manager.js
@@ -1,12 +1,13 @@
 // ./storybook/manager.ts
 import { addons } from '@storybook/addons';
 import { create } from '@storybook/theming';
+import { version } from '../../package.json';
 
 const theme = create({
   base: 'light',
 
   // Brand
-  brandTitle: 'CARTO Design System',
+  brandTitle: `CARTO DS v.${version}`,
   brandImage: undefined
 });
 

--- a/packages/react-ui/storybook/.storybook/manager.js
+++ b/packages/react-ui/storybook/.storybook/manager.js
@@ -7,7 +7,7 @@ const theme = create({
   base: 'light',
 
   // Brand
-  brandTitle: `CARTO DS v.${version}`,
+  brandTitle: `CARTO DS ${version}`,
   brandImage: undefined
 });
 

--- a/packages/react-ui/storybook/stories/Introduction.stories.mdx
+++ b/packages/react-ui/storybook/stories/Introduction.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta, Description } from '@storybook/addon-docs';
+import { version } from '../../package.json';
 
 <Meta title='Introduction' />
 
@@ -6,6 +7,12 @@ import { Meta, Description } from '@storybook/addon-docs';
 
 This storybook includes the UI Components (@carto/react-ui) for CARTO for React.
 They are based on [Material-UI](https://material-ui.com/), and they include a CARTO theme + custom widgets.
+
+## Library version
+
+<p>
+  <strong>{version}</strong>
+</p>
 
 ## Storybook Development
 


### PR DESCRIPTION
# Description

Shortcut: [292309](https://app.shortcut.com/cartoteam/story/292309/add-c4r-npm-version-to-storybook-ui)
[sc-292309]

Add the version of the C4R library in Storybook UI, so the developer/designer knows which version of the library is consulting.

Screenshot:
![Screenshot 2023-02-21 at 11 03 21](https://user-images.githubusercontent.com/1934144/220314259-fba38032-c06f-4daf-b680-88e4bc063742.jpg)
