### PR TITLE
Storybook: show figma codes/theme code snippets for colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Storybook: show figma codes/theme code snippets for colors [#684](https://github.com/CartoDB/carto-react/pull/684)
 - Bar & Histogram & Formula & ComparativeFormula Widgets: Add a skeleton for loading state [#674](https://github.com/CartoDB/carto-react/pull/674)
 
 ## 2.0

--- a/packages/react-ui/storybook/stories/foundations/Palette.stories.js
+++ b/packages/react-ui/storybook/stories/foundations/Palette.stories.js
@@ -90,10 +90,10 @@ const ColorBox = ({ colorVariant, colorName }) => {
         {figmaColorName(colorVariant, colorName)}
         <pre style={{ margin: 0 }}>
           theme.palette.{colorVariant}
-          {typeof colorName === 'string'
-            ? `.${colorName}`
-            : typeof colorName === 'number'
+          {typeof colorName === 'number' || String(colorName).match(/^[0-9]/)
             ? `[${colorName}]`
+            : typeof colorName === 'string'
+            ? `.${colorName}`
             : ''}
         </pre>
       </Typography>

--- a/packages/react-ui/storybook/stories/foundations/Palette.stories.js
+++ b/packages/react-ui/storybook/stories/foundations/Palette.stories.js
@@ -50,11 +50,13 @@ function decamelCase(s) {
 }
 
 function capitalize(s) {
-  return s.substr(0, 1).toUpperCase() + decamelCase(s.substr(1));
+  return s
+    ? String(s).substring(0, 1).toUpperCase() + decamelCase(String(s).substring(1))
+    : '';
 }
 
 function figmaColorName(v, n) {
-  return ['Light', capitalize(v), capitalize(n)].join('/');
+  return ['Light', capitalize(v), capitalize(n)].filter((v) => v).join('/');
 }
 
 const Bullet = styled(Box, {
@@ -85,10 +87,14 @@ const ColorBox = ({ colorVariant, colorName }) => {
       </Box>
       <Bullet color={colorValue} />
       <Typography variant='caption'>
-        {figmaColorName(colorVariant, String(colorName))}
+        {figmaColorName(colorVariant, colorName)}
         <pre style={{ margin: 0 }}>
           theme.palette.{colorVariant}
-          {typeof colorName === 'string' ? `.${colorName}` : `[${colorName}]`}
+          {typeof colorName === 'string'
+            ? `.${colorName}`
+            : typeof colorName === 'number'
+            ? `[${colorName}]`
+            : ''}
         </pre>
       </Typography>
     </Box>

--- a/packages/react-ui/storybook/stories/foundations/Palette.stories.js
+++ b/packages/react-ui/storybook/stories/foundations/Palette.stories.js
@@ -45,12 +45,23 @@ const TextColor = styled(Typography)(({ theme }) => ({
   maxWidth: theme.spacing(18)
 }));
 
+function decamelCase(s) {
+  return s.replaceAll(/([a-z])([A-Z])/g, (x, p1, p2) => `${p1} ${p2}`);
+}
+
+function capitalize(s) {
+  return s.substr(0, 1).toUpperCase() + decamelCase(s.substr(1));
+}
+
+function figmaColorName(v, n) {
+  return ['Light', capitalize(v), capitalize(n)].join('/');
+}
+
 const Bullet = styled(Box, {
   shouldForwardProp: (prop) => prop !== 'color'
 })(({ theme, color: background }) => ({
   height: 48,
   width: '100%',
-  marginBottom: theme.spacing(3),
   border: `1px solid ${theme.palette.grey[100]}`,
   borderRadius: theme.spacing(0.5),
   background
@@ -63,7 +74,7 @@ const ColorBox = ({ colorVariant, colorName }) => {
   const textRef = useRef();
 
   return (
-    <Box>
+    <Box mb={3}>
       <Box mt={0.5}>
         <Typography variant='subtitle1'>{colorName}</Typography>
         <Tooltip title={colorValue} enterDelay={600}>
@@ -73,6 +84,12 @@ const ColorBox = ({ colorVariant, colorName }) => {
         </Tooltip>
       </Box>
       <Bullet color={colorValue} />
+      <Typography variant='caption'>
+        {figmaColorName(colorVariant, String(colorName))}
+        <pre style={{ margin: 0 }}>
+          theme.palette.{colorVariant}.{colorName}
+        </pre>
+      </Typography>
     </Box>
   );
 };

--- a/packages/react-ui/storybook/stories/foundations/Palette.stories.js
+++ b/packages/react-ui/storybook/stories/foundations/Palette.stories.js
@@ -56,7 +56,17 @@ function capitalize(s) {
 }
 
 function figmaColorName(v, n) {
-  return ['Light', capitalize(v), capitalize(n)].filter((v) => v).join('/');
+  return ['Light', capitalize(v), capitalize(n)].filter(Boolean).join('/');
+}
+
+function jsColorSelector(v, n) {
+  return `theme.palette.${v}${
+    typeof n === 'number' || String(n).match(/^[0-9]/)
+      ? `[${n}]`
+      : typeof n === 'string'
+      ? `.${n}`
+      : ''
+  }`;
 }
 
 const Bullet = styled(Box, {
@@ -88,14 +98,7 @@ const ColorBox = ({ colorVariant, colorName }) => {
       <Bullet color={colorValue} />
       <Typography variant='caption'>
         {figmaColorName(colorVariant, colorName)}
-        <pre style={{ margin: 0 }}>
-          theme.palette.{colorVariant}
-          {typeof colorName === 'number' || String(colorName).match(/^[0-9]/)
-            ? `[${colorName}]`
-            : typeof colorName === 'string'
-            ? `.${colorName}`
-            : ''}
-        </pre>
+        <pre style={{ margin: 0 }}>{jsColorSelector(colorVariant, colorName)}</pre>
       </Typography>
     </Box>
   );

--- a/packages/react-ui/storybook/stories/foundations/Palette.stories.js
+++ b/packages/react-ui/storybook/stories/foundations/Palette.stories.js
@@ -87,7 +87,8 @@ const ColorBox = ({ colorVariant, colorName }) => {
       <Typography variant='caption'>
         {figmaColorName(colorVariant, String(colorName))}
         <pre style={{ margin: 0 }}>
-          theme.palette.{colorVariant}.{colorName}
+          theme.palette.{colorVariant}
+          {typeof colorName === 'string' ? `.${colorName}` : `[${colorName}]`}
         </pre>
       </Typography>
     </Box>


### PR DESCRIPTION
# Description

Show figma codes/theme code snippets for colors in playground.

Demo:

<img width="1116" alt="image" src="https://github.com/CartoDB/carto-react/assets/1507542/0d1f0a36-a5bb-4729-8d3f-aedd2a2d00f4">

Finally it will land in this screen: https://storybook-react.carto.com/?path=/docs/foundations-palette--primary

## Type of change

- Documentation

# Acceptance

Check palette playground in storybook
# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
