### PR TITLE
Fix timeseries widget tooltip style

### DIFF
--- a/packages/react-ui/src/widgets/TimeSeriesWidgetUI/components/TimeSeriesChart.js
+++ b/packages/react-ui/src/widgets/TimeSeriesWidgetUI/components/TimeSeriesChart.js
@@ -56,6 +56,7 @@ export default function TimeSeriesChart({
         }
         return position;
       },
+      extraCssText: 'width: auto !important;',
       ...(tooltipFormatter ? { formatter: tooltipFormatter } : {})
     }),
     [theme, tooltip, tooltipFormatter]


### PR DESCRIPTION
# Description

- Story: https://app.shortcut.com/cartoteam/story/317336
- Autolink: [sc-317336]

Fixing with of the tooltip of the timeseries widget, overwriting the following style from `echarts-for-react`:

![Screenshot from 2023-05-28 19-45-07](https://github.com/CartoDB/carto-react/assets/6042873/b119d30c-32b7-430b-b61b-c78eb8c1ebc1)

## Type of change

- Fix

# Acceptance

- Current style:
![Screenshot from 2023-05-28 19-37-24](https://github.com/CartoDB/carto-react/assets/6042873/538694bd-5adb-4283-b956-3e66e5638768)

- Local environment with the fix:
![Screenshot from 2023-05-28 19-42-43](https://github.com/CartoDB/carto-react/assets/6042873/918959ef-53dc-4341-aebc-c6385cba955a)