### PR TITLE
Add missing form stories

### DIFF
--- a/packages/react-ui/storybook/stories/atoms/HelperText.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/HelperText.stories.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { FormControl, FormHelperText, OutlinedInput } from '@mui/material';
+
+const options = {
+  title: 'Atoms/Helper Text',
+  component: FormHelperText,
+  argTypes: {
+    disabled: {
+      control: {
+        type: 'boolean'
+      }
+    },
+    error: {
+      control: {
+        type: 'boolean'
+      }
+    },
+    label: {
+      control: {
+        type: 'text'
+      }
+    }
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/nmaoLeo69xBJCHm9nc6lEV/C4R-Components?node-id=1534-33807&t=dVNCJzz6IduwAMHg-0'
+    },
+    status: {
+      type: 'validated'
+    }
+  }
+};
+export default options;
+
+const Template = ({ label, ...args }) => {
+  return <FormHelperText {...args}>{label}</FormHelperText>;
+};
+
+const CompositionTemplate = ({ label, ...args }) => {
+  return (
+    <FormControl {...args} size='small'>
+      <OutlinedInput placeholder='Input text' />
+      <FormHelperText>{label}</FormHelperText>
+    </FormControl>
+  );
+};
+
+const commonArgs = {
+  label: 'Helper text to be placed below an input'
+};
+
+export const Playground = Template.bind({});
+Playground.args = { ...commonArgs };
+
+export const Composition = CompositionTemplate.bind({});
+Composition.args = { ...commonArgs };

--- a/packages/react-ui/storybook/stories/atoms/InputLabel.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/InputLabel.stories.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import { FormControl, InputLabel, OutlinedInput } from '@mui/material';
+import LabelWithIndicator from '../../../src/components/atoms/LabelWithIndicator';
+import Typography from '../../../src/components/atoms/Typography';
+
+const options = {
+  title: 'Atoms/Input Label',
+  component: InputLabel,
+  argTypes: {
+    disabled: {
+      control: {
+        type: 'boolean'
+      }
+    },
+    error: {
+      control: {
+        type: 'boolean'
+      }
+    },
+    label: {
+      control: {
+        type: 'text'
+      }
+    }
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/nmaoLeo69xBJCHm9nc6lEV/C4R-Components?node-id=1534-33807&t=dVNCJzz6IduwAMHg-0'
+    },
+    status: {
+      type: 'validated'
+    }
+  }
+};
+export default options;
+
+const Template = ({ label, ...args }) => {
+  return <InputLabel {...args}>{label}</InputLabel>;
+};
+
+const CompositionTemplate = ({ label, ...args }) => {
+  return (
+    <FormControl {...args} size='small'>
+      <InputLabel>{label}</InputLabel>
+      <OutlinedInput placeholder='Input text' />
+    </FormControl>
+  );
+};
+
+const RequiredTemplate = ({ label, ...args }) => {
+  return (
+    <>
+      <Typography variant='body2' mb={4}>
+        {'Use <LabelWithIndicator /> component inside the Label'}
+      </Typography>
+
+      <Typography variant='body2' mb={2}>
+        {'Required'}
+      </Typography>
+
+      <FormControl {...args} size='small'>
+        <InputLabel>
+          <LabelWithIndicator label={label} type='required' />
+        </InputLabel>
+        <OutlinedInput placeholder='Input text' />
+      </FormControl>
+
+      <Typography variant='body2' mt={4} mb={2}>
+        {'Optional'}
+      </Typography>
+
+      <FormControl {...args} size='small'>
+        <InputLabel>
+          <LabelWithIndicator label={label} />
+        </InputLabel>
+        <OutlinedInput placeholder='Input text' />
+      </FormControl>
+    </>
+  );
+};
+
+const commonArgs = {
+  label: 'Label text'
+};
+
+export const Playground = Template.bind({});
+Playground.args = { ...commonArgs };
+
+export const Composition = CompositionTemplate.bind({});
+Composition.args = { ...commonArgs };
+
+export const Required = RequiredTemplate.bind({});
+Required.args = { ...commonArgs };

--- a/packages/react-ui/storybook/stories/icons/CartoIcons.stories.js
+++ b/packages/react-ui/storybook/stories/icons/CartoIcons.stories.js
@@ -5,7 +5,7 @@ import { icons } from '../../../src/assets';
 import { GridVerticalContent } from '../../utils/storyStyles';
 
 const options = {
-  title: 'Icons/Carto Icons',
+  title: 'Icons/CARTO Icons',
   argTypes: {
     fontSize: {
       control: {


### PR DESCRIPTION
# Description

Shortcut: [#303600](https://app.shortcut.com/cartoteam/story/303600/tooling-c4r-add-isolated-stories-for-form-elements)

As a result of some feedback received from frontenders, added here some stories to be more explicit about smaller form elements already implemented