### PR TITLE
Remove styles props: className and sx

### DIFF
--- a/packages/react-ui/src/types.d.ts
+++ b/packages/react-ui/src/types.d.ts
@@ -1,5 +1,4 @@
 import { GroupDateTypes } from '@carto/react-core';
-import { SxProps, Theme } from '@mui/material';
 export { SelectFieldProps } from './components/atoms/SelectField';
 export { TypographyProps } from './components/atoms/Typography';
 export { LabelWithIndicatorProps } from './components/atoms/LabelWithIndicator';

--- a/packages/react-ui/src/types.d.ts
+++ b/packages/react-ui/src/types.d.ts
@@ -107,7 +107,6 @@ export type LegendWidgetUIData = {
 };
 
 export type LegendWidgetUI = {
-  className?: string;
   customLegendTypes?: Record<string, Function>;
   layers?: LegendWidgetUIData[];
   collapsed?: boolean;
@@ -169,7 +168,7 @@ export type FeatureSelectionWidgetUI = {
   geometry?: GeoJSON.Feature;
   onSelectGeometry?: Function;
   onDeleteGeometry?: Function;
-  tooltipPlacement?: "bottom" | "left" | "right" | "top";
+  tooltipPlacement?: 'bottom' | 'left' | 'right' | 'top';
 };
 
 export type FeatureSelectionUIDropdown = {
@@ -179,7 +178,7 @@ export type FeatureSelectionUIDropdown = {
   onSelectMode?: Function;
   enabled?: boolean;
   onEnabledChange?: Function;
-  tooltipPlacement?: "bottom" | "left" | "right" | "top";
+  tooltipPlacement?: 'bottom' | 'left' | 'right' | 'top';
 };
 export type FeatureSelectionUIGeometryChips = {
   features: GeoJSON.Feature[];
@@ -188,7 +187,7 @@ export type FeatureSelectionUIGeometryChips = {
   chipTooltip?: string;
   disabledChipTooltip?: string;
   size?: 'small' | 'medium';
-  tooltipPlacement?: "bottom" | "left" | "right" | "top";
+  tooltipPlacement?: 'bottom' | 'left' | 'right' | 'top';
 };
 export type FeatureSelectionUIToggleButton = {
   icon: React.ReactNode;
@@ -196,7 +195,7 @@ export type FeatureSelectionUIToggleButton = {
   clickTooltip?: string;
   enabled?: boolean;
   onEnabledChange?: Function;
-  tooltipPlacement?: "bottom" | "left" | "right" | "top";
+  tooltipPlacement?: 'bottom' | 'left' | 'right' | 'top';
 };
 
 // Legends

--- a/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/CategoryItem.js
+++ b/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/CategoryItem.js
@@ -87,7 +87,6 @@ function CategoryItem({
   maxValue,
   showCheckbox,
   checkboxChecked,
-  className,
   formatter,
   tooltipFormatter,
   onClick = IDENTITY_FN,
@@ -108,7 +107,7 @@ function CategoryItem({
   );
 
   return (
-    <CategoryItemWrapperRoot onClick={() => onClick(item.key)} className={className}>
+    <CategoryItemWrapperRoot onClick={() => onClick(item.key)}>
       {showCheckbox ? <Checkbox checked={checkboxChecked} /> : null}
       <CategoryItemWrapperInner>
         <Typography variant='body2' noWrap>
@@ -157,7 +156,6 @@ CategoryItem.displayName = 'CategoryItem';
 CategoryItem.defaultProps = {
   animation: true,
   animationOptions: {},
-  className: '',
   formatter: IDENTITY_FN,
   tooltipFormatter: IDENTITY_FN,
   onClick: IDENTITY_FN
@@ -169,7 +167,6 @@ CategoryItem.propTypes = {
   maxValue: PropTypes.number.isRequired,
   showCheckbox: PropTypes.bool.isRequired,
   checkboxChecked: PropTypes.bool.isRequired,
-  className: PropTypes.string,
   formatter: PropTypes.func,
   tooltipFormatter: PropTypes.func,
   onClick: PropTypes.func,

--- a/packages/react-ui/src/widgets/legend/LayerOptionWrapper.js
+++ b/packages/react-ui/src/widgets/legend/LayerOptionWrapper.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { Box } from '@mui/material';
 import Typography from '../../components/atoms/Typography';
 
-export default function LayerOptionWrapper({ className = '', label, children }) {
+export default function LayerOptionWrapper({ label, children }) {
   return (
-    <Box className={className} px={2} py={1.5}>
+    <Box px={2} py={1.5}>
       <Typography variant='caption' color='textPrimary'>
         {label}
       </Typography>

--- a/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
+++ b/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
@@ -35,7 +35,6 @@ const LegendBox = styled(Box)(({ theme }) => ({
 }));
 
 function LegendWidgetUI({
-  className,
   customLegendTypes,
   customLayerOptions,
   layers = [],
@@ -49,7 +48,7 @@ function LegendWidgetUI({
   const isSingle = layers.length === 1;
 
   return (
-    <LegendBox className={className}>
+    <LegendBox>
       <LegendContainer
         isSingle={isSingle}
         collapsed={collapsed}
@@ -78,7 +77,6 @@ LegendWidgetUI.defaultProps = {
 };
 
 LegendWidgetUI.propTypes = {
-  className: PropTypes.string,
   customLegendTypes: PropTypes.objectOf(PropTypes.func),
   customLayerOptions: PropTypes.objectOf(PropTypes.func),
   layers: PropTypes.array,

--- a/packages/react-ui/storybook/stories/widgetsUI/LegendWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/LegendWidgetUI.stories.js
@@ -5,11 +5,6 @@ const options = {
   title: 'Organisms/Widgets/LegendWidgetUI',
   component: LegendWidgetUI,
   argTypes: {
-    className: {
-      control: {
-        type: 'text'
-      }
-    },
     layers: {
       defaultValue: [],
       control: {

--- a/packages/react-widgets/src/types.d.ts
+++ b/packages/react-widgets/src/types.d.ts
@@ -1,5 +1,4 @@
 import { AggregationTypes } from '@carto/react-core';
-import type { SxProps, Theme } from '@mui/material';
 
 type CommonWidgetProps = {
   id: string,
@@ -42,7 +41,6 @@ export type BarWidget = {
 export type FormulaWidget = CommonWidgetProps & MonoColumnWidgetProps;
 
 export type GeocoderWidget = {
-  sx?: SxProps<Theme>,
   onError?: Function
 }
 

--- a/packages/react-widgets/src/types.d.ts
+++ b/packages/react-widgets/src/types.d.ts
@@ -42,7 +42,6 @@ export type BarWidget = {
 export type FormulaWidget = CommonWidgetProps & MonoColumnWidgetProps;
 
 export type GeocoderWidget = {
-  className: string,
   sx?: SxProps<Theme>,
   onError?: Function
 }
@@ -97,7 +96,6 @@ export type TimeSeriesWidget = {
 } & CommonWidgetProps & MonoColumnWidgetProps;
 
 export type LegendWidget = {
-  className?: string;
   initialCollapsed?: boolean;
   customLegendTypes?: Record<string, Function>;
   layerOrder?: string[];
@@ -112,7 +110,6 @@ export type WidgetWithAlert = {
 }
 
 export type FeatureSelectionWidget = {
-  className?: string;
   selectionModes?: string[],
   editModes?: string[],
   tooltipPlacement?: string,

--- a/packages/react-widgets/src/widgets/FeatureSelectionWidget.js
+++ b/packages/react-widgets/src/widgets/FeatureSelectionWidget.js
@@ -43,7 +43,6 @@ const EDIT_MODES_MAP = {
 };
 
 function FeatureSelectionWidget({
-  className,
   selectionModes: selectionModesKeys,
   editModes: editModesKeys,
   tooltipPlacement
@@ -95,7 +94,6 @@ function FeatureSelectionWidget({
 
   return (
     <FeatureSelectionWidgetUI
-      className={className}
       selectionModes={selectionModes}
       editModes={editModes}
       selectedMode={selectedMode}
@@ -117,7 +115,6 @@ FeatureSelectionWidget.defaultProps = {
 };
 
 FeatureSelectionWidget.propTypes = {
-  className: FeatureSelectionWidgetUI.propTypes.className,
   selectionModes: PropTypes.arrayOf(
     PropTypes.oneOf(Object.values(FEATURE_SELECTION_MODES))
   ),

--- a/packages/react-widgets/src/widgets/GeocoderWidget.js
+++ b/packages/react-widgets/src/widgets/GeocoderWidget.js
@@ -37,7 +37,6 @@ const SearchIcon = (args) => (
 /**
  * Renders a <GeocoderWidget /> component
  * @param  {object} props
- * @param  {object} [props.sx] - MUI5 for styling with sx prop
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  */
 function GeocoderWidget(props = {}) {
@@ -70,7 +69,7 @@ function GeocoderWidget(props = {}) {
   }, [geocoderResult, dispatch]);
 
   return (
-    <StyledPaper elevation={2} sx={props.sx}>
+    <StyledPaper elevation={2}>
       {loading ? (
         <CircularProgress size={18} sx={svgStyle} />
       ) : (
@@ -94,7 +93,6 @@ function GeocoderWidget(props = {}) {
 }
 
 GeocoderWidget.propTypes = {
-  sx: PropTypes.object,
   onError: PropTypes.func
 };
 

--- a/packages/react-widgets/src/widgets/GeocoderWidget.js
+++ b/packages/react-widgets/src/widgets/GeocoderWidget.js
@@ -37,7 +37,6 @@ const SearchIcon = (args) => (
 /**
  * Renders a <GeocoderWidget /> component
  * @param  {object} props
- * @param  {object} [props.className] - Material-UI withStyle class for styling
  * @param  {object} [props.sx] - MUI5 for styling with sx prop
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  */
@@ -71,7 +70,7 @@ function GeocoderWidget(props = {}) {
   }, [geocoderResult, dispatch]);
 
   return (
-    <StyledPaper className={`${props.className}`} elevation={2} sx={props.sx}>
+    <StyledPaper elevation={2} sx={props.sx}>
       {loading ? (
         <CircularProgress size={18} sx={svgStyle} />
       ) : (
@@ -95,7 +94,6 @@ function GeocoderWidget(props = {}) {
 }
 
 GeocoderWidget.propTypes = {
-  className: PropTypes.string,
   sx: PropTypes.object,
   onError: PropTypes.func
 };

--- a/packages/react-widgets/src/widgets/LegendWidget.js
+++ b/packages/react-widgets/src/widgets/LegendWidget.js
@@ -9,14 +9,12 @@ import sortLayers from './utils/sortLayers';
  * Renders a <LegendWidget /> component
  * @param  {object} props
  * @param  {string} [props.title] - Title of the widget.
- * @param  {string} [props.className] - CSS class name.
  * @param  {Object.<string, Function>} [props.customLayerOptions] - Allow to add custom controls to a legend item to tweak the associated layer.
  * @param  {Object.<string, Function>} [props.customLegendTypes] - Allow to customise by default legend types that can be rendered.
  * @param  {boolean} [props.initialCollapsed] - Define initial collapsed value. false by default.
  * @param  {string[]} [props.layerOrder] - Array of layer identifiers. Defines the order of layer legends. [] by default.
  */
 function LegendWidget({
-  className,
   customLayerOptions,
   customLegendTypes,
   initialCollapsed,
@@ -66,7 +64,6 @@ function LegendWidget({
   return (
     <LegendWidgetUI
       title={title}
-      className={className}
       customLegendTypes={customLegendTypes}
       customLayerOptions={customLayerOptions}
       layers={layers}
@@ -81,7 +78,6 @@ function LegendWidget({
 
 LegendWidget.propTypes = {
   title: PropTypes.string,
-  className: PropTypes.string,
   customLegendTypes: PropTypes.objectOf(PropTypes.func),
   initialCollapsed: PropTypes.bool,
   layerOrder: PropTypes.arrayOf(PropTypes.string)


### PR DESCRIPTION
# Description

Shortcut: [320955)](https://app.shortcut.com/cartoteam/story/320955/c4r-remove-classname-and-sx-props-from-components)
[sc-320955]

