### PR TITLE
Fix histogram widget filter for max/min values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Migrate multiples components from storybook away from makeStyles [#652](https://github.com/CartoDB/carto-react/pull/652)
 - Remove makeStyles leftovers [#669](https://github.com/CartoDB/carto-react/pull/669)
 - FormulaWidgetUI component migrated from makeStyles to styled-components + cleanup [#666](https://github.com/CartoDB/carto-react/pull/666)
+- Fix histogram widget filter for max/min values [#671](https://github.com/CartoDB/carto-react/pull/671)
 
 ## 2.0
 

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -119,7 +119,7 @@ function HistogramWidget({
     dataSource,
     id,
     column,
-    type: FilterTypes.CLOSED_OPEN
+    type: FilterTypes.BETWEEN
   });
 
   const selectedBars = useMemo(() => {
@@ -131,7 +131,7 @@ function HistogramWidget({
           return ticks.length;
         } else {
           const idx = ticks.indexOf(from);
-          return idx !== -1 ? idx + 1 : null;
+          return idx !== -1 ? idx + 1 : 0;
         }
       })
       .filter((v) => v !== null);
@@ -141,8 +141,8 @@ function HistogramWidget({
     (selectedBars) => {
       if (selectedBars?.length) {
         const thresholds = selectedBars.map((i) => {
-          let left = ticks[i - 1];
-          let right = ticks.length !== i ? ticks[i] : undefined;
+          let left = ticks[i - 1] || min;
+          let right = ticks.length !== i ? ticks[i] : max;
 
           return [left, right];
         });
@@ -150,7 +150,7 @@ function HistogramWidget({
           addFilter({
             id: dataSource,
             column,
-            type: FilterTypes.CLOSED_OPEN,
+            type: FilterTypes.BETWEEN,
             values: thresholds,
             owner: id
           })
@@ -165,7 +165,7 @@ function HistogramWidget({
         );
       }
     },
-    [column, dataSource, id, dispatch, ticks]
+    [column, dataSource, id, dispatch, ticks, min, max]
   );
 
   return (


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/312083/histogram-widget-with-custom-max-value-displaying-values-outside-of-range#activity-313269

The Histogram widget max and min filters were not working correctly. We were filtering using an open interval, so these min/max values were not really being used.

With this change, we should be able to filter correctly using a custom min/max value.

## Type of change

- [x] Fix

# Acceptance

1. Add a histogram widget with custom min/max values
2. Check that the max/min values' filter is correctly applied
- Max filter:
![May-10-2023 13-45-04](https://github.com/CartoDB/carto-react/assets/56086628/a7f99d81-d5f1-4aab-8bf3-56e22a388d99)

- Min filter:
![May-10-2023 13-53-07](https://github.com/CartoDB/carto-react/assets/56086628/bb8e4184-f2ef-4dc8-8522-4a7b43789a5c)

3. Check that if there is one feature that has the same value as the max filter, the feature is not filtered
![May-10-2023 13-46-42](https://github.com/CartoDB/carto-react/assets/56086628/c2bf674f-946f-4cd1-895d-4b3b9a8d98bc)

4. Perform the same check with the min value
![May-10-2023 13-53-57](https://github.com/CartoDB/carto-react/assets/56086628/eafe48b8-09b1-44a2-9ba5-771c7b54d0a0)

# Basic checklist

- [x] Good PR name
- [x] Shortcut link
- [x] Changelog entry
- [x] Just one issue per PR
- [x] GitHub labels
- [x] Proper status & reviewers
- [ ] Tests
- [ ] Documentation
