### PR TITLE
Migrate 'CategoryWidgetUI' from makeStyles to styled-component + cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Storybook documentation and fixes [#629](https://github.com/CartoDB/carto-react/pull/629)
 - Note component cleaned styles from makeStyles [#630](https://github.com/CartoDB/carto-react/pull/630)
 - OpacityControl component migrated from makeStyles to styled-components + cleanup [#631](https://github.com/CartoDB/carto-react/pull/631)
+- CategoryWidgetUI component migrated from makeStyles to styled-components + cleanup [#641](https://github.com/CartoDB/carto-react/pull/641)
 
 ## 2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Storybook documentation and fixes [#629](https://github.com/CartoDB/carto-react/pull/629)
 - Note component cleaned styles from makeStyles [#630](https://github.com/CartoDB/carto-react/pull/630)
 - OpacityControl component migrated from makeStyles to styled-components + cleanup [#631](https://github.com/CartoDB/carto-react/pull/631)
-- CategoryWidgetUI component migrated from makeStyles to styled-components + cleanup [#641](https://github.com/CartoDB/carto-react/pull/641)
+- CategoryWidgetUI component migrated from makeStyles to styled-components + cleanup [#645](https://github.com/CartoDB/carto-react/pull/645)
 
 ## 2.0
 

--- a/packages/react-ui/src/widgets/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI.js
@@ -46,7 +46,7 @@ const Label = styled(Typography)(({ theme }) => ({
   marginRight: theme.spacing(2)
 }));
 
-const LinkAsButton = styled(Link)(({theme}) => ({
+const LinkAsButton = styled(Link)(({ theme }) => ({
   ...theme.typography.caption,
   cursor: 'pointer',
   '& + hr': {
@@ -68,35 +68,36 @@ const StylesGridElement = styled(Grid, {
   shouldForwardProp: (prop) => !['selectable', 'name', 'unselected'].includes(prop)
 })(({ theme, selectable, name, unselected }) => {
   return {
-  flexDirection: 'row',
-  ...(unselected && {
-    color: theme.palette.text.disabled,
-    '.progressbar div':{
-      backgroundColor: theme.palette.text.disabled
-    }
-  }),
-  ...(name !== REST_CATEGORY && selectable && {
-    cursor: 'pointer',
-    flexWrap: 'nowrap',
+    flexDirection: 'row',
+    ...(unselected && {
+      color: theme.palette.text.disabled,
+      '.progressbar div': {
+        backgroundColor: theme.palette.text.disabled
+      }
+    }),
+    ...(name !== REST_CATEGORY &&
+      selectable && {
+        cursor: 'pointer',
+        flexWrap: 'nowrap',
 
-    '&:hover .progressbar div': {
-      backgroundColor: theme.palette.secondary.dark
-    }
-  }),
-  ...(name === REST_CATEGORY && {
-    cursor: 'default',
-    '.progressbar div':{
-      backgroundColor: theme.palette.text.disabled
-    }
-  }),
-}
+        '&:hover .progressbar div': {
+          backgroundColor: theme.palette.secondary.dark
+        }
+      }),
+    ...(name === REST_CATEGORY && {
+      cursor: 'default',
+      '.progressbar div': {
+        backgroundColor: theme.palette.text.disabled
+      }
+    })
+  };
 });
 
 const StyledOptionsSelectedBar = styled(Grid)(({ theme: { spacing, palette } }) => ({
   flexDirection: 'row',
   justifyContent: 'space-between',
   alignItems: 'center',
-  marginBottom: spacing(2),
+  marginBottom: spacing(1.5),
   paddingRight: spacing(1),
   '& .MuiTypography-caption': {
     color: palette.text.secondary
@@ -383,10 +384,10 @@ function CategoryWidgetUI(props) {
       };
     }, []);
 
-
-    const unselected = !showAll &&
-    selectedCategories.length > 0 &&
-    selectedCategories.indexOf(data.name) === -1
+    const unselected =
+      !showAll &&
+      selectedCategories.length > 0 &&
+      selectedCategories.indexOf(data.name) === -1;
     return (
       <StylesGridElement
         container
@@ -414,11 +415,7 @@ function CategoryWidgetUI(props) {
               title={getCategoryLabel(data.name)}
               disableHoverListener={!isOverflowed}
             >
-              <Label
-                variant='body2'
-                noWrap
-                ref={textElementRef}
-              >
+              <Label variant='body2' noWrap ref={textElementRef}>
                 {getCategoryLabel(data.name)}
               </Label>
             </Tooltip>
@@ -432,7 +429,7 @@ function CategoryWidgetUI(props) {
               <span>{value}</span>
             )}
           </Grid>
-          <Progressbar className='progressbar' item >
+          <Progressbar className='progressbar' item>
             <div style={{ width: getProgressbarLength(data.value) }}></div>
           </Progressbar>
         </Grid>
@@ -477,33 +474,21 @@ function CategoryWidgetUI(props) {
                 {selectedCategories.length ? selectedCategories.length : 'All'} selected
               </Typography>
               {showAll ? (
-                <LinkAsButton
-                  onClick={handleApplyClicked}
-                  underline='hover'
-                >
+                <LinkAsButton onClick={handleApplyClicked} underline='hover'>
                   Apply
                 </LinkAsButton>
               ) : blockedCategories.length > 0 ? (
-                <LinkAsButton
-                  onClick={handleUnblockClicked}
-                  underline='hover'
-                >
+                <LinkAsButton onClick={handleUnblockClicked} underline='hover'>
                   Unlock
                 </LinkAsButton>
               ) : (
                 selectedCategories.length > 0 && (
                   <Grid container direction='row' justifyContent='flex-end' item xs>
-                    <LinkAsButton
-                      onClick={handleBlockClicked}
-                      underline='hover'
-                    >
+                    <LinkAsButton onClick={handleBlockClicked} underline='hover'>
                       Lock
                     </LinkAsButton>
                     <Divider orientation='vertical' flexItem />
-                    <LinkAsButton
-                      onClick={handleClearClicked}
-                      underline='hover'
-                    >
+                    <LinkAsButton onClick={handleClearClicked} underline='hover'>
                       Clear
                     </LinkAsButton>
                   </Grid>

--- a/packages/react-ui/src/widgets/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI.js
@@ -75,20 +75,20 @@ const StylesGridElement = styled(Grid, {
       backgroundColor: theme.palette.text.disabled
     }
   }),
-  ...(name === REST_CATEGORY && {
-    cursor: 'default',
-    '.progressbar div':{
-      backgroundColor: theme.palette.text.disabled
-    }
-  }),
-  ...(selectable && {
+  ...(name !== REST_CATEGORY && selectable && {
     cursor: 'pointer',
     flexWrap: 'nowrap',
 
     '&:hover .progressbar div': {
       backgroundColor: theme.palette.secondary.dark
     }
-  })
+  }),
+  ...(name === REST_CATEGORY && {
+    cursor: 'default',
+    '.progressbar div':{
+      backgroundColor: theme.palette.text.disabled
+    }
+  }),
 }
 });
 

--- a/packages/react-ui/src/widgets/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI.js
@@ -9,7 +9,9 @@ import {
   Divider,
   SvgIcon,
   TextField,
-  Tooltip
+  Tooltip,
+  styled,
+  Box
 } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { Skeleton } from '@mui/material';
@@ -18,36 +20,12 @@ import { animateValues } from './utils/animations';
 import Typography from '../components/atoms/Typography';
 
 const useStyles = makeStyles((theme) => ({
-  root: {
-    ...theme.typography.body2
-  },
-
-  categoriesWrapper: {
-    maxHeight: theme.spacing(40),
-    overflow: 'auto',
-    padding: theme.spacing(0, 1, 1, 0)
-  },
-
   selectable: {
     cursor: 'pointer',
     flexWrap: 'nowrap',
 
     '&:hover $progressbar div': {
       backgroundColor: theme.palette.secondary.dark
-    }
-  },
-
-  element: {
-    '&$unselected': {
-      color: theme.palette.text.disabled,
-
-      '& $progressbar div': {
-        backgroundColor: theme.palette.text.disabled
-      }
-    },
-
-    '&$rest $progressbar div': {
-      backgroundColor: theme.palette.text.disabled
     }
   },
 
@@ -85,15 +63,6 @@ const useStyles = makeStyles((theme) => ({
     cursor: 'default'
   },
 
-  optionsSelectedBar: {
-    marginBottom: theme.spacing(2),
-    paddingRight: theme.spacing(1),
-
-    '& .MuiTypography-caption': {
-      color: theme.palette.text.secondary
-    }
-  },
-
   linkAsButton: {
     ...theme.typography.caption,
     cursor: 'pointer',
@@ -105,6 +74,42 @@ const useStyles = makeStyles((theme) => ({
 
   searchInput: {
     marginTop: theme.spacing(-0.5)
+  }
+}));
+
+const StyledRoot = styled(Box)(({ theme: { typography } }) => ({
+  ...typography.body2
+}));
+
+const StyledCategoriesWrapper = styled(Grid)(({ theme: { spacing } }) => ({
+  maxHeight: spacing(40),
+  overflow: 'auto',
+  padding: spacing(0, 1, 1, 0)
+}));
+
+const StylesGridElement = styled(Grid)(({ theme: { palette } }) => ({
+  flexDirection: 'row',
+  '&$unselected': {
+    color: palette.text.disabled,
+
+    '& $progressbar div': {
+      backgroundColor: palette.text.disabled
+    }
+  },
+
+  '&$rest $progressbar div': {
+    backgroundColor: palette.text.disabled
+  }
+}));
+
+const StyledOptionsSelectedBar = styled(Grid)(({ theme: { spacing, palette } }) => ({
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: spacing(2),
+  paddingRight: spacing(1),
+  '& .MuiTypography-caption': {
+    color: palette.text.secondary
   }
 }));
 
@@ -390,13 +395,12 @@ function CategoryWidgetUI(props) {
     }, []);
 
     return (
-      <Grid
+      <StylesGridElement
         container
         direction='row'
         spacing={1}
         onClick={filterable ? onCategoryClick : () => {}}
         className={`
-          ${classes.element}
           ${filterable ? classes.selectable : ''}
           ${
             !showAll &&
@@ -448,26 +452,20 @@ function CategoryWidgetUI(props) {
             <div style={{ width: getProgressbarLength(data.value) }}></div>
           </Grid>
         </Grid>
-      </Grid>
+      </StylesGridElement>
     );
   };
 
   const CategoryItemSkeleton = () => (
     <>
-      <Grid
-        container
-        direction='row'
-        justifyContent='space-between'
-        alignItems='center'
-        className={classes.optionsSelectedBar}
-      >
+      <StyledOptionsSelectedBar container>
         <Typography variant='caption'>
           <Skeleton variant='text' width={100} />
         </Typography>
-      </Grid>
-      <Grid container item className={classes.categoriesWrapper}>
+      </StyledOptionsSelectedBar>
+      <StyledCategoriesWrapper container item>
         {[...Array(4)].map((_, i) => (
-          <Grid key={i} container direction='row' spacing={1} className={classes.element}>
+          <StylesGridElement key={i} container spacing={1}>
             <Grid container item xs zeroMinWidth>
               <Grid container item direction='row' justifyContent='space-between'>
                 <Typography variant='body2' noWrap>
@@ -479,24 +477,18 @@ function CategoryWidgetUI(props) {
               </Grid>
               <Skeleton variant='text' className={classes.skeletonProgressbar} />
             </Grid>
-          </Grid>
+          </StylesGridElement>
         ))}
-      </Grid>
+      </StyledCategoriesWrapper>
     </>
   );
 
   return (
-    <div className={classes.root}>
+    <StyledRoot>
       {data?.length > 0 ? (
         <>
           {filterable && sortedData.length > 0 && (
-            <Grid
-              container
-              direction='row'
-              justifyContent='space-between'
-              alignItems='center'
-              className={classes.optionsSelectedBar}
-            >
+            <StyledOptionsSelectedBar container>
               <Typography variant='caption'>
                 {selectedCategories.length ? selectedCategories.length : 'All'} selected
               </Typography>
@@ -537,16 +529,10 @@ function CategoryWidgetUI(props) {
                   </Grid>
                 )
               )}
-            </Grid>
+            </StyledOptionsSelectedBar>
           )}
           {data.length > maxItems && showAll && (
-            <Grid
-              container
-              direction='row'
-              justifyContent='space-between'
-              alignItems='center'
-              className={classes.optionsSelectedBar}
-            >
+            <StyledOptionsSelectedBar container>
               <TextField
                 size='small'
                 placeholder='Search'
@@ -561,9 +547,9 @@ function CategoryWidgetUI(props) {
                   )
                 }}
               />
-            </Grid>
+            </StyledOptionsSelectedBar>
           )}
-          <Grid container item className={classes.categoriesWrapper}>
+          <StyledCategoriesWrapper container item>
             {animValues.length ? (
               animValues.map((d, i) => (
                 <CategoryItem
@@ -584,7 +570,7 @@ function CategoryWidgetUI(props) {
                 </Typography>
               </>
             )}
-          </Grid>
+          </StyledCategoriesWrapper>
           {data.length > maxItems && searchable ? (
             showAll ? (
               <Button size='small' color='primary' onClick={handleCancelClicked}>
@@ -605,7 +591,7 @@ function CategoryWidgetUI(props) {
       ) : (
         <CategoryItemSkeleton />
       )}
-    </div>
+    </StyledRoot>
   );
 }
 


### PR DESCRIPTION
# Description

This PR includes a refactorization of CategoryWidgetUI component, all classes from makestyles are been converted to styled components

Shortcut:  [297037](https://app.shortcut.com/cartoteam/story/297037/migrate-away-from-makestyles-i-widgets)

## Type of change

- Refactor

# Acceptance

The code resultant must return same styles component visualization as the same before changes

1. Overview a general visualization from v1.x to v2.x

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
