### PR TITLE
Migrate 'GeocoderWidget' component from makeStyles to styled-component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Storybook documentation and fixes [#629](https://github.com/CartoDB/carto-react/pull/629)
 - Note component cleaned styles from makeStyles [#630](https://github.com/CartoDB/carto-react/pull/630)
 - OpacityControl component migrated from makeStyles to styled-components + cleanup [#631](https://github.com/CartoDB/carto-react/pull/631)
+- GeocoderWidget component migrated from makeStyles to styled-components [#638](https://github.com/CartoDB/carto-react/pull/638)
 
 ## 2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - LegendProportion component migrated from makeStyles to styled-components + cleanup [#635](https://github.com/CartoDB/carto-react/pull/635)
 - LegendRamp component migrated from makeStyles to styled-components + cleanup [#636](https://github.com/CartoDB/carto-react/pull/636)
 - LegendWidgetUI component migrated from makeStyles to styled-components + cleanup [#637](https://github.com/CartoDB/carto-react/pull/637)
+- GeocoderWidget component migrated from makeStyles to styled-components [#638](https://github.com/CartoDB/carto-react/pull/638)
 
 ## 2.0
 
@@ -26,7 +27,6 @@
 - Storybook documentation and fixes [#629](https://github.com/CartoDB/carto-react/pull/629)
 - Note component cleaned styles from makeStyles [#630](https://github.com/CartoDB/carto-react/pull/630)
 - OpacityControl component migrated from makeStyles to styled-components + cleanup [#631](https://github.com/CartoDB/carto-react/pull/631)
-- GeocoderWidget component migrated from makeStyles to styled-components [#638](https://github.com/CartoDB/carto-react/pull/638)
 
 ### 2.0.0 (2023-04-05)
 

--- a/packages/react-widgets/src/types.d.ts
+++ b/packages/react-widgets/src/types.d.ts
@@ -1,4 +1,5 @@
 import { AggregationTypes } from '@carto/react-core';
+import type { SxProps, Theme } from '@mui/material';
 
 type CommonWidgetProps = {
   id: string,
@@ -42,6 +43,7 @@ export type FormulaWidget = CommonWidgetProps & MonoColumnWidgetProps;
 
 export type GeocoderWidget = {
   className: string,
+  sx?: SxProps<Theme>,
   onError?: Function
 }
 

--- a/packages/react-widgets/src/widgets/GeocoderWidget.js
+++ b/packages/react-widgets/src/widgets/GeocoderWidget.js
@@ -4,32 +4,28 @@ import { PropTypes } from 'prop-types';
 
 import { addLayer, setViewState } from '@carto/react-redux';
 
-import { CircularProgress, InputBase, Paper, SvgIcon } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
+import { CircularProgress, InputBase, Paper, SvgIcon, styled } from '@mui/material';
 import useGeocoderWidgetController from '../hooks/useGeocoderWidgetController';
 
-const useStyles = makeStyles((theme) => ({
-  paperInput: {
-    height: theme.spacing(4.5),
-    width: theme.spacing(30),
-    paddingLeft: theme.spacing(1.5),
-    borderRadius: 4,
-    display: 'flex',
-    alignItems: 'center'
-  },
-  icon: {
-    fill: theme.palette.text.secondary,
-    height: '1em',
-    fontSize: `${theme.typography.body2.lineHeight}em`
-  },
-  clear: {
-    ...theme.typography.body2
-  },
-  input: {
-    ...theme.typography.body2,
-    width: `calc(100% - ${theme.spacing(5)})`,
-    marginLeft: theme.spacing(1)
-  }
+const StyledPaper = styled(Paper)(({ theme: { spacing } }) => ({
+  height: spacing(4.5),
+  width: spacing(30),
+  paddingLeft: spacing(1.5),
+  borderRadius: 4,
+  display: 'flex',
+  alignItems: 'center'
+}));
+
+const StyledIcon = styled(SvgIcon)(({ theme: { palette, typography } }) => ({
+  fill: palette.text.secondary,
+  fontSize: `${typography.body2.lineHeight}em`,
+  height: '1em'
+}));
+
+const StyledInputBase = styled(InputBase)(({ theme: { typography, spacing } }) => ({
+  ...typography.body2,
+  width: `calc(100% - ${spacing(5)})`,
+  marginLeft: spacing(1)
 }));
 
 const SearchIcon = (args) => (
@@ -48,7 +44,6 @@ const SearchIcon = (args) => (
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  */
 function GeocoderWidget(props = {}) {
-  const classes = useStyles();
   const dispatch = useDispatch();
   const geocoderResult = useSelector((state) => state.carto.geocoderResult);
 
@@ -78,19 +73,22 @@ function GeocoderWidget(props = {}) {
   }, [geocoderResult, dispatch]);
 
   return (
-    <Paper className={`${props.className} ${classes.paperInput}`} elevation={2}>
+    <StyledPaper className={`${props.className}`} elevation={2}>
       {loading ? (
-        <CircularProgress size={20} className={classes.icon} />
+        <StyledIcon>
+          <CircularProgress size={20} />
+        </StyledIcon>
       ) : (
-        <SearchIcon className={classes.icon} />
+        <StyledIcon>
+          <SearchIcon />
+        </StyledIcon>
       )}
 
-      <InputBase
+      <StyledInputBase
         type='search'
         tabIndex={-1}
         size='small'
         placeholder='Search address'
-        className={classes.input}
         value={searchText}
         inputProps={{ 'aria-label': 'GeocoderSearch' }}
         onChange={handleChange}
@@ -98,7 +96,7 @@ function GeocoderWidget(props = {}) {
         onKeyDown={handleKeyPress}
         onBlur={handleBlur}
       />
-    </Paper>
+    </StyledPaper>
   );
 }
 

--- a/packages/react-widgets/src/widgets/GeocoderWidget.js
+++ b/packages/react-widgets/src/widgets/GeocoderWidget.js
@@ -11,22 +11,19 @@ const StyledPaper = styled(Paper)(({ theme: { spacing } }) => ({
   height: spacing(4.5),
   width: spacing(30),
   paddingLeft: spacing(1.5),
-  borderRadius: 4,
+  borderRadius: spacing(0.5),
   display: 'flex',
   alignItems: 'center'
 }));
 
-const StyledIcon = styled(SvgIcon)(({ theme: { palette, typography } }) => ({
-  fill: palette.text.secondary,
-  fontSize: `${typography.body2.lineHeight}em`,
-  height: '1em'
-}));
-
-const StyledInputBase = styled(InputBase)(({ theme: { typography, spacing } }) => ({
-  ...typography.body2,
+const InputSearch = styled(InputBase)(({ theme: { spacing } }) => ({
   width: `calc(100% - ${spacing(5)})`,
   marginLeft: spacing(1)
 }));
+
+const svgStyle = {
+  fill: ({ palette }) => palette.text.secondary
+};
 
 const SearchIcon = (args) => (
   <SvgIcon {...args}>
@@ -41,6 +38,7 @@ const SearchIcon = (args) => (
  * Renders a <GeocoderWidget /> component
  * @param  {object} props
  * @param  {Object} [props.className] - Material-UI withStyle class for styling
+ * @param  {Object} [props.sx] - MUI5 for styling with sx prop
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  */
 function GeocoderWidget(props = {}) {
@@ -73,18 +71,14 @@ function GeocoderWidget(props = {}) {
   }, [geocoderResult, dispatch]);
 
   return (
-    <StyledPaper className={`${props.className}`} elevation={2}>
+    <StyledPaper className={`${props.className}`} elevation={2} sx={props.sx}>
       {loading ? (
-        <StyledIcon>
-          <CircularProgress size={20} />
-        </StyledIcon>
+        <CircularProgress size={18} sx={svgStyle} />
       ) : (
-        <StyledIcon>
-          <SearchIcon />
-        </StyledIcon>
+        <SearchIcon sx={svgStyle} />
       )}
 
-      <StyledInputBase
+      <InputSearch
         type='search'
         tabIndex={-1}
         size='small'
@@ -102,6 +96,7 @@ function GeocoderWidget(props = {}) {
 
 GeocoderWidget.propTypes = {
   className: PropTypes.string,
+  sx: PropTypes.object,
   onError: PropTypes.func
 };
 


### PR DESCRIPTION
# Description

This PR includes a refactorization of GeocoderWidget component, all classes from makestyles are been converted to styled components

Shortcut: [297037](https://app.shortcut.com/cartoteam/story/297037/migrate-away-from-makestyles-i-widgets)

## Type of change

- Refactor

# Acceptance

The code resultant must returns same styles component visualization as the same before changes

1. Overview a general visualization from v1.x to v2.x