### PR TITLE
Added Storybook documentation on how to add an IconButton in a Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Added Storybook documentation on how to add an IconButton in a Table [#664](https://github.com/CartoDB/carto-react/pull/664)
 - Changed how widget are calculated when a mask is set: use just the mask, no more intersection between mask and viewport [#661](https://github.com/CartoDB/carto-react/pull/661)
 - LegendCategories component migrated from makeStyles to styled-components + cleanup [#634](https://github.com/CartoDB/carto-react/pull/634)
 - LegendProportion component migrated from makeStyles to styled-components + cleanup [#635](https://github.com/CartoDB/carto-react/pull/635)

--- a/packages/react-ui/storybook/stories/molecules/Table.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/Table.stories.js
@@ -2,9 +2,6 @@ import React from 'react';
 import {
   Box,
   Chip,
-  FormControl,
-  MenuItem,
-  Select,
   Tooltip,
   Typography,
   TableRow,
@@ -12,26 +9,48 @@ import {
   TableHead,
   TableContainer,
   TableBody,
-  Table
+  Table,
+  IconButton
 } from '@mui/material';
 import SelectField from '../../../src/components/atoms/SelectField';
+import { MoreVertOutlined } from '@mui/icons-material';
 
 const rows = [
-  { name: 'Test Data 1', type: 'string', mode: '', description: 'Test Data 1' },
+  {
+    name: 'Test Data 1',
+    type: 'string',
+    mode: '',
+    description: 'Test Data 1',
+    icon: ''
+  },
   {
     name: 'very long text that should trigger the overflow style',
     type: 'string',
     mode: '',
-    description: 'Test Data 2'
+    description: 'Test Data 2',
+    icon: ''
   },
-  { name: 'Test Data 3', type: 'string', mode: '', description: 'Test Data 3' },
+  {
+    name: 'Test Data 3',
+    type: 'string',
+    mode: '',
+    description: 'Test Data 3',
+    icon: ''
+  },
   {
     name: 'Test Data 4',
     type: 'string',
     mode: '',
-    description: 'very long text that should trigger the overflow style'
+    description: 'very long text that should trigger the overflow style',
+    icon: ''
   },
-  { name: 'Test Data 5', type: 'string', mode: '', description: 'Test Data 5' }
+  {
+    name: 'Test Data 5',
+    type: 'string',
+    mode: '',
+    description: 'Test Data 5',
+    icon: ''
+  }
 ];
 
 const options = {
@@ -62,6 +81,7 @@ const PlaygroundTemplate = (args) => {
             <TableCell>Type</TableCell>
             <TableCell>Mode</TableCell>
             <TableCell>Description</TableCell>
+            <TableCell>Actions</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -106,6 +126,11 @@ const PlaygroundTemplate = (args) => {
                   row.description
                 )}
               </TableCell>
+              <TableCell>
+                <IconButton size='small'>
+                  <MoreVertOutlined />
+                </IconButton>
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>
@@ -125,6 +150,7 @@ const ScrollTemplate = (args) => (
             <TableCell>Type</TableCell>
             <TableCell>Mode</TableCell>
             <TableCell>Description</TableCell>
+            <TableCell>Actions</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -168,6 +194,11 @@ const ScrollTemplate = (args) => (
                 ) : (
                   row.description
                 )}
+              </TableCell>
+              <TableCell>
+                <IconButton size='small'>
+                  <MoreVertOutlined />
+                </IconButton>
               </TableCell>
             </TableRow>
           ))}

--- a/packages/react-ui/storybook/stories/molecules/Table.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/Table.stories.js
@@ -20,36 +20,31 @@ const rows = [
     name: 'Test Data 1',
     type: 'string',
     mode: '',
-    description: 'Test Data 1',
-    icon: ''
+    description: 'Test Data 1'
   },
   {
     name: 'very long text that should trigger the overflow style',
     type: 'string',
     mode: '',
-    description: 'Test Data 2',
-    icon: ''
+    description: 'Test Data 2'
   },
   {
     name: 'Test Data 3',
     type: 'string',
     mode: '',
-    description: 'Test Data 3',
-    icon: ''
+    description: 'Test Data 3'
   },
   {
     name: 'Test Data 4',
     type: 'string',
     mode: '',
-    description: 'very long text that should trigger the overflow style',
-    icon: ''
+    description: 'very long text that should trigger the overflow style'
   },
   {
     name: 'Test Data 5',
     type: 'string',
     mode: '',
-    description: 'Test Data 5',
-    icon: ''
+    description: 'Test Data 5'
   }
 ];
 


### PR DESCRIPTION
# Description

As is a common case, designers have a need to document how to add an `IconButton` to a `Table`, so we are adding an example to Storybook.