### PR TITLE
Normalization functions for mask/viewports

### DIFF
--- a/packages/react-core/__tests__/utils/geo.test.js
+++ b/packages/react-core/__tests__/utils/geo.test.js
@@ -1,5 +1,10 @@
 import bboxPolygon from '@turf/bbox-polygon';
-import { isGlobalViewport, getGeometryToIntersect } from '../../src/utils/geo';
+import {
+  isGlobalViewport,
+  getGeometryToIntersect,
+  normalizeGeometry
+} from '../../src/utils/geo';
+import { polygon, multiPolygon } from '@turf/helpers';
 
 /** @type { import('../../src').Viewport } */
 const viewport = [-10, -10, 10, 10]; // west - south - east - north
@@ -37,7 +42,6 @@ describe('isGlobalViewport', () => {
   });
 
   test.each(globalViewports)('return true for global viewports', ({ v }) => {
-    console.log(viewport);
     expect(isGlobalViewport(v));
   });
 });
@@ -59,5 +63,182 @@ describe('getGeometryToIntersect', () => {
     expect(getGeometryToIntersect(viewport, filterGeometry)).toStrictEqual(
       filterGeometry
     );
+  });
+});
+
+describe('normalizeGeometry', () => {
+  test('does not clip when not needed', () => {
+    const input = polygon([
+      [
+        [-90, 0],
+        [0, -45],
+        [90, 0],
+        [0, 45],
+        [-90, 0]
+      ]
+    ]).geometry;
+    const expected = input;
+    expect(normalizeGeometry(input)).toStrictEqual(expected);
+  });
+
+  test('it produces multipolygons wrapping from the west', () => {
+    const input = multiPolygon([
+      [
+        [
+          [-90, 0],
+          [0, -45],
+          [90, 0],
+          [0, 45],
+          [-90, 0]
+        ]
+      ],
+      [
+        [
+          [-190, -50],
+          [-170, -70],
+          [-170, 70],
+          [-190, 50],
+          [-190, -50]
+        ]
+      ]
+    ]).geometry;
+    const expected = multiPolygon([
+      [
+        [
+          [-180, -60],
+          [-170, -70],
+          [-170, 70],
+          [-180, 60],
+          [-180, -60]
+        ]
+      ],
+      [
+        [
+          [-90, 0],
+          [0, -45],
+          [90, 0],
+          [0, 45],
+          [-90, 0]
+        ]
+      ],
+      [
+        [
+          [170, -50],
+          [180, -60],
+          [180, 60],
+          [170, 50],
+          [170, -50]
+        ]
+      ]
+    ]).geometry;
+    expect(normalizeGeometry(input)).toStrictEqual(expected);
+  });
+
+  test('it produces multipolygons wrapping from the east', () => {
+    const input = multiPolygon([
+      [
+        [
+          [-90, 0],
+          [0, -45],
+          [90, 0],
+          [0, 45],
+          [-90, 0]
+        ]
+      ],
+      [
+        [
+          [170, -50],
+          [190, -70],
+          [190, 70],
+          [170, 50],
+          [170, -50]
+        ]
+      ]
+    ]).geometry;
+    const expected = multiPolygon([
+      [
+        [
+          [-180, -60],
+          [-170, -70],
+          [-170, 70],
+          [-180, 60],
+          [-180, -60]
+        ]
+      ],
+      [
+        [
+          [-90, 0],
+          [0, -45],
+          [90, 0],
+          [0, 45],
+          [-90, 0]
+        ]
+      ],
+      [
+        [
+          [170, -50],
+          [180, -60],
+          [180, 60],
+          [170, 50],
+          [170, -50]
+        ]
+      ]
+    ]).geometry;
+    expect(normalizeGeometry(input)).toStrictEqual(expected);
+  });
+
+  test('it unwraps large viewports', () => {
+    const input = polygon([
+      [
+        [-200, -80],
+        [210, -80],
+        [210, 75],
+        [-200, 75],
+        [-200, -80]
+      ]
+    ]).geometry;
+    const expected = polygon([
+      [
+        [-180, -80],
+        [180, -80],
+        [180, 75],
+        [-180, 75],
+        [-180, -80]
+      ]
+    ]).geometry;
+    expect(normalizeGeometry(input)).toStrictEqual(expected);
+  });
+
+  test('it absorbes unneeded polygons', () => {
+    const input = multiPolygon([
+      [
+        [
+          [-200, -80],
+          [210, -80],
+          [210, 75],
+          [-200, 75],
+          [-200, -80]
+        ]
+      ],
+      [
+        [
+          [-90, 0],
+          [0, -45],
+          [90, 0],
+          [0, 45],
+          [-90, 0]
+        ]
+      ]
+    ]).geometry;
+    const expected = polygon([
+      [
+        [-180, -80],
+        [180, -80],
+        [180, 75],
+        [-180, 75],
+        [-180, -80]
+      ]
+    ]).geometry;
+    expect(normalizeGeometry(input)).toStrictEqual(expected);
   });
 });

