### PR TITLE
Fix paired buttons spacing when the button is from a different variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Fix paired buttons spacing when the button is from a different variant [#668](https://github.com/CartoDB/carto-react/pull/668)
 - Added Storybook documentation on how to add an IconButton in a Table [#664](https://github.com/CartoDB/carto-react/pull/664)
 - Changed how widget are calculated when a mask is set: use just the mask, no more intersection between mask and viewport [#661](https://github.com/CartoDB/carto-react/pull/661)
 - LegendCategories component migrated from makeStyles to styled-components + cleanup [#634](https://github.com/CartoDB/carto-react/pull/634)

--- a/packages/react-ui/src/theme/sections/components/buttons.js
+++ b/packages/react-ui/src/theme/sections/components/buttons.js
@@ -63,7 +63,7 @@ export const buttonsOverrides = {
           fill: 'currentColor'
         },
         // Pairing buttons separation
-        '& + &': {
+        '& + .MuiButtonBase-root': {
           marginLeft: getSpacing(1)
         }
       }),


### PR DESCRIPTION
story: https://app.shortcut.com/cartoteam/story/292993/workspace-settings-ui-improvements-bugfixing
[sc-292993]

Found a bug in the theme related to buttons: when you have 2 buttons inline, there is no horizontal padding if they are from different variants.