### PR TITLE
Migrate 'LegendRamp' component from makeStyles to styled-component + cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Storybook documentation and fixes [#629](https://github.com/CartoDB/carto-react/pull/629)
 - Note component cleaned styles from makeStyles [#630](https://github.com/CartoDB/carto-react/pull/630)
 - OpacityControl component migrated from makeStyles to styled-components + cleanup [#631](https://github.com/CartoDB/carto-react/pull/631)
+- LegendRamp component migrated from makeStyles to styled-components + cleanup [#636](https://github.com/CartoDB/carto-react/pull/636)
 
 ## 2.0
 

--- a/packages/react-ui/__tests__/widgets/legend/LegendRamp.test.js
+++ b/packages/react-ui/__tests__/widgets/legend/LegendRamp.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen } from '../../widgets/utils/testUtils';
 import LegendRamp from '../../../src/widgets/legend/LegendRamp';
 import { getPalette } from '../../../src/utils/palette';
+import { hexToRgb } from '@mui/material';
 
 const COLOR = 'TealGrn';
 
@@ -33,8 +34,10 @@ describe('LegendRamp', () => {
 
       const elements = document.querySelectorAll('[class*="step"]');
       expect(elements.length).toBe(3);
-      getPalette(COLOR, 3).forEach((color, idx) =>
-        expect(elements[idx]).toHaveStyle(`background-color: ${color}`)
+      getPalette(COLOR, 3).forEach((color, idx) => {
+        const backgroundColor = window.getComputedStyle(elements[idx])['background-color'];
+        expect(backgroundColor).toBe(hexToRgb(color))
+      }
       );
     });
     test('renders formatted labels correctly', () => {
@@ -44,9 +47,10 @@ describe('LegendRamp', () => {
 
       const elements = document.querySelectorAll('[class*="step"]');
       expect(elements.length).toBe(3);
-      getPalette(COLOR, 3).forEach((color, idx) =>
-        expect(elements[idx]).toHaveStyle(`background-color: ${color}`)
-      );
+      getPalette(COLOR, 3).forEach((color, idx) =>{
+        const backgroundColor = window.getComputedStyle(elements[idx])['background-color'];
+        expect(backgroundColor).toBe(hexToRgb(color))
+      });
     });
   });
   describe('continuous', () => {
@@ -55,10 +59,10 @@ describe('LegendRamp', () => {
       expect(screen.queryByText('0')).toBeInTheDocument();
       expect(screen.queryByText('200')).toBeInTheDocument();
 
-      const ramp = document.querySelector('[class*="step"]');
+      const ramp = document.querySelector('.step');
       const palette = getPalette(COLOR, 2);
-      expect(ramp).toHaveStyle(
-        `background-image: linear-gradient(to right, ${palette.join()})`
+      const backgroundImage = window.getComputedStyle(ramp)['background'];
+      expect(backgroundImage).toHaveCSS('background', `linear-gradient(to right, ${palette.join()})`
       );
     });
     test('renders formatted labels correctly', () => {
@@ -68,11 +72,10 @@ describe('LegendRamp', () => {
       expect(screen.queryByText('0 km')).toBeInTheDocument();
       expect(screen.queryByText('200 km')).toBeInTheDocument();
 
-      const ramp = document.querySelector('[class*="step"]');
+      const ramp = document.querySelector('.step');
       const palette = getPalette(COLOR, 2);
-      expect(ramp).toHaveStyle(
-        `background-image: linear-gradient(to right, ${palette.join()})`
-      );
+      const backgroundImage = window.getComputedStyle(ramp)['background'];
+      expect(backgroundImage).toBe(`linear-gradient(to right, ${palette.join()})`);
     });
   });
 });

--- a/packages/react-ui/__tests__/widgets/legend/LegendRamp.test.js
+++ b/packages/react-ui/__tests__/widgets/legend/LegendRamp.test.js
@@ -32,7 +32,7 @@ describe('LegendRamp', () => {
       expect(screen.queryByText('< 0')).toBeInTheDocument();
       expect(screen.queryByText('≥ 200')).toBeInTheDocument();
 
-      const elements = document.querySelectorAll('[class*="step"]');
+      const elements = document.querySelectorAll('[data-testid=step-discontinuous]');
       expect(elements.length).toBe(3);
       getPalette(COLOR, 3).forEach((color, idx) => {
         const backgroundColor = window.getComputedStyle(elements[idx])[
@@ -46,7 +46,7 @@ describe('LegendRamp', () => {
       expect(screen.queryByText('< 0 km')).toBeInTheDocument();
       expect(screen.queryByText('≥ 200 km')).toBeInTheDocument();
 
-      const elements = document.querySelectorAll('[class*="step"]');
+      const elements = document.querySelectorAll('[data-testid=step-discontinuous]');
       expect(elements.length).toBe(3);
       getPalette(COLOR, 3).forEach((color, idx) => {
         const backgroundColor = window.getComputedStyle(elements[idx])[
@@ -62,7 +62,7 @@ describe('LegendRamp', () => {
       expect(screen.queryByText('0')).toBeInTheDocument();
       expect(screen.queryByText('200')).toBeInTheDocument();
 
-      const ramp = document.querySelector('.step');
+      const ramp = document.querySelector('[data-testid=step-continuous]');
       const palette = getPalette(COLOR, 2);
       expect(ramp).toHaveStyle(
         `background: linear-gradient(to right, ${palette.join()})`
@@ -75,7 +75,7 @@ describe('LegendRamp', () => {
       expect(screen.queryByText('0 km')).toBeInTheDocument();
       expect(screen.queryByText('200 km')).toBeInTheDocument();
 
-      const ramp = document.querySelector('.step');
+      const ramp = document.querySelector('[data-testid=step-continuous]');
       const palette = getPalette(COLOR, 2);
       expect(ramp).toHaveStyle(
         `background: linear-gradient(to right, ${palette.join()})`

--- a/packages/react-ui/__tests__/widgets/legend/LegendRamp.test.js
+++ b/packages/react-ui/__tests__/widgets/legend/LegendRamp.test.js
@@ -35,10 +35,11 @@ describe('LegendRamp', () => {
       const elements = document.querySelectorAll('[class*="step"]');
       expect(elements.length).toBe(3);
       getPalette(COLOR, 3).forEach((color, idx) => {
-        const backgroundColor = window.getComputedStyle(elements[idx])['background-color'];
-        expect(backgroundColor).toBe(hexToRgb(color))
-      }
-      );
+        const backgroundColor = window.getComputedStyle(elements[idx])[
+          'background-color'
+        ];
+        expect(backgroundColor).toBe(hexToRgb(color));
+      });
     });
     test('renders formatted labels correctly', () => {
       render(<LegendRamp legend={DEFAULT_LEGEND_WITH_FORMATTED_LABELS} />);
@@ -47,9 +48,11 @@ describe('LegendRamp', () => {
 
       const elements = document.querySelectorAll('[class*="step"]');
       expect(elements.length).toBe(3);
-      getPalette(COLOR, 3).forEach((color, idx) =>{
-        const backgroundColor = window.getComputedStyle(elements[idx])['background-color'];
-        expect(backgroundColor).toBe(hexToRgb(color))
+      getPalette(COLOR, 3).forEach((color, idx) => {
+        const backgroundColor = window.getComputedStyle(elements[idx])[
+          'background-color'
+        ];
+        expect(backgroundColor).toBe(hexToRgb(color));
       });
     });
   });
@@ -61,8 +64,8 @@ describe('LegendRamp', () => {
 
       const ramp = document.querySelector('.step');
       const palette = getPalette(COLOR, 2);
-      const backgroundImage = window.getComputedStyle(ramp)['background'];
-      expect(backgroundImage).toHaveCSS('background', `linear-gradient(to right, ${palette.join()})`
+      expect(ramp).toHaveStyle(
+        `background: linear-gradient(to right, ${palette.join()})`
       );
     });
     test('renders formatted labels correctly', () => {
@@ -74,8 +77,9 @@ describe('LegendRamp', () => {
 
       const ramp = document.querySelector('.step');
       const palette = getPalette(COLOR, 2);
-      const backgroundImage = window.getComputedStyle(ramp)['background'];
-      expect(backgroundImage).toBe(`linear-gradient(to right, ${palette.join()})`);
+      expect(ramp).toHaveStyle(
+        `background: linear-gradient(to right, ${palette.join()})`
+      );
     });
   });
 });

--- a/packages/react-ui/src/widgets/legend/LegendRamp.js
+++ b/packages/react-ui/src/widgets/legend/LegendRamp.js
@@ -94,7 +94,7 @@ const StepsContinuous = styled(Grid, {
   backgroundImage: `linear-gradient(to right, ${palette.join()})`
 }));
 
-const StepsDiscontinuousGrid = styled(Grid, {
+const StepGrid = styled(Grid, {
   shouldForwardProp: (prop) => prop !== 'color'
 })(({ color }) => ({
   height: 8,
@@ -122,7 +122,7 @@ function StepsDiscontinuous({ labels = [], palette = [], max, min }) {
 
         return (
           <Tooltip key={idx} title={title}>
-            <StepsDiscontinuousGrid item xs color={palette[idx]} />
+            <StepGrid item xs color={palette[idx]} />
           </Tooltip>
         );
       })}

--- a/packages/react-ui/src/widgets/legend/LegendRamp.js
+++ b/packages/react-ui/src/widgets/legend/LegendRamp.js
@@ -43,7 +43,7 @@ function LegendRamp({ isContinuous = false, legend }) {
         <>
           <Grid container item>
             {isContinuous ? (
-              <StepsContinuous className="step" item xs palette={palette} />
+              <StepsContinuous data-testid='step-continuous' item xs palette={palette} />
             ) : (
               <StepsDiscontinuous
                 labels={formattedLabels}
@@ -88,22 +88,22 @@ export default LegendRamp;
 
 const StepsContinuous = styled(Grid, {
   shouldForwardProp: (prop) => prop !== 'palette'
-})(({ palette }) => ({
-  height: 8,
-  borderRadius: 4,
+})(({ palette, theme }) => ({
+  height: theme.spacing(1),
+  borderRadius: theme.spacing(0.5),
   background: `linear-gradient(to right, ${palette.join()})`
 }));
 
 const StepGrid = styled(Grid, {
   shouldForwardProp: (prop) => prop !== 'color'
-})(({ color }) => ({
-  height: 8,
+})(({ color, theme }) => ({
+  height: theme.spacing(1),
   backgroundColor: color,
   '&:first-of-type': {
-    borderRadius: '4px 0 0 4px'
+    borderRadius: theme.spacing(0.5, 0, 0, 0.5)
   },
   '&:last-of-type': {
-    borderRadius: '0 4px 4px 0'
+    borderRadius: theme.spacing(0, 0.5, 0.5, 0)
   }
 }));
 
@@ -122,7 +122,7 @@ function StepsDiscontinuous({ labels = [], palette = [], max, min }) {
 
         return (
           <Tooltip key={idx} title={title}>
-            <StepGrid className="step" item xs color={palette[idx]} />
+            <StepGrid data-testid='step-discontinuous' item xs color={palette[idx]} />
           </Tooltip>
         );
       })}

--- a/packages/react-ui/src/widgets/legend/LegendRamp.js
+++ b/packages/react-ui/src/widgets/legend/LegendRamp.js
@@ -1,20 +1,11 @@
-import React from 'react';
-import { Grid, Tooltip } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
-import { getPalette } from '../../utils/palette';
+import { Grid, Tooltip, styled } from '@mui/material';
 import PropTypes from 'prop-types';
-import { getMinMax } from './LegendProportion';
-import LegendProportion from './LegendProportion';
+import React from 'react';
 import Typography from '../../components/atoms/Typography';
+import { getPalette } from '../../utils/palette';
+import LegendProportion, { getMinMax } from './LegendProportion';
 
-const useStyles = makeStyles(() => ({
-  errorContainer: {
-    maxWidth: 240
-  }
-}));
 function LegendRamp({ isContinuous = false, legend }) {
-  const classes = useStyles();
-
   const { labels = [], colors = [] } = legend;
 
   const palette = getPalette(
@@ -43,7 +34,7 @@ function LegendRamp({ isContinuous = false, legend }) {
   return (
     <Grid container item direction='column' spacing={1} data-testid='ramp-legend'>
       {error ? (
-        <Grid item className={classes.errorContainer}>
+        <Grid item xs maxWidth={240}>
           <Typography variant='overline'>
             You need to specify valid numbers for the labels property
           </Typography>
@@ -52,7 +43,7 @@ function LegendRamp({ isContinuous = false, legend }) {
         <>
           <Grid container item>
             {isContinuous ? (
-              <StepsContinuous palette={palette} />
+              <StepsContinuous item xs palette={palette} />
             ) : (
               <StepsDiscontinuous
                 labels={formattedLabels}
@@ -95,36 +86,28 @@ LegendRamp.propTypes = {
 
 export default LegendRamp;
 
-// Aux
-const useStylesStepsContinuous = makeStyles(() => ({
-  step: {
-    height: 8,
-    borderRadius: 4
-  }
+const StepsContinuous = styled(Grid, {
+  shouldForwardProp: (prop) => prop !== 'palette'
+})(({ palette }) => ({
+  height: 8,
+  borderRadius: 4,
+  backgroundImage: `linear-gradient(to right, ${palette.join()})`
 }));
 
-function StepsContinuous({ palette = [] }) {
-  const classes = useStylesStepsContinuous();
-
-  const backgroundImage = `linear-gradient(to right, ${palette.join()})`;
-
-  return <Grid item xs className={classes.step} style={{ backgroundImage }} />;
-}
-
-const useStylesStepsDiscontinuous = makeStyles(() => ({
-  step: {
-    height: 8,
-    '&:first-child': {
-      borderRadius: '4px 0 0 4px'
-    },
-    '&:last-child': {
-      borderRadius: '0 4px 4px 0'
-    }
+const StepsDiscontinuousGrid = styled(Grid, {
+  shouldForwardProp: (prop) => prop !== 'color'
+})(({ color }) => ({
+  height: 8,
+  backgroundColor: color,
+  '&:first-child': {
+    borderRadius: '4px 0 0 4px'
+  },
+  '&:last-child': {
+    borderRadius: '0 4px 4px 0'
   }
 }));
 
 function StepsDiscontinuous({ labels = [], palette = [], max, min }) {
-  const classes = useStylesStepsDiscontinuous();
   const rightLabels = labels.length ? [min, ...labels] : [min, max];
 
   return (
@@ -139,12 +122,7 @@ function StepsDiscontinuous({ labels = [], palette = [], max, min }) {
 
         return (
           <Tooltip key={idx} title={title}>
-            <Grid
-              item
-              xs
-              className={classes.step}
-              style={{ backgroundColor: palette[idx] }}
-            />
+            <StepsDiscontinuousGrid item xs color={palette[idx]} />
           </Tooltip>
         );
       })}

--- a/packages/react-ui/src/widgets/legend/LegendRamp.js
+++ b/packages/react-ui/src/widgets/legend/LegendRamp.js
@@ -43,7 +43,7 @@ function LegendRamp({ isContinuous = false, legend }) {
         <>
           <Grid container item>
             {isContinuous ? (
-              <StepsContinuous item xs palette={palette} />
+              <StepsContinuous className="step" item xs palette={palette} />
             ) : (
               <StepsDiscontinuous
                 labels={formattedLabels}
@@ -91,7 +91,7 @@ const StepsContinuous = styled(Grid, {
 })(({ palette }) => ({
   height: 8,
   borderRadius: 4,
-  backgroundImage: `linear-gradient(to right, ${palette.join()})`
+  background: `linear-gradient(to right, ${palette.join()})`
 }));
 
 const StepGrid = styled(Grid, {
@@ -99,10 +99,10 @@ const StepGrid = styled(Grid, {
 })(({ color }) => ({
   height: 8,
   backgroundColor: color,
-  '&:first-child': {
+  '&:first-of-type': {
     borderRadius: '4px 0 0 4px'
   },
-  '&:last-child': {
+  '&:last-of-type': {
     borderRadius: '0 4px 4px 0'
   }
 }));
@@ -122,7 +122,7 @@ function StepsDiscontinuous({ labels = [], palette = [], max, min }) {
 
         return (
           <Tooltip key={idx} title={title}>
-            <StepGrid item xs color={palette[idx]} />
+            <StepGrid className="step" item xs color={palette[idx]} />
           </Tooltip>
         );
       })}


### PR DESCRIPTION
# Description

This PR includes a refactorization of LegendRamp component, all classes from makestyles are been converted to styled components

Shortcut:  [297037](https://app.shortcut.com/cartoteam/story/297037/migrate-away-from-makestyles-i-widgets)

## Type of change

- Refactor

# Acceptance

The code resultant must return same styles component visualization as the same before changes

1. Overview a general visualization from v1.x to v2.x

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
