### PR TITLE
react-ui: Add component typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- react-ui: Add component typings [#663](https://github.com/CartoDB/carto-react/pull/663)
 - Fix paired buttons spacing when the button is from a different variant [#668](https://github.com/CartoDB/carto-react/pull/668)
 - Added Storybook documentation on how to add an IconButton in a Table [#664](https://github.com/CartoDB/carto-react/pull/664)
 - Changed how widget are calculated when a mask is set: use just the mask, no more intersection between mask and viewport [#661](https://github.com/CartoDB/carto-react/pull/661)

--- a/packages/react-ui/src/components/atoms/Button.d.ts
+++ b/packages/react-ui/src/components/atoms/Button.d.ts
@@ -1,0 +1,6 @@
+import { ButtonProps as MuiButtonProps } from '@mui/material/Button';
+
+export type ButtonProps = MuiButtonProps;
+
+declare const Button: (props: ButtonProps) => JSX.Element;
+export default Button;

--- a/packages/react-ui/src/components/atoms/Button.d.ts
+++ b/packages/react-ui/src/components/atoms/Button.d.ts
@@ -1,6 +1,7 @@
-import { ButtonProps as MuiButtonProps } from '@mui/material/Button';
+import { ButtonProps, ButtonTypeMap } from '@mui/material/Button';
+import { OverridableComponent } from '@mui/material/OverridableComponent';
 
-export type ButtonProps = MuiButtonProps;
+export { ButtonProps };
 
-declare const Button: (props: ButtonProps) => JSX.Element;
+declare const Button: OverridableComponent<ButtonTypeMap>;
 export default Button;

--- a/packages/react-ui/src/components/atoms/LabelWithIndicator.d.ts
+++ b/packages/react-ui/src/components/atoms/LabelWithIndicator.d.ts
@@ -1,0 +1,7 @@
+export type LabelWithIndicatorProps = {
+  label: React.ReactNode;
+  type?: 'optional' | 'required';
+};
+
+declare const LabelWithIndicator: (props: LabelWithIndicatorProps) => JSX.Element;
+export default LabelWithIndicator;

--- a/packages/react-ui/src/components/atoms/PasswordField.d.ts
+++ b/packages/react-ui/src/components/atoms/PasswordField.d.ts
@@ -1,0 +1,6 @@
+import { TextFieldProps } from '@mui/material/TextField';
+
+export type PasswordFieldProps = TextFieldProps;
+
+declare const PasswordField: (props: PasswordFieldProps) => JSX.Element;
+export default PasswordField;

--- a/packages/react-ui/src/components/atoms/SelectField.d.ts
+++ b/packages/react-ui/src/components/atoms/SelectField.d.ts
@@ -1,0 +1,16 @@
+import { TextFieldProps } from '@mui/material/TextField';
+
+export type SelectFieldProps = TextFieldProps & {
+  items: [
+    {
+      label: string;
+      value: string | number;
+    }
+  ];
+  multiple?: boolean;
+  placeholder: string;
+  size?: 'small' | 'medium';
+};
+
+declare const SelectField: (props: SelectFieldProps) => JSX.Element;
+export default SelectField;

--- a/packages/react-ui/src/components/atoms/SelectField.d.ts
+++ b/packages/react-ui/src/components/atoms/SelectField.d.ts
@@ -1,14 +1,14 @@
 import { TextFieldProps } from '@mui/material/TextField';
 
-export type SelectFieldProps = TextFieldProps & {
-  items: [
-    {
-      label: string;
-      value: string | number;
-    }
-  ];
+type SelectFieldItem = {
+  label: string;
+  value: string | number;
+};
+
+export type SelectFieldProps = Omit<TextFieldProps, 'placeholder'> & {
+  items: SelectFieldItem[];
   multiple?: boolean;
-  placeholder: string;
+  placeholder?: React.ReactNode;
   size?: 'small' | 'medium';
 };
 

--- a/packages/react-ui/src/components/atoms/Typography.d.ts
+++ b/packages/react-ui/src/components/atoms/Typography.d.ts
@@ -1,9 +1,9 @@
 import React from 'react';
-import { TypographyTypeMap } from '@mui/material/Typography';
+import { TypographyTypeMap as MuiTypographyTypeMap } from '@mui/material/Typography';
 import { OverridableComponent, OverrideProps } from '@mui/material/OverridableComponent';
 
-export type CartoTypographyTypeMap<D extends React.ElementType = 'span'> =
-  TypographyTypeMap<
+export type TypographyTypeMap<D extends React.ElementType = 'span'> =
+  MuiTypographyTypeMap<
     {
       /**
        * Font weight for Carto typography:
@@ -21,10 +21,9 @@ export type CartoTypographyTypeMap<D extends React.ElementType = 'span'> =
 export type CartoFontWeight = 'regular' | 'medium' | 'strong';
 
 export type TypographyProps<
-  D extends React.ElementType = CartoTypographyTypeMap['defaultComponent'],
-  P = {}
-> = OverrideProps<TypographyTypeMap<P, D>, D>;
+  D extends React.ElementType = TypographyTypeMap['defaultComponent']
+> = OverrideProps<TypographyTypeMap<D>, D>;
 
 // https://github.com/mui/material-ui/issues/19536#issuecomment-598856255
-declare const Typography: OverridableComponent<CartoTypographyTypeMap>;
+declare const Typography: OverridableComponent<TypographyTypeMap>;
 export default Typography;

--- a/packages/react-ui/src/components/atoms/Typography.d.ts
+++ b/packages/react-ui/src/components/atoms/Typography.d.ts
@@ -1,0 +1,30 @@
+import React from 'react';
+import { TypographyTypeMap } from '@mui/material/Typography';
+import { OverridableComponent, OverrideProps } from '@mui/material/OverridableComponent';
+
+export type CartoTypographyTypeMap<D extends React.ElementType = 'span'> =
+  TypographyTypeMap<
+    {
+      /**
+       * Font weight for Carto typography:
+       *
+       *  * `'regular'` - 400
+       *  * `'medium'` - 500
+       *  * `'strong'` - 600
+       */
+      weight?: CartoFontWeight;
+      italic?: boolean;
+    },
+    D
+  >;
+
+export type CartoFontWeight = 'regular' | 'medium' | 'strong';
+
+export type TypographyProps<
+  D extends React.ElementType = CartoTypographyTypeMap['defaultComponent'],
+  P = {}
+> = OverrideProps<TypographyTypeMap<P, D>, D>;
+
+// https://github.com/mui/material-ui/issues/19536#issuecomment-598856255
+declare const Typography: OverridableComponent<CartoTypographyTypeMap>;
+export default Typography;

--- a/packages/react-ui/src/components/molecules/AccordionGroup.d.ts
+++ b/packages/react-ui/src/components/molecules/AccordionGroup.d.ts
@@ -1,0 +1,15 @@
+export type AccordionGroupProps = React.HTMLAttributes<HTMLDivElement> & {
+  variant?: 'standard' | 'outlined';
+  items: [
+    {
+      summary: string;
+      content: React.ReactNode;
+      disabled?: boolean;
+      defaultExpanded?: boolean;
+      onChange?: (event: React.SyntheticEvent, expanded: boolean) => void;
+    }
+  ];
+};
+
+declare const AccordionGroup: (props: AccordionGroupProps) => JSX.Element;
+export default AccordionGroup;

--- a/packages/react-ui/src/components/molecules/Avatar.d.ts
+++ b/packages/react-ui/src/components/molecules/Avatar.d.ts
@@ -1,0 +1,8 @@
+import { AvatarProps as MuiAvatarProps } from '@mui/material/Avatar';
+
+export type AvatarProps = MuiAvatarProps & {
+  size?: 'large' | 'medium' | 'small' | 'xsmall';
+};
+
+declare const Avatar: (props: AvatarProps) => JSX.Element;
+export default Avatar;

--- a/packages/react-ui/src/components/molecules/UploadField/UploadField.d.ts
+++ b/packages/react-ui/src/components/molecules/UploadField/UploadField.d.ts
@@ -1,0 +1,12 @@
+import { TextFieldProps } from '@mui/material/TextField';
+
+export type UploadFieldProps = TextFieldProps & {
+  buttonText?: string;
+  accept?: string[];
+  files?: [];
+  multiple?: boolean;
+  onChange: (file?: File | null) => void;
+};
+
+declare const UploadField: (props: UploadFieldProps) => JSX.Element;
+export default UploadField;

--- a/packages/react-ui/src/components/organisms/AppBar/AppBar.d.ts
+++ b/packages/react-ui/src/components/organisms/AppBar/AppBar.d.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { AppBarTypeMap as MuiAppBarTypeMap } from '@mui/material/AppBar';
+import { OverridableComponent, OverrideProps } from '@mui/material/OverridableComponent';
+
+export type AppBarTypeMap<D extends React.ElementType<any> = 'header'> = MuiAppBarTypeMap<
+  {
+    brandLogo?: React.ReactNode;
+    brandText?: React.ReactNode;
+    secondaryText?: React.ReactNode;
+    onClickMenu?: (event: React.MouseEvent) => void;
+    showBurgerMenu?: boolean;
+  },
+  D
+>;
+
+export type AppBarProps<D extends React.ElementType = AppBarTypeMap['defaultComponent']> =
+  OverrideProps<AppBarTypeMap<D>, D>;
+
+declare const AppBar: OverridableComponent<AppBarTypeMap>;
+
+export default AppBar;

--- a/packages/react-ui/src/index.d.ts
+++ b/packages/react-ui/src/index.d.ts
@@ -29,20 +29,26 @@ import Typography, {
   CartoFontWeight,
   TypographyProps
 } from './components/atoms/Typography';
-import Button from './components/atoms/Button';
-import PasswordField from './components/atoms/PasswordField';
-import SelectField from './components/atoms/SelectField';
-import UploadField from './components/molecules/UploadField/UploadField';
-import AppBar from './components/organisms/AppBar/AppBar';
-import LabelWithIndicator from './components/atoms/LabelWithIndicator';
+import Button, { ButtonProps } from './components/atoms/Button';
+import PasswordField, { PasswordFieldProps } from './components/atoms/PasswordField';
+import SelectField, { SelectFieldProps } from './components/atoms/SelectField';
+import UploadField, {
+  UploadFieldProps
+} from './components/molecules/UploadField/UploadField';
+import AppBar, {AppBarProps} from './components/organisms/AppBar/AppBar';
+import LabelWithIndicator, {
+  LabelWithIndicatorProps
+} from './components/atoms/LabelWithIndicator';
 import { getCartoColorStylePropsForItem } from './utils/palette';
-import Avatar from './components/molecules/Avatar';
+import Avatar, { AvatarProps } from './components/molecules/Avatar';
 import {
   ICON_SIZE_SMALL,
   ICON_SIZE_MEDIUM,
   ICON_SIZE_LARGE
 } from './theme/themeConstants';
-import AccordionGroup from './components/molecules/AccordionGroup';
+import AccordionGroup, {
+  AccordionGroupProps
+} from './components/molecules/AccordionGroup';
 
 export {
   theme,
@@ -77,15 +83,24 @@ export {
   TypographyProps,
   CartoFontWeight,
   Button,
+  ButtonProps,
   PasswordField,
+  PasswordFieldProps,
   SelectField,
+  SelectFieldProps,
   UploadField,
+  UploadFieldProps,
   AppBar,
+  AppBarProps,
+
   LabelWithIndicator,
+  LabelWithIndicatorProps,
   getCartoColorStylePropsForItem,
   Avatar,
+  AvatarProps,
   ICON_SIZE_SMALL,
   ICON_SIZE_MEDIUM,
   ICON_SIZE_LARGE,
-  AccordionGroup
+  AccordionGroup,
+  AccordionGroupProps
 };

--- a/packages/react-ui/src/index.d.ts
+++ b/packages/react-ui/src/index.d.ts
@@ -25,7 +25,10 @@ import FeatureSelectionWidgetUI from './widgets/FeatureSelectionWidgetUI';
 import ComparativePieWidgetUI from './widgets/comparative/ComparativePieWidgetUI';
 import ComparativeFormulaWidgetUI from './widgets/comparative/ComparativeFormulaWidgetUI/ComparativeFormulaWidgetUI';
 import ComparativeCategoryWidgetUI from './widgets/comparative/ComparativeCategoryWidgetUI/ComparativeCategoryWidgetUI';
-import Typography from './components/atoms/Typography';
+import Typography, {
+  CartoFontWeight,
+  TypographyProps
+} from './components/atoms/Typography';
 import Button from './components/atoms/Button';
 import PasswordField from './components/atoms/PasswordField';
 import SelectField from './components/atoms/SelectField';
@@ -71,6 +74,8 @@ export {
   LegendProportion,
   LegendRamp,
   Typography,
+  TypographyProps,
+  CartoFontWeight,
   Button,
   PasswordField,
   SelectField,

--- a/packages/react-ui/src/types.d.ts
+++ b/packages/react-ui/src/types.d.ts
@@ -1,12 +1,12 @@
 import { GroupDateTypes } from '@carto/react-core';
-import {
-  AppBarProps as MuiAppBarProps,
-  TextFieldProps,
-  AvatarProps as MuiAvatarProps,
-  SxProps,
-  Theme
-} from '@mui/material';
+import { SxProps, Theme } from '@mui/material';
+export { SelectFieldProps } from './components/atoms/SelectField';
 export { TypographyProps } from './components/atoms/Typography';
+export { LabelWithIndicatorProps } from './components/atoms/LabelWithIndicator';
+export { AvatarProps } from './components/molecules/Avatar';
+export { AccordionGroupProps } from './components/molecules/AccordionGroup';
+export { UploadFieldProps } from './components/molecules/UploadField/UploadField';
+export { AppBarProps } from './components/organisms/AppBar/AppBar';
 
 export type WrapperWidgetUI = {
   title: string;
@@ -283,59 +283,4 @@ type TooltipDataProps = {
     }
   ];
   title?: string;
-};
-
-// SelectField
-export interface SelectFieldProps extends TextFieldProps {
-  items: [
-    {
-      label: string;
-      value: string | number;
-    }
-  ];
-  multiple?: boolean;
-  placeholder: string;
-  size?: 'small' | 'medium';
-}
-
-// UploadField
-export interface UploadFieldProps extends TextFieldProps {
-  buttonText?: string;
-  accept?: string[];
-  files?: [];
-  onChange: (file?: File | null) => void;
-}
-
-// AppBar
-export interface AppBarProps extends MuiAppBarProps {
-  brandLogo?: React.ReactElement;
-  brandText?: string | React.ReactElement;
-  secondaryText?: string | React.ReactElement;
-  onClickMenu?: Function;
-  showBurgerMenu?: boolean;
-}
-
-// LabelWithIndicator
-export type LabelWithIndicatorProps = {
-  label: string | React.ReactElement;
-  type?: 'optional' | 'required';
-};
-
-// Avatar
-export interface AvatarProps extends MuiAvatarProps {
-  size?: 'large' | 'medium' | 'small' | 'xsmall';
-}
-
-// AccordionGroup
-export type AccordionGroupProps = {
-  variant?: 'standard' | 'outlined';
-  items: [
-    {
-      summary: string;
-      content: string | React.ReactElement;
-      disabled?: boolean;
-      defaultExpanded?: boolean;
-      onChange?: Function;
-    }
-  ];
 };

--- a/packages/react-ui/src/types.d.ts
+++ b/packages/react-ui/src/types.d.ts
@@ -2,12 +2,11 @@ import { GroupDateTypes } from '@carto/react-core';
 import {
   AppBarProps as MuiAppBarProps,
   TextFieldProps,
-  TypographyProps as MuiTypographyProps,
   AvatarProps as MuiAvatarProps,
   SxProps,
   Theme
 } from '@mui/material';
-import { CSSProperties } from 'react';
+export { TypographyProps } from './components/atoms/Typography';
 
 export type WrapperWidgetUI = {
   title: string;
@@ -271,13 +270,6 @@ export type ComparativePieWidgetUIProps = {
   selectedCategories?: string[];
   onCategorySelected?: (categories: string[]) => any;
 };
-
-// Typography
-export interface TypographyProps extends MuiTypographyProps {
-  weight?: 'regular' | 'medium' | 'strong';
-  italic?: boolean;
-  style?: CSSProperties;
-}
 
 // Tooltip data
 // Export types and component if we need it outsite C4R


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/306547

Provide proper typings for following components from `@carto/react-ui`:
 * `Button`
 * `LabelWithIndicator`
 * `PasswordField`
 * `SelectField`
 * `Typography`
 * `AccordionGroup`
 * `Avatar`
 * `UploadField`
 * `AppBar`
 
Also export all `*Props` definitions in same manner as MUI does.

<img width="995" alt="image" src="https://user-images.githubusercontent.com/1507542/236229026-6251506e-b06b-43cf-8f2e-4295622a0e5d.png">

## Type of change

(choose one and remove the others)

- Fix
- Feature

# Acceptance


When importing `import { Typography } from '@carto/react-ui'` the type of component should be properly detected by IDE and tsc compiler

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