--- a/packages/react-core/src/utils/geo.d.ts
+++ b/packages/react-core/src/utils/geo.d.ts
@@ -4,3 +4,5 @@ import { Polygon, MultiPolygon } from 'geojson';
 export function getGeometryToIntersect(viewport: Viewport | null, geometry: Polygon | MultiPolygon | null): Polygon | MultiPolygon | null;
 
 export function isGlobalViewport(viewport: Viewport | null): boolean;
+
+export function normalizeGeometry(geometry: Polygon | MultiPolygon): Polygon | MultiPolygon | null

--- a/packages/react-core/src/utils/geo.js
+++ b/packages/react-core/src/utils/geo.js
@@ -1,4 +1,8 @@
+import bboxClip from '@turf/bbox-clip';
 import bboxPolygon from '@turf/bbox-polygon';
+import union from '@turf/union';
+import { getType } from '@turf/invariant';
+import { polygon, multiPolygon } from '@turf/helpers';
 
 /**
  * Select the geometry to use for widget calculation and data filtering.
@@ -6,7 +10,7 @@ import bboxPolygon from '@turf/bbox-polygon';
  * Since it's possible that no mask and no viewport is set, return null in this case.
  *
  * @typedef { import('geojson').Polygon | import('geojson').MultiPolygon } Geometry
- * @typedef { import('../types').Viewport? } Viewport
+ * @typedef { import('../types').Viewport } Viewport
  *
  * @param { Viewport? } viewport viewport [minX, minY, maxX, maxY], if any
  * @param { Geometry? } geometry the active spatial filter (mask), if any
@@ -22,10 +26,9 @@ export function getGeometryToIntersect(viewport, geometry) {
 
 /**
  * Check if a viewport is large enough to represent a global coverage.
- * In this case the spatial filter parameter for widget calculation
- * can be removed.
+ * In this case the spatial filter parameter for widget calculation is removed.
  *
- * @param { import('../types').Viewport? } viewport
+ * @param { Viewport? } viewport
  * @returns { boolean }
  */
 export function isGlobalViewport(viewport) {
@@ -34,4 +37,89 @@ export function isGlobalViewport(viewport) {
     return maxx - minx > 179.5 * 2 && maxy - miny > 85.05 * 2;
   }
   return false;
+}
+
+function cleanPolygonCoords(cc) {
+  const coords = cc.filter((c) => c.length > 0);
+  return coords.length > 0 ? coords : null;
+}
+
+function cleanMultiPolygonCoords(ccc) {
+  const coords = ccc.map(cleanPolygonCoords).filter((cc) => cc);
+  return coords.length > 0 ? coords : null;
+}
+
+function clean(geometry) {
+  if (!geometry) {
+    return null;
+  } else if (getType(geometry) === 'Polygon') {
+    const coords = cleanPolygonCoords(geometry.coordinates);
+    return coords ? polygon(coords).geometry : null;
+  } else if (getType(geometry) === 'MultiPolygon') {
+    const coords = cleanMultiPolygonCoords(geometry.coordinates);
+    return coords ? multiPolygon(coords).geometry : null;
+  } else {
+    return null;
+  }
+}
+
+function txContourCoords(cc, distance) {
+  return cc.map((c) => [c[0] + distance, c[1]]);
+}
+
+function txPolygonCoords(ccc, distance) {
+  return ccc.map((cc) => txContourCoords(cc, distance));
+}
+
+function txMultiPolygonCoords(cccc, distance) {
+  return cccc.map((ccc) => txPolygonCoords(ccc, distance));
+}
+
+function tx(geometry, distance) {
+  if (geometry && getType(geometry) === 'Polygon') {
+    const coords = txPolygonCoords(geometry.coordinates, distance);
+    return polygon(coords).geometry;
+  } else if (geometry && getType(geometry) === 'MultiPolygon') {
+    const coords = txMultiPolygonCoords(geometry.coordinates, distance);
+    return multiPolygon(coords).geometry;
+  } else {
+    return null;
+  }
+}
+
+/**
+ * Normalized a geometry, coming from a mask or a viewport. The parts
+ * spanning outside longitude range [-180, +180] are clipped and "folded"
+ * back to the valid range and unioned to the polygons inide that range.
+ *
+ * It results in a Polygon or MultiPolygon strictly inside the validity range.
+ *
+ * @param {Geometry} geometry
+ * @returns {Geometry?}
+ */
+export function normalizeGeometry(geometry) {
+  const WORLD = [-180, -90, +180, +90];
+
+  const worldClip = clean(bboxClip(geometry, WORLD).geometry);
+
+  const geometryTxWest = tx(geometry, 360);
+  const geometryTxEast = tx(geometry, -360);
+
+  let result = worldClip;
+
+  if (result && geometryTxWest) {
+    const worldWestClip = clean(bboxClip(geometryTxWest, WORLD).geometry);
+    if (worldWestClip) {
+      result = clean(union(result, worldWestClip)?.geometry);
+    }
+  }
+
+  if (result && geometryTxEast) {
+    const worldEastClip = clean(bboxClip(geometryTxEast, WORLD).geometry);
+    if (worldEastClip) {
+      result = clean(union(result, worldEastClip)?.geometry);
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/314403/formula-and-histogram-widgets-viewport-mode-is-not-displaying-data-with-zoom-0-bq-check-this-one

This normalizes the spatial filter before sending it to the API for remote calculation