### PR TITLE
Disable ligatures in the monospaced font family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- DS update: Disable ligatures in the monospaced font family [#649](https://github.com/CartoDB/carto-react/pull/649)
 - DS update: change action.disabledBackground color [#647](https://github.com/CartoDB/carto-react/pull/647)
 - Storybook documentation and fixes [#629](https://github.com/CartoDB/carto-react/pull/629)
 - Note component cleaned styles from makeStyles [#630](https://github.com/CartoDB/carto-react/pull/630)

--- a/packages/react-ui/src/theme/sections/typography.js
+++ b/packages/react-ui/src/theme/sections/typography.js
@@ -121,21 +121,24 @@ const customTypography = {
     fontWeight: 400,
     fontSize: getPixelToRem(16),
     lineHeight: 1.5,
-    letterSpacing: 0
+    letterSpacing: 0,
+    fontVariantLigatures: 'no-common-ligatures'
   },
   code2: {
     fontFamily: '"Overpass Mono", monospace',
     fontWeight: 400,
     fontSize: getPixelToRem(14),
     lineHeight: 1.428,
-    letterSpacing: 0
+    letterSpacing: 0,
+    fontVariantLigatures: 'no-common-ligatures'
   },
   code3: {
     fontFamily: '"Overpass Mono", monospace',
     fontWeight: 400,
     fontSize: getPixelToRem(12),
     lineHeight: 1.333,
-    letterSpacing: 0
+    letterSpacing: 0,
+    fontVariantLigatures: 'no-common-ligatures'
   }
 };
 


### PR DESCRIPTION
# Description

Shortcut: ([#306420](https://app.shortcut.com/cartoteam/story/306420/disable-ligatures-in-the-monospaced-font-family))
[sc-306420]
