### PR TITLE
Migrate 'RangeWidgetUI' component from makeStyles to styled-component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Storybook documentation and fixes [#629](https://github.com/CartoDB/carto-react/pull/629)
 - Note component cleaned styles from makeStyles [#630](https://github.com/CartoDB/carto-react/pull/630)
 - OpacityControl component migrated from makeStyles to styled-components + cleanup [#631](https://github.com/CartoDB/carto-react/pull/631)
+- RangeWidgetUI component migrated from makeStyles to styled-components [#639](https://github.com/CartoDB/carto-react/pull/639)
 
 ## 2.0
 

--- a/packages/react-ui/src/widgets/RangeWidgetUI.js
+++ b/packages/react-ui/src/widgets/RangeWidgetUI.js
@@ -1,69 +1,73 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Box, Link, Slider, TextField } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
+import { Box, Link, Slider, TextField, styled } from '@mui/material';
 import { debounce } from '@carto/react-core';
+import Typography from '../components/atoms/Typography';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    position: 'relative'
+const StyledRoot = styled(Box)(() => ({
+  position: 'relative'
+}));
+
+const StyledClearWrapper = styled(Box)(({ theme: { spacing } }) => ({
+  display: 'flex',
+  flexDirection: 'row-reverse',
+  height: spacing(1.5)
+}));
+
+const StyledClearButton = styled(Link)(() => ({
+  cursor: 'pointer'
+}));
+
+const StyledTextField = styled(TextField)(({ theme: { spacing } }) => ({
+  maxWidth: spacing(9),
+  margin: 0,
+  '& fieldset': {
+    borderWidth: 1
   },
-  sliderWithThumbRail: {
-    color: theme.palette.text.hint
-  },
-  sliderLimit: {
-    pointerEvents: 'none',
-    position: 'absolute',
-    zIndex: 1,
-    left: 0,
-    right: 0
-  },
-  sliderLimitThumb: {
+  '& input': {
+    '&[type=number]': {
+      appearance: 'textfield'
+    },
+    '&::-webkit-outer-spin-button': {
+      appearance: 'none',
+      margin: 0
+    },
+    '&::-webkit-inner-spin-button': {
+      appearance: 'none',
+      margin: 0
+    }
+  }
+}));
+
+const StyledSlider = styled(Slider)(({ theme: { palette } }) => ({
+  '& .MuiSlider-rail': {
+    color: palette.text.hint
+  }
+}));
+
+const StyledSliderLimit = styled(Slider)(({ theme: { palette, spacing } }) => ({
+  pointerEvents: 'none',
+  position: 'absolute',
+  zIndex: 1,
+  left: 0,
+  right: 0,
+  '& .MuiSlider-rail': {
     display: 'none'
   },
-  sliderLimitRail: {
+  '& .MuiSlider-thumb': {
     display: 'none'
   },
-  sliderLimitMarks: {
-    backgroundColor: theme.palette.primary.main,
-    opacity: 0.38,
-    height: theme.spacing(1),
-    width: theme.spacing(0.25),
-    top: '50%',
-    transform: 'translateY(-50%)'
-  },
-  sliderLimitsTrack: {
-    color: theme.palette.primary.main,
+  '& .MuiSlider-track': {
+    color: palette.primary.main,
     opacity: 0.38
   },
-  input: {
-    maxWidth: theme.spacing(9),
-    margin: 0,
-    '& fieldset': {
-      borderWidth: 1
-    },
-    '& input': {
-      '&[type=number]': {
-        appearance: 'textfield'
-      },
-      '&::-webkit-outer-spin-button': {
-        appearance: 'none',
-        margin: 0
-      },
-      '&::-webkit-inner-spin-button': {
-        appearance: 'none',
-        margin: 0
-      }
-    }
-  },
-  clearWrapper: {
-    display: 'flex',
-    flexDirection: 'row-reverse',
-    height: theme.spacing(1.5)
-  },
-  clearButton: {
-    ...theme.typography.caption,
-    cursor: 'pointer'
+  '& .MuiSlider-mark, & .MuiSlider-markActive': {
+    backgroundColor: palette.primary.main,
+    opacity: 0.38,
+    height: spacing(1),
+    width: spacing(0.25),
+    top: '50%',
+    transform: 'translateY(-50%)'
   }
 }));
 
@@ -79,7 +83,6 @@ const useStyles = makeStyles((theme) => ({
  */
 
 function RangeWidgetUI({ data, min, max, limits, onSelectedRangeChange }) {
-  const classes = useStyles();
   const [sliderValues, setSliderValues] = useState([min, max]);
   const [inputsValues, setInputsValues] = useState([min, max]);
 
@@ -153,36 +156,27 @@ function RangeWidgetUI({ data, min, max, limits, onSelectedRangeChange }) {
   };
 
   return (
-    <Box className={classes.root}>
-      <Box className={classes.clearWrapper}>
+    <StyledRoot>
+      <StyledClearWrapper>
         {hasBeenModified && (
-          <Link onClick={resetSlider} className={classes.clearButton} underline='hover'>
-            Clear
-          </Link>
+          <StyledClearButton onClick={resetSlider} underline='hover'>
+            <Typography variant='caption' color='primary'>
+              Clear
+            </Typography>
+          </StyledClearButton>
         )}
-      </Box>
+      </StyledClearWrapper>
       <Box>
-        <Slider
+        <StyledSlider
           getAriaLabel={(index) => (index === 0 ? 'min value' : 'max value')}
-          classes={{
-            rail: classes.sliderWithThumbRail
-          }}
           value={sliderValues}
           min={min}
           max={max}
           onChange={(_, values) => changeSliderValues(values)}
         />
         {limits && limits.length === 2 && (
-          <Slider
+          <StyledSliderLimit
             getAriaLabel={(index) => (index === 0 ? 'min limit' : 'max limit')}
-            className={classes.sliderLimit}
-            classes={{
-              rail: classes.sliderLimitRail,
-              thumb: classes.sliderLimitThumb,
-              track: classes.sliderLimitsTrack,
-              mark: classes.sliderLimitMarks,
-              markActive: classes.sliderLimitMarks
-            }}
             value={limits}
             min={min}
             max={max}
@@ -191,8 +185,7 @@ function RangeWidgetUI({ data, min, max, limits, onSelectedRangeChange }) {
         )}
       </Box>
       <Box display={'flex'} justifyContent={'space-between'} mb={1}>
-        <TextField
-          className={classes.input}
+        <StyledTextField
           value={inputsValues[0]}
           size='small'
           onChange={(event) => handleInputChange(event, 0)}
@@ -204,8 +197,7 @@ function RangeWidgetUI({ data, min, max, limits, onSelectedRangeChange }) {
             'aria-label': 'min value'
           }}
         />
-        <TextField
-          className={classes.input}
+        <StyledTextField
           value={inputsValues[1]}
           size='small'
           onChange={(event) => handleInputChange(event, 1)}
@@ -218,7 +210,7 @@ function RangeWidgetUI({ data, min, max, limits, onSelectedRangeChange }) {
           }}
         />
       </Box>
-    </Box>
+    </StyledRoot>
   );
 }
 

--- a/packages/react-ui/src/widgets/RangeWidgetUI.js
+++ b/packages/react-ui/src/widgets/RangeWidgetUI.js
@@ -4,21 +4,21 @@ import { Box, Link, Slider, TextField, styled } from '@mui/material';
 import { debounce } from '@carto/react-core';
 import Typography from '../components/atoms/Typography';
 
-const StyledRoot = styled(Box)(() => ({
+const Root = styled(Box)(() => ({
   position: 'relative'
 }));
 
-const StyledClearWrapper = styled(Box)(({ theme: { spacing } }) => ({
+const ClearWrapper = styled(Box)(({ theme: { spacing } }) => ({
   display: 'flex',
   flexDirection: 'row-reverse',
   height: spacing(1.5)
 }));
 
-const StyledClearButton = styled(Link)(() => ({
+const ClearButton = styled(Link)(() => ({
   cursor: 'pointer'
 }));
 
-const StyledTextField = styled(TextField)(({ theme: { spacing } }) => ({
+const LimitTextField = styled(TextField)(({ theme: { spacing } }) => ({
   maxWidth: spacing(9),
   margin: 0,
   '& fieldset': {
@@ -45,7 +45,7 @@ const StyledSlider = styled(Slider)(({ theme: { palette } }) => ({
   }
 }));
 
-const StyledSliderLimit = styled(Slider)(({ theme: { palette, spacing } }) => ({
+const SliderLimit = styled(Slider)(({ theme: { palette, spacing } }) => ({
   pointerEvents: 'none',
   position: 'absolute',
   zIndex: 1,
@@ -156,16 +156,16 @@ function RangeWidgetUI({ data, min, max, limits, onSelectedRangeChange }) {
   };
 
   return (
-    <StyledRoot>
-      <StyledClearWrapper>
+    <Root>
+      <ClearWrapper>
         {hasBeenModified && (
-          <StyledClearButton onClick={resetSlider} underline='hover'>
+          <ClearButton onClick={resetSlider} underline='hover'>
             <Typography variant='caption' color='primary'>
               Clear
             </Typography>
-          </StyledClearButton>
+          </ClearButton>
         )}
-      </StyledClearWrapper>
+      </ClearWrapper>
       <Box>
         <StyledSlider
           getAriaLabel={(index) => (index === 0 ? 'min value' : 'max value')}
@@ -175,7 +175,7 @@ function RangeWidgetUI({ data, min, max, limits, onSelectedRangeChange }) {
           onChange={(_, values) => changeSliderValues(values)}
         />
         {limits && limits.length === 2 && (
-          <StyledSliderLimit
+          <SliderLimit
             getAriaLabel={(index) => (index === 0 ? 'min limit' : 'max limit')}
             value={limits}
             min={min}
@@ -185,7 +185,7 @@ function RangeWidgetUI({ data, min, max, limits, onSelectedRangeChange }) {
         )}
       </Box>
       <Box display={'flex'} justifyContent={'space-between'} mb={1}>
-        <StyledTextField
+        <LimitTextField
           value={inputsValues[0]}
           size='small'
           onChange={(event) => handleInputChange(event, 0)}
@@ -197,7 +197,7 @@ function RangeWidgetUI({ data, min, max, limits, onSelectedRangeChange }) {
             'aria-label': 'min value'
           }}
         />
-        <StyledTextField
+        <LimitTextField
           value={inputsValues[1]}
           size='small'
           onChange={(event) => handleInputChange(event, 1)}
@@ -210,7 +210,7 @@ function RangeWidgetUI({ data, min, max, limits, onSelectedRangeChange }) {
           }}
         />
       </Box>
-    </StyledRoot>
+    </Root>
   );
 }
 

--- a/packages/react-ui/src/widgets/RangeWidgetUI.js
+++ b/packages/react-ui/src/widgets/RangeWidgetUI.js
@@ -159,11 +159,11 @@ function RangeWidgetUI({ data, min, max, limits, onSelectedRangeChange }) {
     <Root>
       <ClearWrapper>
         {hasBeenModified && (
-          <ClearButton onClick={resetSlider} underline='hover'>
-            <Typography variant='caption' color='primary'>
+          <Typography variant='caption' color='primary'>
+            <ClearButton onClick={resetSlider} underline='hover'>
               Clear
-            </Typography>
-          </ClearButton>
+            </ClearButton>
+          </Typography>
         )}
       </ClearWrapper>
       <Box>


### PR DESCRIPTION
# Description

This PR includes a refactorization of RangeWidgetUI component, all classes from makestyles are been converted to styled components

Shortcut: [297037](https://app.shortcut.com/cartoteam/story/297037/migrate-away-from-makestyles-i-widgets)

## Type of change

- Refactor

# Acceptance

The code resultant must returns same styles component visualization as the same before changes

1. Overview a general visualization from v1.x to v2.x