### PR TITLE
Cleanup makeStyles from TimeSeriesWidgetUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Storybook documentation and fixes [#629](https://github.com/CartoDB/carto-react/pull/629)
 - Note component cleaned styles from makeStyles [#630](https://github.com/CartoDB/carto-react/pull/630)
 - OpacityControl component migrated from makeStyles to styled-components + cleanup [#631](https://github.com/CartoDB/carto-react/pull/631)
+- TimeSeriesWidgetUI component cleanup makeStyles and unnecessary className [#642](https://github.com/CartoDB/carto-react/pull/642)
 
 ## 2.0
 

--- a/packages/react-ui/src/widgets/TimeSeriesWidgetUI/TimeSeriesWidgetUI.js
+++ b/packages/react-ui/src/widgets/TimeSeriesWidgetUI/TimeSeriesWidgetUI.js
@@ -150,7 +150,6 @@ function TimeSeriesWidgetUIContent({
   showControls,
   animation
 }) {
-  const classes = useStyles();
   const [anchorSpeedEl, setAnchorSpeedEl] = useState(null);
   const [speed, setSpeed] = useState(1);
   const {

--- a/packages/react-ui/src/widgets/TimeSeriesWidgetUI/TimeSeriesWidgetUI.js
+++ b/packages/react-ui/src/widgets/TimeSeriesWidgetUI/TimeSeriesWidgetUI.js
@@ -137,13 +137,6 @@ TimeSeriesWidgetUI.defaultProps = {
 
 export default TimeSeriesWidgetUI;
 
-const useStyles = makeStyles((theme) => ({
-  currentStepSize: {
-    fontSize: 12,
-    marginLeft: theme.spacing(1)
-  }
-}));
-
 // Content is splitted from the default
 // component to be able to use context
 function TimeSeriesWidgetUIContent({
@@ -316,7 +309,9 @@ function TimeSeriesWidgetUIContent({
               {currentDate}
             </Typography>
             <Typography
-              className={classes.currentStepSize}
+              xs
+              fontSize={12}
+              ml={1}
               color='textSecondary'
               variant='caption'
             >


### PR DESCRIPTION
# Description

This PR includes a cleanup of TimeSeriesWidgetUI component makeStyles and className unnecesary

Shortcut:  [297037](https://app.shortcut.com/cartoteam/story/297037/migrate-away-from-makestyles-i-widgets)

## Type of change

- Refactor

# Acceptance

The code resultant must return same styles component visualization as the same before changes

1. Overview a general visualization from v1.x to v2.x

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
