### PR TITLE
Migrate 'LegendProportion' component from makeStyles to styled-components + cleanup

### DIFF
--- a/packages/react-ui/src/widgets/legend/LegendProportion.js
+++ b/packages/react-ui/src/widgets/legend/LegendProportion.js
@@ -1,43 +1,43 @@
-import React from 'react';
-import { Box, Grid } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
+import { Box, Grid, styled } from '@mui/material';
 import PropTypes from 'prop-types';
+import React from 'react';
 import Typography from '../../components/atoms/Typography';
 
-const useStyles = makeStyles((theme) => ({
-  circles: {
-    position: 'relative',
-    marginBottom: 4
-  },
-  avg: {
-    width: 12,
-    height: 2,
+const Circle = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'index'
+})(({ index = 0, theme }) => {
+  const sizes = {
+    0: 96,
+    1: 72,
+    2: 48,
+    3: 24
+  };
+  const width = `${sizes[index]}px`;
+  const height = `${sizes[index]}px`;
+
+  return {
+    border: `solid 1px ${theme.palette.grey[100]}`,
+    backgroundColor: theme.palette.grey[50],
+    borderRadius: '50%',
     position: 'absolute',
-    // TODO change color
-    border: `1px solid ${theme.palette.grey[900]}`,
-    borderRadius: 4,
-    backgroundColor: theme.palette.grey[900],
     right: 0,
-    boxSizing: 'border-box'
-  },
-  errorContainer: {
-    maxWidth: 240
-  }
-}));
+    bottom: 0,
+    width,
+    height
+  };
+});
 
 function LegendProportion({ legend }) {
-  const classes = useStyles();
-
   const { min, max, error } = calculateRange(legend);
   const [step1, step2] = !error ? calculateSteps(min, max) : [0, 0];
 
   return (
     <Grid container item direction='row' spacing={2} data-testid='proportion-legend'>
-      <Grid container item xs={6} justifyContent='flex-end' className={classes.circles}>
-        <Circle index={0}></Circle>
-        <Circle index={1}></Circle>
-        <Circle index={2}></Circle>
-        <Circle index={3}></Circle>
+      <Grid container item xs={6} justifyContent='flex-end' mb={4} position='relative'>
+        <Circle index={0} component='span'></Circle>
+        <Circle index={1} component='span'></Circle>
+        <Circle index={2} component='span'></Circle>
+        <Circle index={3} component='span'></Circle>
       </Grid>
       <Grid
         container
@@ -48,7 +48,7 @@ function LegendProportion({ legend }) {
         spacing={1}
       >
         {error ? (
-          <Grid item className={classes.errorContainer}>
+          <Grid item xs maxWidth={240}>
             <Typography variant='overline'>
               You need to specify valid numbers for the labels property
             </Typography>
@@ -121,33 +121,4 @@ function calculateSteps(min, max) {
   const step2 = max - gap;
 
   return [step1, step2];
-}
-
-const useStylesCircle = makeStyles((theme) => ({
-  circle: {
-    border: `solid 1px ${theme.palette.grey[100]}`,
-    backgroundColor: theme.palette.grey[50],
-    borderRadius: '50%',
-    position: 'absolute',
-    right: 0,
-    bottom: 0
-  }
-}));
-
-function Circle({ index = 0 }) {
-  const classes = useStylesCircle();
-
-  const sizes = {
-    0: 96,
-    1: 72,
-    2: 48,
-    3: 24
-  };
-
-  const width = sizes[index];
-  const height = sizes[index];
-
-  return (
-    <Box component='span' className={classes.circle} style={{ width, height }}></Box>
-  );
 }

--- a/packages/react-ui/src/widgets/legend/LegendProportion.js
+++ b/packages/react-ui/src/widgets/legend/LegendProportion.js
@@ -3,17 +3,18 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Typography from '../../components/atoms/Typography';
 
+const sizes = {
+  0: 12,
+  1: 9,
+  2: 6,
+  3: 3
+};
+
 const Circle = styled(Box, {
   shouldForwardProp: (prop) => prop !== 'index'
 })(({ index = 0, theme }) => {
-  const sizes = {
-    0: 96,
-    1: 72,
-    2: 48,
-    3: 24
-  };
-  const width = `${sizes[index]}px`;
-  const height = `${sizes[index]}px`;
+  const width = theme.spacing(sizes[index]);
+  const height = theme.spacing(sizes[index]);
 
   return {
     border: `solid 1px ${theme.palette.grey[100]}`,
@@ -54,7 +55,7 @@ function LegendProportion({ legend }) {
         spacing={1}
       >
         {error ? (
-          <Grid item xs maxWidth={240}>
+          <Grid item maxWidth={240}>
             <Typography variant='overline'>
               You need to specify valid numbers for the labels property
             </Typography>

--- a/packages/react-ui/src/widgets/legend/LegendProportion.js
+++ b/packages/react-ui/src/widgets/legend/LegendProportion.js
@@ -27,18 +27,24 @@ const Circle = styled(Box, {
   };
 });
 
+const ProportionalGrid = styled(Grid)(({ theme: { spacing } }) => ({
+  justifyContent: 'flex-end',
+  marginBottom: spacing(0.5),
+  position: 'relative'
+}));
+
 function LegendProportion({ legend }) {
   const { min, max, error } = calculateRange(legend);
   const [step1, step2] = !error ? calculateSteps(min, max) : [0, 0];
 
   return (
     <Grid container item direction='row' spacing={2} data-testid='proportion-legend'>
-      <Grid container item xs={6} justifyContent='flex-end' mb={4} position='relative'>
+      <ProportionalGrid container item xs={6}>
         <Circle index={0} component='span'></Circle>
         <Circle index={1} component='span'></Circle>
         <Circle index={2} component='span'></Circle>
         <Circle index={3} component='span'></Circle>
-      </Grid>
+      </ProportionalGrid>
       <Grid
         container
         item

--- a/packages/react-ui/src/widgets/legend/LegendProportion.js
+++ b/packages/react-ui/src/widgets/legend/LegendProportion.js
@@ -41,10 +41,9 @@ function LegendProportion({ legend }) {
   return (
     <Grid container item direction='row' spacing={2} data-testid='proportion-legend'>
       <ProportionalGrid container item xs={6}>
-        <Circle index={0} component='span'></Circle>
-        <Circle index={1} component='span'></Circle>
-        <Circle index={2} component='span'></Circle>
-        <Circle index={3} component='span'></Circle>
+        {[...Array(4)].map((circle, index) => (
+          <Circle index={index} component='span'></Circle>
+        ))}
       </ProportionalGrid>
       <Grid
         container


### PR DESCRIPTION
# Description

This PR includes a refactorization of LegendProportion component, all classes from makestyles are been converted to styled components

Shortcut:  [297037](https://app.shortcut.com/cartoteam/story/297037/migrate-away-from-makestyles-i-widgets)

## Type of change

- Refactor

# Acceptance

The code resultant must return same styles component visualization as the same before changes

1. Overview a general visualization from v1.x to v2.x

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
