### PR TITLE
Allow to inject headers externally to executeSQL helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not released
 
 - New Avatar component based on Mui Avatar [#617](https://github.com/CartoDB/carto-react/pull/617)
+- Allow to inject headers externally to executeSQL helper [#620](https://github.com/CartoDB/carto-react/pull/620)
 
 ## 2.0
 

--- a/packages/react-api/src/api/SQL.js
+++ b/packages/react-api/src/api/SQL.js
@@ -16,7 +16,7 @@ const DEFAULT_USER_COMPONENT_IN_URL = '{user}';
  * @param { string } props.credentials.serverUrlTemplate - CARTO server URL template
  * @param { string } props.query - SQL query to be executed
  * @param { string } props.connection - connection name required for CARTO cloud native
- * @param { Object } props.opts - Additional options for the HTTP request
+ * @param { Object } props.opts - Additional options for the HTTP request (eg `{ headers: {} }`)
  * @param { import('@deck.gl/carto').QueryParameters } props.queryParameters - SQL query parameters
  */
 export const executeSQL = async ({

--- a/packages/react-core/src/utils/requestsUtils.js
+++ b/packages/react-core/src/utils/requestsUtils.js
@@ -7,13 +7,15 @@ export const REQUEST_GET_MAX_URL_LENGTH = 2048;
  * Simple GET request
  */
 export function getRequest(url, opts, headers = {}) {
+  const { headers: extraHeaders, ...extraOpts } = opts;
   return new Request(url, {
     method: 'GET',
     headers: {
       Accept: 'application/json',
-      ...headers
+      ...headers,
+      ...extraHeaders
     },
-    ...opts
+    ...extraOpts
   });
 }
 
@@ -21,15 +23,17 @@ export function getRequest(url, opts, headers = {}) {
  * Simple POST request
  */
 export function postRequest(url, payload, opts, headers = {}) {
+  const { headers: extraHeaders, ...extraOpts } = opts;
   return new Request(url, {
     method: 'POST',
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',
-      ...headers
+      ...headers,
+      ...extraHeaders
     },
     body: JSON.stringify(payload),
-    ...opts
+    ...extraOpts
   });
 }
 


### PR DESCRIPTION
# Description

Allowing to inject headers into executeSQL helper method.

Eg:
```
const opts = { headers: { cache: 'no-cache' } }
executeSQL({
      credentials,
      query,
      queryParameters,
      connection,
      opts
    })
```

## Type of change

- Feature

# Acceptance

Opts can be injected correctly, without affecting other headers

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
