### PR TITLE
v2.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,16 @@
 
 ## Not released
 
+## 2.0
+
+### 2.0.8 (2023-06-13)
+
 - Add custom Alert component [#698](https://github.com/CartoDB/carto-react/pull/698)
 - [Design system] Text button change to improve layout [#703](https://github.com/CartoDB/carto-react/pull/703)
 - Remove styles props from components: className and sx [#701](https://github.com/CartoDB/carto-react/pull/701)
 - Fix histogramWidget not passing down loading state to widgetUI [#702](https://github.com/CartoDB/carto-react/pull/702)
 
-## 2.0
+### 2.0.7 (2023-06-13)
 
 ### 2.0.6 (2023-06-07)
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,8 @@
 {
-  "packages": ["packages/*"],
+  "packages": [
+    "packages/*"
+  ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "2.0.6"
+  "version": "2.0.8"
 }

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -64,9 +64,9 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.0.7",
-    "@carto/react-redux": "^2.0.7",
-    "@carto/react-workers": "^2.0.7",
+    "@carto/react-core": "^2.0.8",
+    "@carto/react-redux": "^2.0.8",
+    "@carto/react-workers": "^2.0.8",
     "@deck.gl/carto": "^8.9.17",
     "@deck.gl/core": "^8.9.17",
     "@deck.gl/extensions": "^8.9.17",

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-api",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "CARTO for React - Api",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -64,9 +64,9 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.0.6",
-    "@carto/react-redux": "^2.0.6",
-    "@carto/react-workers": "^2.0.6",
+    "@carto/react-core": "^2.0.7",
+    "@carto/react-redux": "^2.0.7",
+    "@carto/react-workers": "^2.0.7",
     "@deck.gl/carto": "^8.9.17",
     "@deck.gl/core": "^8.9.17",
     "@deck.gl/extensions": "^8.9.17",

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-auth",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "CARTO for React - Auth",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -64,7 +64,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.0.6",
+    "@carto/react-core": "^2.0.7",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x"
   }

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -64,7 +64,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.0.7",
+    "@carto/react-core": "^2.0.8",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x"
   }

--- a/packages/react-basemaps/package.json
+++ b/packages/react-basemaps/package.json
@@ -64,7 +64,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.0.7",
+    "@carto/react-core": "^2.0.8",
     "@deck.gl/google-maps": "^8.9.17",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x"

--- a/packages/react-basemaps/package.json
+++ b/packages/react-basemaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-basemaps",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "CARTO for React - Basemaps",
   "keywords": [
     "carto",
@@ -64,7 +64,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.0.6",
+    "@carto/react-core": "^2.0.7",
     "@deck.gl/google-maps": "^8.9.17",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x"

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-core",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "CARTO for React - Core",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -63,8 +63,8 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.0.7",
-    "@carto/react-workers": "^2.0.7",
+    "@carto/react-core": "^2.0.8",
+    "@carto/react-workers": "^2.0.8",
     "@deck.gl/carto": "^8.9.17",
     "@deck.gl/core": "^8.9.17",
     "@reduxjs/toolkit": "^1.5.0"

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-redux",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "CARTO for React - Redux",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -63,8 +63,8 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.0.6",
-    "@carto/react-workers": "^2.0.6",
+    "@carto/react-core": "^2.0.7",
+    "@carto/react-workers": "^2.0.7",
     "@deck.gl/carto": "^8.9.17",
     "@deck.gl/core": "^8.9.17",
     "@reduxjs/toolkit": "^1.5.0"

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-ui",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "CARTO for React - UI",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -78,7 +78,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.0.6",
+    "@carto/react-core": "^2.0.7",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@mui/icons-material": "^5.11.16",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -78,7 +78,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.0.7",
+    "@carto/react-core": "^2.0.8",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@mui/icons-material": "^5.11.16",

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-widgets",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "CARTO for React - Widgets",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -65,11 +65,11 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-api": "^2.0.6",
-    "@carto/react-core": "^2.0.6",
-    "@carto/react-redux": "^2.0.6",
-    "@carto/react-ui": "^2.0.6",
-    "@carto/react-workers": "^2.0.6",
+    "@carto/react-api": "^2.0.7",
+    "@carto/react-core": "^2.0.7",
+    "@carto/react-redux": "^2.0.7",
+    "@carto/react-ui": "^2.0.7",
+    "@carto/react-workers": "^2.0.7",
     "@deck.gl/core": "^8.9.17",
     "@deck.gl/layers": "^8.9.17",
     "@emotion/react": "^11.10.6",

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -65,11 +65,11 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-api": "^2.0.7",
-    "@carto/react-core": "^2.0.7",
-    "@carto/react-redux": "^2.0.7",
-    "@carto/react-ui": "^2.0.7",
-    "@carto/react-workers": "^2.0.7",
+    "@carto/react-api": "^2.0.8",
+    "@carto/react-core": "^2.0.8",
+    "@carto/react-redux": "^2.0.8",
+    "@carto/react-ui": "^2.0.8",
+    "@carto/react-workers": "^2.0.8",
     "@deck.gl/core": "^8.9.17",
     "@deck.gl/layers": "^8.9.17",
     "@emotion/react": "^11.10.6",

--- a/packages/react-workers/package.json
+++ b/packages/react-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-workers",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "CARTO for React - Workers",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.9",
-    "@carto/react-core": "^2.0.6",
+    "@carto/react-core": "^2.0.7",
     "@turf/bbox-polygon": "^6.3.0",
     "@turf/boolean-intersects": "^6.3.0",
     "@turf/boolean-within": "^6.3.0",

--- a/packages/react-workers/package.json
+++ b/packages/react-workers/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.9",
-    "@carto/react-core": "^2.0.7",
+    "@carto/react-core": "^2.0.8",
     "@turf/bbox-polygon": "^6.3.0",
     "@turf/boolean-intersects": "^6.3.0",
     "@turf/boolean-within": "^6.3.0",


### PR DESCRIPTION
`2.0.7` had some unwanted changes introduced by mistake, so creating `2.0.8` right away to roll back it an do the right upgrade of the lib