### PR TITLE
Migrate Note componente to MUI5

### DIFF
--- a/packages/react-ui/src/widgets/legend/Note.js
+++ b/packages/react-ui/src/widgets/legend/Note.js
@@ -1,16 +1,13 @@
 import { Box } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
+import { styled } from '@mui/material/styles';
 import React from 'react';
 import Typography from '../../components/atoms/Typography';
 
-const useNoteStyles = makeStyles(() => ({
-  note: {
-    fontWeight: 'normal'
-  }
+const LighterTypography = styled(Typography)(({ theme }) => ({
+  fontWeight: 'normal'
 }));
 
 export default function Note({ children }) {
-  const classes = useNoteStyles();
 
   if (!children) {
     return null;
@@ -19,9 +16,9 @@ export default function Note({ children }) {
   return (
     <Box mt={1} data-testid='note-legend'>
       <Typography variant='caption'>Note:</Typography>{' '}
-      <Typography className={classes.note} variant='caption'>
+      <LighterTypography variant='caption'>
         {children}
-      </Typography>
+      </LighterTypography>
     </Box>
   );
 }

--- a/packages/react-ui/src/widgets/legend/Note.js
+++ b/packages/react-ui/src/widgets/legend/Note.js
@@ -3,7 +3,7 @@ import { styled } from '@mui/material/styles';
 import React from 'react';
 import Typography from '../../components/atoms/Typography';
 
-const LighterTypography = styled(Typography)(({ theme }) => ({
+const FontWeightNormalTypography = styled(Typography)(({ theme }) => ({
   fontWeight: 'normal'
 }));
 
@@ -16,9 +16,9 @@ export default function Note({ children }) {
   return (
     <Box mt={1} data-testid='note-legend'>
       <Typography variant='caption'>Note:</Typography>{' '}
-      <LighterTypography variant='caption'>
+      <FontWeightNormalTypography variant='caption'>
         {children}
-      </LighterTypography>
+      </FontWeightNormalTypography>
     </Box>
   );
 }


### PR DESCRIPTION
# Description

Shortcut: [297037](https://app.shortcut.com/cartoteam/story/297037/migrate-away-from-makestyles-i-widgets)

## Type of change

- Refactor

# Acceptance

Same previous styles, but with MUI5

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
