### PR TITLE
Migrate 'BarWidgetUI' from makeStyles to styled-component + cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Storybook documentation and fixes [#629](https://github.com/CartoDB/carto-react/pull/629)
 - Note component cleaned styles from makeStyles [#630](https://github.com/CartoDB/carto-react/pull/630)
 - OpacityControl component migrated from makeStyles to styled-components + cleanup [#631](https://github.com/CartoDB/carto-react/pull/631)
+- BarWidgetUI component migrated from makeStyles to styled-components + cleanup [#644](https://github.com/CartoDB/carto-react/pull/644)
 
 ## 2.0
 

--- a/packages/react-ui/src/widgets/BarWidgetUI.js
+++ b/packages/react-ui/src/widgets/BarWidgetUI.js
@@ -1,27 +1,27 @@
 import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import ReactEcharts from '../custom-components/echarts-for-react';
-import { Grid, Link, useTheme, darken } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
+import { Grid, Link, useTheme, darken, styled } from '@mui/material';
 import detectTouchScreen from './utils/detectTouchScreen';
 import { processFormatterRes } from './utils/formatterUtils';
 import Typography from '../components/atoms/Typography';
 
 const IS_TOUCH_SCREEN = detectTouchScreen();
 
-const useStyles = makeStyles((theme) => ({
-  optionsSelectedBar: {
-    marginBottom: theme.spacingValue * 2,
 
-    '& .MuiTypography-caption': {
-      color: theme.palette.text.secondary
-    }
-  },
-
-  selectAllButton: {
-    ...theme.typography.caption,
-    cursor: 'pointer'
+const OptionsSelectedBar = styled(Grid)(({ theme }) => ({
+  marginBottom: theme.spacingValue * 2,
+  direction: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  '& .MuiTypography-caption': {
+    color: theme.palette.text.secondary
   }
+}));
+
+const SelectAllButton = styled(Link)(({ theme }) => ({
+  ...theme.typography.caption,
+  cursor: 'pointer'
 }));
 
 function BarWidgetUI(props) {
@@ -49,7 +49,6 @@ function BarWidgetUI(props) {
   const isMultiSeries = series.length > 1;
 
   const theme = useTheme();
-  const classes = useStyles();
 
   // Tooltip
   const tooltipOptions = useMemo(
@@ -292,26 +291,19 @@ function BarWidgetUI(props) {
   return (
     <div>
       {onSelectedBarsChange && (
-        <Grid
-          container
-          direction='row'
-          justifyContent='space-between'
-          alignItems='center'
-          className={classes.optionsSelectedBar}
-        >
+        <OptionsSelectedBar container>
           <Typography variant='caption'>
             {selectedBars?.length || 'All'} selected
           </Typography>
           {selectedBars && selectedBars.length > 0 && (
-            <Link
-              className={classes.selectAllButton}
+            <SelectAllButton
               onClick={() => clearBars()}
               underline='hover'
             >
               Clear
-            </Link>
+            </SelectAllButton>
           )}
-        </Grid>
+        </OptionsSelectedBar>
       )}
       {!!options && (
         <ReactEcharts


### PR DESCRIPTION
# Description

This PR includes a refactorization of BarWidgetUI component, all classes from makestyles are been converted to styled components

Shortcut:  [297037](https://app.shortcut.com/cartoteam/story/297037/migrate-away-from-makestyles-i-widgets)

## Type of change

- Refactor

# Acceptance

The code resultant must return same styles component visualization as the same before changes

1. Overview a general visualization from v1.x to v2.x

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
