### PR TITLE
Fixes to allow good integration with carto-react-template

### DIFF
--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ICON_SIZE_MEDIUM, ICON_SIZE_LARGE, ICON_SIZE_SMALL } from '../../themeConstants';
 import { getSpacing } from '../../themeUtils';
 import { commonPalette } from '../palette';


### PR DESCRIPTION
- [x] Add explicit react import in dataDisplay for fragment