### PR TITLE
Migrate 'HistogramWidgetUI' component from makeStyles to styled-component + cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Storybook documentation and fixes [#629](https://github.com/CartoDB/carto-react/pull/629)
 - Note component cleaned styles from makeStyles [#630](https://github.com/CartoDB/carto-react/pull/630)
 - OpacityControl component migrated from makeStyles to styled-components + cleanup [#631](https://github.com/CartoDB/carto-react/pull/631)
+- HistogramWidgetUI component migrated from makeStyles to styled-components + cleanup [#646](https://github.com/CartoDB/carto-react/pull/646)
 
 ## 2.0
 

--- a/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
@@ -2,8 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useMemo } from 'react';
 import ReactEcharts from '../../custom-components/echarts-for-react';
-import { darken, Grid, Link, useTheme } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
+import { darken, Grid, Link, styled, useTheme } from '@mui/material';
 import { processFormatterRes } from '../utils/formatterUtils';
 import detectTouchscreen from '../utils/detectTouchScreen';
 import useHistogramInteractivity from './useHistogramInteractivity';
@@ -11,19 +10,21 @@ import Typography from '../../components/atoms/Typography';
 
 const IS_TOUCH_SCREEN = detectTouchscreen();
 
-const useStyles = makeStyles((theme) => ({
-  optionsSelectedBar: {
-    marginBottom: theme.spacing(2),
+const OptionsSelectedBar = styled(Grid)(({theme}) => ({
+  marginBottom: theme.spacing(2),
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
 
-    '& .MuiTypography-caption': {
-      color: theme.palette.text.secondary
-    }
-  },
-  clearButton: {
-    ...theme.typography.caption,
-    cursor: 'pointer'
+  '& .MuiTypography-caption': {
+    color: theme.palette.text.secondary
   }
-}));
+}))
+
+const ClearButton = styled(Link)(({theme}) => ({
+  ...theme.typography.caption,
+  cursor: 'pointer'
+}))
 
 function HistogramWidgetUI({
   data,
@@ -40,7 +41,7 @@ function HistogramWidgetUI({
   filterable: _filterable,
   height
 }) {
-  const classes = useStyles();
+
   const theme = useTheme();
 
   const filterable = _filterable && !!onSelectedBarsChange;
@@ -257,26 +258,19 @@ function HistogramWidgetUI({
   return (
     <div>
       {filterable && (
-        <Grid
-          container
-          direction='row'
-          justifyContent='space-between'
-          alignItems='center'
-          className={classes.optionsSelectedBar}
-        >
+        <OptionsSelectedBar container>
           <Typography variant='caption' weight='strong'>
             {selectedBars.length ? yAxisFormatter(countSelectedElements) : 'All'} selected
           </Typography>
           {selectedBars.length > 0 && (
-            <Link
-              className={classes.clearButton}
+            <ClearButton
               onClick={() => onSelectedBarsChange([])}
               underline='hover'
             >
               Clear
-            </Link>
+            </ClearButton>
           )}
-        </Grid>
+        </OptionsSelectedBar>
       )}
       <ReactEcharts
         option={options}


### PR DESCRIPTION
# Description

This PR includes a refactorization of HistogramWidgetUI component, all classes from makestyles are been converted to styled components

Shortcut:  [297037](https://app.shortcut.com/cartoteam/story/297037/migrate-away-from-makestyles-i-widgets)

## Type of change

- Refactor

# Acceptance

The code resultant must return same styles component visualization as the same before changes

1. Overview a general visualization from v1.x to v2.x

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
