### PR TITLE
Fix histogramWidget not passing down loading state to widgetUI

### DIFF
--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -199,6 +199,7 @@ function HistogramWidget({
             yAxisFormatter={formatter}
             animation={animation}
             filterable={filterable}
+            isLoading={isLoading}
           />
         )}
       </WidgetWithAlert>


### PR DESCRIPTION
# Description

Shortcut: [(314283)](https://app.shortcut.com/cartoteam/story/314283/new-loader-ui-for-widgets-histogram)
[sc-314283]

