### PR TITLE
Migrate 'FeatureSelectionWidgetUI' component from makeStyles to styled-component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Storybook documentation and fixes [#629](https://github.com/CartoDB/carto-react/pull/629)
 - Note component cleaned styles from makeStyles [#630](https://github.com/CartoDB/carto-react/pull/630)
 - OpacityControl component migrated from makeStyles to styled-components + cleanup [#631](https://github.com/CartoDB/carto-react/pull/631)
+- FeatureSelectionWidgetUI component migrated from makeStyles to styled-components [#640](https://github.com/CartoDB/carto-react/pull/640)
 
 ## 2.0
 

--- a/packages/react-ui/src/types.d.ts
+++ b/packages/react-ui/src/types.d.ts
@@ -3,7 +3,9 @@ import {
   AppBarProps as MuiAppBarProps,
   TextFieldProps,
   TypographyProps as MuiTypographyProps,
-  AvatarProps as MuiAvatarProps
+  AvatarProps as MuiAvatarProps,
+  SxProps,
+  Theme
 } from '@mui/material';
 import { CSSProperties } from 'react';
 
@@ -164,6 +166,7 @@ export type FeatureSelectionWidgetUI = {
   onSelectGeometry?: Function;
   tooltipPlacement?: string;
   className?: string;
+  sx?: SxProps<Theme>;
 };
 
 // Legends

--- a/packages/react-ui/src/widgets/FeatureSelectionWidgetUI.js
+++ b/packages/react-ui/src/widgets/FeatureSelectionWidgetUI.js
@@ -18,6 +18,7 @@ import Typography from '../components/atoms/Typography';
 
 function FeatureSelectionWidgetUI({
   className,
+  sx,
   selectionModes,
   editModes,
   selectedMode,
@@ -30,7 +31,7 @@ function FeatureSelectionWidgetUI({
   tooltipPlacement
 }) {
   return (
-    <Wrapper className={className}>
+    <Wrapper sx={sx} className={className}>
       <Helper
         hasMode={!!selectedMode}
         isEdit={editModes.some((mode) => mode.id === selectedMode)}
@@ -68,7 +69,7 @@ function FeatureSelectionWidgetUI({
 }
 
 FeatureSelectionWidgetUI.defaultProps = {
-  className: '',
+  sx: undefined,
   enabled: false,
   tooltipPlacement: 'bottom',
   editModes: []
@@ -81,7 +82,7 @@ const MODE_SHAPE = PropTypes.shape({
 });
 
 FeatureSelectionWidgetUI.propTypes = {
-  className: PropTypes.string,
+  sx: PropTypes.any,
   selectionModes: PropTypes.arrayOf(MODE_SHAPE.isRequired).isRequired,
   editModes: PropTypes.arrayOf(MODE_SHAPE.isRequired),
   selectedMode: PropTypes.string.isRequired,
@@ -313,6 +314,10 @@ const StylesWrapper = styled('div')(({ theme: { spacing, palette, shape } }) => 
     '0px 3px 5px -1px rgb(0 0 0 / 16%), 0px 5px 8px 0px rgb(0 0 0 / 8%), 0px 1px 14px 0px rgb(0 0 0 / 4%)'
 }));
 
-function Wrapper({ className, children }) {
-  return <StylesWrapper className={`${className}`}>{children}</StylesWrapper>;
+function Wrapper({ sx, className, children }) {
+  return (
+    <StylesWrapper className={className} sx={sx}>
+      {children}
+    </StylesWrapper>
+  );
 }

--- a/packages/react-ui/src/widgets/FeatureSelectionWidgetUI.js
+++ b/packages/react-ui/src/widgets/FeatureSelectionWidgetUI.js
@@ -8,10 +8,10 @@ import {
   IconButton,
   Menu,
   MenuItem,
+  styled,
   Tooltip,
   useTheme
 } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
 import { ArrowDropDown } from '@mui/icons-material';
 import PropTypes from 'prop-types';
 import Typography from '../components/atoms/Typography';
@@ -159,13 +159,11 @@ function GeometryViewer({
   );
 }
 
-const useSelectedModeViewerStyles = makeStyles((theme) => ({
-  btn: {
-    color: ({ enabled }) =>
-      enabled ? theme.palette.primary.main : theme.palette.text.secondary,
-    backgroundColor: ({ enabled }) =>
-      enabled ? alpha(theme.palette.primary.main, 0.05) : null
-  }
+const StyledSelectedModeViewerButton = styled(IconButton, {
+  shouldForwardProp: (prop) => prop !== 'enabled'
+})(({ theme: { palette }, enabled }) => ({
+  color: enabled ? palette.primary.main : palette.text.secondary,
+  backgroundColor: enabled ? alpha(palette.primary.main, 0.05) : null
 }));
 
 function SelectedModeViewer({
@@ -175,8 +173,6 @@ function SelectedModeViewer({
   onEnabledChange,
   tooltipPlacement
 }) {
-  const classes = useSelectedModeViewerStyles({ enabled });
-
   const { label, icon, isEdit } = useMemo(() => {
     if (modes?.length && selectedMode) {
       const foundMode = modes.find(({ id: modeId }) => modeId === selectedMode);
@@ -195,24 +191,22 @@ function SelectedModeViewer({
 
   return (
     <Tooltip title={tooltipTitle} placement={tooltipPlacement}>
-      <IconButton onClick={onEnabledChangeWrapper} className={classes.btn}>
+      <StyledSelectedModeViewerButton onClick={onEnabledChangeWrapper} enabled={enabled}>
         {icon}
-      </IconButton>
+      </StyledSelectedModeViewerButton>
     </Tooltip>
   );
 }
 
-const useModesSelectorStyles = makeStyles((theme) => ({
-  btn: {
-    color: theme.palette.text.secondary,
-    width: 24
-  },
-  divider: {
-    margin: theme.spacing(1, 0)
-  },
-  enabledMenuItem: {
-    backgroundColor: alpha(theme.palette.primary.main, 0.08)
-  }
+const StyledButtonArrow = styled(IconButton)(({ theme: { palette } }) => ({
+  color: palette.text.secondary,
+  width: 24
+}));
+
+const StyledMenuItem = styled(MenuItem, {
+  shouldForwardProp: (prop) => prop !== 'enabled'
+})(({ theme: { palette }, enabled }) => ({
+  ...(enabled && { backgroundColor: alpha(palette.primary.main, 0.08) })
 }));
 
 function ModesSelector({
@@ -224,8 +218,6 @@ function ModesSelector({
   tooltipPlacement
 }) {
   const theme = useTheme();
-  const classes = useModesSelectorStyles();
-
   const [anchorEl, setAnchorEl] = useState(null);
 
   const open = Boolean(anchorEl);
@@ -247,8 +239,8 @@ function ModesSelector({
   const hasEditModes = !!editModes.length;
 
   const MenuItemWrapper = forwardRef(({ mode, isEnabled }, ref) => (
-    <MenuItem
-      className={isEnabled ? classes.enabledMenuItem : null}
+    <StyledMenuItem
+      enabled={isEnabled}
       ref={ref}
       onClick={() => handleSelectMode(mode.id)}
     >
@@ -258,7 +250,7 @@ function ModesSelector({
           <Typography variant='body2'>{capitalize(mode.label)}</Typography>
         </Box>
       </Box>
-    </MenuItem>
+    </StyledMenuItem>
   ));
 
   const createMenuItemWrapper = (mode) => (
@@ -272,16 +264,15 @@ function ModesSelector({
   return (
     <Box>
       <Tooltip title='Select a mode' placement={tooltipPlacement}>
-        <IconButton
+        <StyledButtonArrow
           id='fade-button'
           aria-controls='fade-menu'
           aria-haspopup='true'
           aria-expanded={open ? 'true' : undefined}
-          className={classes.btn}
           onClick={handleClick}
         >
           <ArrowDropDown />
-        </IconButton>
+        </StyledButtonArrow>
       </Tooltip>
       <Menu
         style={{ zIndex: theme.zIndex.tooltip + 1 }}
@@ -297,35 +288,31 @@ function ModesSelector({
           <Typography variant='caption'>Choose a selection mode</Typography>
         </MenuItem>
         {hasSelectionModes && selectionModes.map(createMenuItemWrapper)}
-        {hasSelectionModes && hasEditModes && <Divider className={classes.divider} />}
+        {hasSelectionModes && hasEditModes && (
+          <Divider
+            sx={{
+              margin: ({ spacing }) => spacing(1, 0)
+            }}
+          />
+        )}
         {hasSelectionModes && editModes.map(createMenuItemWrapper)}
       </Menu>
     </Box>
   );
 }
 
-const useWrapperStyles = makeStyles((theme) => ({
-  root: {
-    padding: theme.spacing(0.5),
-    backgroundColor: theme.palette.common.white,
-    color: theme.palette.text.primary,
-    borderRadius: theme.shape.borderRadius,
-    boxShadow:
-      '0px 3px 5px -1px rgb(0 0 0 / 16%), 0px 5px 8px 0px rgb(0 0 0 / 8%), 0px 1px 14px 0px rgb(0 0 0 / 4%)'
-  }
+const StylesWrapper = styled('div')(({ theme: { spacing, palette, shape } }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: spacing(0.5),
+  backgroundColor: palette.common.white,
+  color: palette.text.primary,
+  borderRadius: shape.borderRadius,
+  boxShadow:
+    '0px 3px 5px -1px rgb(0 0 0 / 16%), 0px 5px 8px 0px rgb(0 0 0 / 8%), 0px 1px 14px 0px rgb(0 0 0 / 4%)'
 }));
 
 function Wrapper({ className, children }) {
-  const classes = useWrapperStyles();
-  return (
-    <Box
-      className={`${classes.root} ${className}`}
-      p={0.5}
-      display='flex'
-      alignItems='center'
-      justifyContent='space-between'
-    >
-      {children}
-    </Box>
-  );
+  return <StylesWrapper className={`${className}`}>{children}</StylesWrapper>;
 }


### PR DESCRIPTION
# Description

This PR includes a refactorization of RangeWidgetUI component, all classes from makestyles are been converted to styled components

Shortcut: [297037](https://app.shortcut.com/cartoteam/story/297037/migrate-away-from-makestyles-i-widgets)

## Type of change

- Refactor

# Acceptance

The code resultant must returns same styles component visualization as the same before changes

1. Overview a general visualization from v1.x to v2.x