### PR TITLE
Support for feature flags in react-core

### DIFF
--- a/packages/react-core/__tests__/utils/featureFlags.test.js
+++ b/packages/react-core/__tests__/utils/featureFlags.test.js
@@ -1,0 +1,64 @@
+import { hasFlag, setFlags, clearFlags } from '../../src/utils/featureFlags';
+
+describe('Feature flags', () => {
+  afterEach(() => {
+    clearFlags();
+  });
+
+  test('are not set initially', () => {
+    expect(hasFlag('A')).toStrictEqual(false);
+    expect(hasFlag('B')).toStrictEqual(false);
+    expect(hasFlag('C')).toStrictEqual(false);
+  });
+
+  test('can be set using an array of strings', () => {
+    setFlags(['A', 'B']);
+    expect(hasFlag('A')).toStrictEqual(true);
+    expect(hasFlag('B')).toStrictEqual(true);
+    expect(hasFlag('C')).toStrictEqual(false);
+
+    setFlags([]);
+    expect(hasFlag('A')).toStrictEqual(false);
+    expect(hasFlag('B')).toStrictEqual(false);
+    expect(hasFlag('C')).toStrictEqual(false);
+  });
+
+  test('can be set using an object', () => {
+    setFlags({
+      A: 10,
+      B: true,
+      C: false,
+      D: undefined,
+      E: null,
+      F: [],
+      G: {}
+    });
+    expect(hasFlag('A')).toStrictEqual(true);
+    expect(hasFlag('B')).toStrictEqual(true);
+    expect(hasFlag('C')).toStrictEqual(false);
+    expect(hasFlag('D')).toStrictEqual(false);
+    expect(hasFlag('E')).toStrictEqual(false);
+    expect(hasFlag('F')).toStrictEqual(true);
+    expect(hasFlag('G')).toStrictEqual(true);
+
+    setFlags({});
+    expect(hasFlag('A')).toStrictEqual(false);
+    expect(hasFlag('B')).toStrictEqual(false);
+    expect(hasFlag('C')).toStrictEqual(false);
+  });
+
+  test('are cleared', () => {
+    setFlags(['A']);
+    expect(hasFlag('A')).toStrictEqual(true);
+    clearFlags();
+    expect(hasFlag('A')).toStrictEqual(false);
+  });
+
+  const invaild = [10, '', 'A', false, { '': 10 }, ['A', '']];
+  test.each(invaild)('fail in case of invalid flags %p', (x) => {
+    const t = () => {
+      setFlags(x);
+    };
+    expect(t).toThrow();
+  });
+});

--- a/packages/react-core/src/index.d.ts
+++ b/packages/react-core/src/index.d.ts
@@ -36,3 +36,9 @@ export { groupValuesByDateColumn } from './operations/groupByDate';
 export { SpatialIndex } from './operations/constants/SpatialIndexTypes'
 
 export { FEATURE_SELECTION_MODES, EDIT_MODES, MASK_ID } from './utils/featureSelectionConstants';
+
+export {
+  hasFlag as _hasFeatureFlag,
+  setFlags as _setFeatureFlags,
+  clearFlags as _clearFeatureFlags
+} from './utils/featureFlags';

--- a/packages/react-core/src/index.js
+++ b/packages/react-core/src/index.js
@@ -47,3 +47,9 @@ export {
   EDIT_MODES,
   MASK_ID
 } from './utils/featureSelectionConstants';
+
+export {
+  hasFlag as _hasFeatureFlag,
+  setFlags as _setFeatureFlags,
+  clearFlags as _clearFeatureFlags
+} from './utils/featureFlags';

--- a/packages/react-core/src/utils/featureFlags.d.ts
+++ b/packages/react-core/src/utils/featureFlags.d.ts
@@ -1,0 +1,3 @@
+export function setFlags(flags: Record<string, any> | string[]): void
+export function clearFlags(): void
+export function hasFlag(flag: string): boolean

--- a/packages/react-core/src/utils/featureFlags.js
+++ b/packages/react-core/src/utils/featureFlags.js
@@ -1,0 +1,30 @@
+let featureFlags = [];
+
+export function setFlags(flags) {
+  const isValidFlag = (f) => typeof f === 'string' && f;
+
+  if (Array.isArray(flags) && flags.every(isValidFlag)) {
+    featureFlags = flags;
+  } else if (
+    !Array.isArray(flags) &&
+    typeof flags === 'object' &&
+    Object.keys(flags).every(isValidFlag)
+  ) {
+    featureFlags = [];
+    for (const [flag, value] of Object.entries(flags)) {
+      if (value) {
+        featureFlags.push(flag);
+      }
+    }
+  } else {
+    throw new Error(`Invalid feature flags: ${flags}`);
+  }
+}
+
+export function clearFlags() {
+  featureFlags = [];
+}
+
+export function hasFlag(flag) {
+  return featureFlags.includes(flag);
+}


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/311258/support-feature-flags-in-carto-4-react

This exports from `react-core` functions to set and test feature flags, a global setting for Carto 4 React.

- `_hasFeatureFlag`
- `_setFeatureFlags`
- `_clearFeatureFlags`

## Type of change

- Feature (internal)
