### PR TITLE
Add TableCell styles for padding prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Add TableCell styles for padding prop [#725](https://github.com/CartoDB/carto-react/pull/725)
+
 ## 2.1
 
 ### 2.1.3 (2023-06-28)
@@ -81,6 +83,7 @@
 - Fix type propTypes issues [#677](https://github.com/CartoDB/carto-react/pull/677)
 
 ### 2.0.3 (2023-05-18)
+
 - Bump deck.gl to latest 8.9.15 [#675](https://github.com/CartoDB/carto-react/pull/675)
 - Calculation of widget using maps API under FF [#658](https://github.com/CartoDB/carto-react/pull/658)
 - TablePagination fixes & DS application [#673](https://github.com/CartoDB/carto-react/pull/673)

--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -300,6 +300,12 @@ export const dataDisplayOverrides = {
       }),
       stickyHeader: ({ theme }) => ({
         backgroundColor: theme.palette.common.white
+      }),
+      paddingCheckbox: ({ theme }) => ({
+        padding: theme.spacing(0.5, 1)
+      }),
+      paddingNone: ({ theme }) => ({
+        padding: 0
       })
     }
   },

--- a/packages/react-ui/storybook/stories/molecules/Table.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/Table.stories.js
@@ -121,7 +121,7 @@ const PlaygroundTemplate = (args) => {
                   row.description
                 )}
               </TableCell>
-              <TableCell>
+              <TableCell padding='checkbox'>
                 <IconButton size='small'>
                   <MoreVertOutlined />
                 </IconButton>
@@ -190,7 +190,7 @@ const ScrollTemplate = (args) => (
                   row.description
                 )}
               </TableCell>
-              <TableCell>
+              <TableCell padding='none'>
                 <IconButton size='small'>
                   <MoreVertOutlined />
                 </IconButton>

--- a/packages/react-ui/storybook/stories/molecules/Table.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/Table.stories.js
@@ -190,7 +190,7 @@ const ScrollTemplate = (args) => (
                   row.description
                 )}
               </TableCell>
-              <TableCell padding='none'>
+              <TableCell padding='checkbox'>
                 <IconButton size='small'>
                   <MoreVertOutlined />
                 </IconButton>


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/325900/unify-table-ui-in-settings
[sc-325900]

Add TableCell styles for padding prop to be able to adapt the padding to different use cases based on DS specs.