### PR TITLE
react-api: stats request uses POST for big queries/queryParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- react-api: getStats request uses POST for big queries/queryParameters [#656](https://github.com/CartoDB/carto-react/pull/656)
 - New DS core component: Table [#657](https://github.com/CartoDB/carto-react/pull/657)
 - Improve upgrade guide documentation [#651](https://github.com/CartoDB/carto-react/pull/651)
 - Fix storybook publication with Node 18 [#654](https://github.com/CartoDB/carto-react/pull/654)


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/306016/support-for-long-queries-in-builder

`@carto/react-api` `stats` request suport for long queries or queryParameters by using POST is get URL exceeds certain limits.

## Type of change

- Feature

# Acceptance

Please describe how to validate the feature or fix

1. go to X
2. test Y
3. assert Z

If feature deals with theme / UI or internal elements used also in CARTO 3, please also add a note on how to do acceptance on that part.

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
