### PR TITLE
Avatar component based on Mui Avatar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- New Avatar component based on Mui Avatar [#617](https://github.com/CartoDB/carto-react/pull/617)
+
 ## 2.0
 
 ### 2.0.0-beta.4 (2023-03-17)

--- a/packages/react-ui/src/components/molecules/Avatar.js
+++ b/packages/react-ui/src/components/molecules/Avatar.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Avatar as MuiAvatar } from '@mui/material';
 import { styled } from '@mui/material/styles';
@@ -35,16 +35,13 @@ const AvatarContainer = styled(MuiAvatar, {
   })
 }));
 
-const Avatar = forwardRef(({ size, children, ...otherProps }, ref) => {
-  // forwardRef needed to be able to hold a reference, in this way it can be a child for some Mui components, like Tooltip
-  // https://mui.com/material-ui/guides/composition/#caveat-with-refs
-
+const Avatar = ({ size, children, ...otherProps }) => {
   return (
-    <AvatarContainer {...otherProps} ref={ref} size={size}>
+    <AvatarContainer {...otherProps} size={size}>
       {children}
     </AvatarContainer>
   );
-});
+};
 
 Avatar.defaultProps = {
   size: 'medium'

--- a/packages/react-ui/src/components/molecules/Avatar.js
+++ b/packages/react-ui/src/components/molecules/Avatar.js
@@ -1,0 +1,56 @@
+import React, { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+import { Avatar as MuiAvatar } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+const Sizes = {
+  large: 5,
+  medium: 4,
+  small: 3,
+  xsmall: 2.25
+};
+
+const AvatarContainer = styled(MuiAvatar, {
+  shouldForwardProp: (prop) => prop !== 'size'
+})(({ size, theme }) => ({
+  width: theme.spacing(Sizes[size]),
+  height: theme.spacing(Sizes[size]),
+  ...theme.typography.subtitle1,
+
+  ...(size === 'large' && {
+    ...theme.typography.h6
+  }),
+  ...(size === 'small' && {
+    ...theme.typography.caption,
+    fontWeight: 500
+  }),
+  ...(size === 'xsmall' && {
+    ...theme.typography.caption,
+    fontWeight: 500,
+
+    svg: {
+      width: theme.spacing(2),
+      height: theme.spacing(2)
+    }
+  })
+}));
+
+const Avatar = forwardRef(({ size, children, ...otherProps }, ref) => {
+  // forwardRef needed to be able to hold a reference, in this way it can be a child for some Mui components, like Tooltip
+  // https://mui.com/material-ui/guides/composition/#caveat-with-refs
+
+  return (
+    <AvatarContainer {...otherProps} ref={ref} size={size}>
+      {children}
+    </AvatarContainer>
+  );
+});
+
+Avatar.defaultProps = {
+  size: 'medium'
+};
+Avatar.propTypes = {
+  size: PropTypes.oneOf(Object.keys(Sizes))
+};
+
+export default Avatar;

--- a/packages/react-ui/src/components/molecules/Avatar.js
+++ b/packages/react-ui/src/components/molecules/Avatar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Avatar as MuiAvatar } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
-const Sizes = {
+const sizes = {
   large: 5,
   medium: 4,
   small: 3,
@@ -13,8 +13,8 @@ const Sizes = {
 const AvatarContainer = styled(MuiAvatar, {
   shouldForwardProp: (prop) => prop !== 'size'
 })(({ size, theme }) => ({
-  width: theme.spacing(Sizes[size]),
-  height: theme.spacing(Sizes[size]),
+  width: theme.spacing(sizes[size]),
+  height: theme.spacing(sizes[size]),
   ...theme.typography.subtitle1,
 
   ...(size === 'large' && {
@@ -47,7 +47,7 @@ Avatar.defaultProps = {
   size: 'medium'
 };
 Avatar.propTypes = {
-  size: PropTypes.oneOf(Object.keys(Sizes))
+  size: PropTypes.oneOf(Object.keys(sizes))
 };
 
 export default Avatar;

--- a/packages/react-ui/src/index.d.ts
+++ b/packages/react-ui/src/index.d.ts
@@ -33,6 +33,7 @@ import UploadField from './components/molecules/UploadField/UploadField';
 import AppBar from './components/organisms/AppBar/AppBar';
 import LabelWithIndicator from './components/atoms/LabelWithIndicator';
 import { getCartoColorStylePropsForItem } from './utils/palette';
+import Avatar from './components/molecules/Avatar';
 
 export {
   theme,
@@ -70,5 +71,6 @@ export {
   UploadField,
   AppBar,
   LabelWithIndicator,
-  getCartoColorStylePropsForItem
+  getCartoColorStylePropsForItem,
+  Avatar
 };

--- a/packages/react-ui/src/index.js
+++ b/packages/react-ui/src/index.js
@@ -34,6 +34,7 @@ import UploadField from './components/molecules/UploadField/UploadField';
 import AppBar from './components/organisms/AppBar/AppBar';
 import LabelWithIndicator from './components/atoms/LabelWithIndicator';
 import { getCartoColorStylePropsForItem } from './utils/palette';
+import Avatar from './components/molecules/Avatar';
 
 const featureSelectionIcons = {
   CursorIcon,
@@ -77,5 +78,6 @@ export {
   AppBar,
   ArrowDropIcon,
   LabelWithIndicator,
-  getCartoColorStylePropsForItem
+  getCartoColorStylePropsForItem,
+  Avatar
 };

--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -10,6 +10,8 @@ const tooltipArrowSize = 1;
 const tooltipSeparation = 0.5;
 const tooltipMargin = tooltipArrowSize + tooltipSeparation;
 const avatarFallbackImage = getIconPath(<PersonOutline />);
+const avatarCircularRadius = '50%';
+const avatarRodundedRadius = 0.5;
 
 export const dataDisplayOverrides = {
   // Divider
@@ -430,9 +432,12 @@ export const dataDisplayOverrides = {
   MuiAvatar: {
     styleOverrides: {
       root: {
+        overflow: 'initial',
         color: commonPalette.secondary.contrastText,
         backgroundColor: commonPalette.secondary.main,
 
+        //  Default fallback image override
+        // https://github.com/mui/material-ui/issues/33229
         '& .MuiAvatar-fallback': {
           path: {
             d: `path('${avatarFallbackImage}') !important`
@@ -440,16 +445,21 @@ export const dataDisplayOverrides = {
         }
       },
       img: {
-        // border: `1px solid ${commonPalette.default.outlinedBorder}` TODO fix the background color overlap
+        boxShadow: `0 0 0 1px ${commonPalette.default.outlinedBorder}`
       },
+
       circular: {
+        borderRadius: avatarCircularRadius,
+
         '& img': {
-          borderRadius: '50%'
+          borderRadius: avatarCircularRadius
         }
       },
       rounded: {
+        borderRadius: getSpacing(avatarRodundedRadius),
+
         '& img': {
-          borderRadius: getSpacing(0.5)
+          borderRadius: getSpacing(avatarRodundedRadius)
         }
       }
     }

--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -1,11 +1,15 @@
+import React from 'react';
 import { ICON_SIZE, ICON_SIZE_M } from '../../themeConstants';
 import { getSpacing } from '../../themeUtils';
 import { commonPalette } from '../palette';
 import { themeTypography } from '../typography';
+import { PersonOutline } from '@mui/icons-material';
+import { getIconPath } from '../../themeUtils';
 
 const tooltipArrowSize = 1;
 const tooltipSeparation = 0.5;
 const tooltipMargin = tooltipArrowSize + tooltipSeparation;
+const avatarFallbackImage = getIconPath(<PersonOutline />);
 
 export const dataDisplayOverrides = {
   // Divider
@@ -427,7 +431,13 @@ export const dataDisplayOverrides = {
     styleOverrides: {
       root: {
         color: commonPalette.secondary.contrastText,
-        backgroundColor: commonPalette.secondary.main
+        backgroundColor: commonPalette.secondary.main,
+
+        '& .MuiAvatar-fallback': {
+          path: {
+            d: `path('${avatarFallbackImage}') !important`
+          }
+        }
       },
       img: {
         // border: `1px solid ${commonPalette.default.outlinedBorder}` TODO fix the background color overlap

--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -11,7 +11,7 @@ const tooltipSeparation = 0.5;
 const tooltipMargin = tooltipArrowSize + tooltipSeparation;
 const avatarFallbackImage = getIconPath(<PersonOutline />);
 const avatarCircularRadius = '50%';
-const avatarRodundedRadius = 0.5;
+const avatarRoundedRadius = 0.5;
 
 export const dataDisplayOverrides = {
   // Divider
@@ -456,10 +456,10 @@ export const dataDisplayOverrides = {
         }
       },
       rounded: {
-        borderRadius: getSpacing(avatarRodundedRadius),
+        borderRadius: getSpacing(avatarRoundedRadius),
 
         '& img': {
-          borderRadius: getSpacing(avatarRodundedRadius)
+          borderRadius: getSpacing(avatarRoundedRadius)
         }
       }
     }

--- a/packages/react-ui/src/theme/themeUtils.js
+++ b/packages/react-ui/src/theme/themeUtils.js
@@ -13,7 +13,7 @@ export function getPixelToRem(px) {
   return rem;
 }
 
-// Get the icon path from a given Mui icon
+// Get the icon path from a given icon
 export function getIconPath(icon) {
   const iconString = ReactDOMServer.renderToString(icon);
   const parser = new DOMParser();

--- a/packages/react-ui/src/theme/themeUtils.js
+++ b/packages/react-ui/src/theme/themeUtils.js
@@ -1,3 +1,4 @@
+import ReactDOMServer from 'react-dom/server';
 import { createSpacing } from '@mui/system';
 import { SPACING } from './themeConstants';
 
@@ -10,4 +11,14 @@ export function getPixelToRem(px) {
   const rem = (1 / fontBase) * px + 'rem';
 
   return rem;
+}
+
+// Get the icon path from a given Mui icon
+export function getIconPath(icon) {
+  const iconString = ReactDOMServer.renderToString(icon);
+  const parser = new DOMParser();
+  const svg = parser.parseFromString(iconString, 'image/svg+xml');
+  const iconPath = svg.querySelector('path').getAttribute('d');
+
+  return iconPath;
 }

--- a/packages/react-ui/src/types.d.ts
+++ b/packages/react-ui/src/types.d.ts
@@ -2,7 +2,8 @@ import { GroupDateTypes } from '@carto/react-core';
 import {
   AppBarProps as MuiAppBarProps,
   TextFieldProps,
-  TypographyProps as MuiTypographyProps
+  TypographyProps as MuiTypographyProps,
+  AvatarProps as MuiAvatarProps
 } from '@mui/material';
 import { CSSProperties } from 'react';
 
@@ -324,3 +325,8 @@ export type LabelWithIndicatorProps = {
   label: string | React.ReactElement;
   type?: 'optional' | 'required';
 };
+
+// LabelWithIndicator
+export interface AvatarProps extends MuiAvatarProps {
+  size?: 'large' | 'medium' | 'small' | 'xsmall';
+}

--- a/packages/react-ui/src/types.d.ts
+++ b/packages/react-ui/src/types.d.ts
@@ -326,7 +326,7 @@ export type LabelWithIndicatorProps = {
   type?: 'optional' | 'required';
 };
 
-// LabelWithIndicator
+// Avatar
 export interface AvatarProps extends MuiAvatarProps {
   size?: 'large' | 'medium' | 'small' | 'xsmall';
 }

--- a/packages/react-ui/storybook/stories/molecules/Avatar.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/Avatar.stories.js
@@ -381,14 +381,25 @@ const ColorBackgroundTemplate = ({ ...args }) => {
     </Grid>
   );
 };
+
+const disabledVariantArgType = {
+  variant: { table: { disable: true } }
+};
+const disabledSizeArgType = {
+  size: { table: { disable: true } }
+};
+
 export const Playground = Template.bind({});
 
 export const Shape = ShapeTemplate.bind({});
+Shape.argTypes = disabledVariantArgType;
 
 export const Content = ContentTemplate.bind({});
 
 export const ShapeSizes = ShapeSizeTemplate.bind({});
+ShapeSizes.argTypes = { ...disabledVariantArgType, ...disabledSizeArgType };
 
 export const ContentSize = ContentSizeTemplate.bind({});
+ContentSize.argTypes = disabledSizeArgType;
 
 export const ColorBackground = ColorBackgroundTemplate.bind({});

--- a/packages/react-ui/storybook/stories/molecules/Avatar.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/Avatar.stories.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import { Avatar, Grid, Box, useTheme } from '@mui/material';
+import { Grid, Box, useTheme } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { Star } from '@mui/icons-material';
-import { getCartoColorStylePropsForItem, Typography } from '@carto/react-ui';
+import { getCartoColorStylePropsForItem, Typography, Avatar } from '@carto/react-ui';
 
 const options = {
   title: 'Molecules/Avatar',
   component: Avatar,
   argTypes: {
-    sizes: {
+    size: {
       control: {
         type: 'select',
         options: ['large', 'medium', 'small', 'xsmall']
@@ -27,7 +27,7 @@ const options = {
       url: 'https://www.figma.com/file/nmaoLeo69xBJCHm9nc6lEV/CARTO-Components-1.0?node-id=1925%3A30532&t=Y3JoU7theewbWKOW-0'
     },
     status: {
-      type: 'inDevelopment'
+      type: 'readyToReview'
     }
   }
 };
@@ -372,7 +372,7 @@ const ColorBackgroundTemplate = ({ ...args }) => {
                   style={{
                     ...getCartoColorStylePropsForItem(theme, index)
                   }}
-                >{`C${index + 1}`}</Avatar>
+                >{`${index + 1}`}</Avatar>
               </Grid>
             ))}
           </Grid>


### PR DESCRIPTION
# Description

Shortcut: ([#292310](https://app.shortcut.com/cartoteam/story/292310/core-new-component-avatar))

Add an custom prop `size`.