### PR TITLE
Fix blank map when loading widgets for tilesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not released
 
 - Search by coordinates supported in useGeocoderWidgetController hook [#731](https://github.com/CartoDB/carto-react/pull/731)
+- Fix blank map when loading widgets for tilesets [#733](https://github.com/CartoDB/carto-react/pull/733)
 
 ## 2.1
 

--- a/packages/react-widgets/src/hooks/useWidgetFetch.js
+++ b/packages/react-widgets/src/hooks/useWidgetFetch.js
@@ -111,7 +111,7 @@ export default function useWidgetFetch(
           if (outdated) return;
 
           onStateChange?.({ state: WidgetStateType.Success, data });
-          setData(data);
+          setData(data ?? undefined);
         })
         .catch((error) => {
           if (outdated) return;


### PR DESCRIPTION
# Description

With [this change](https://github.com/CartoDB/carto-react/pull/699/files#diff-9c1b5f29c8e39be7f20ce23181c8e28ae8cf9b58416060cb18c1eefd6d335e1aR114) now `data` can be `null`, so this breaks some widgets (like [CategoryWidget](https://github.com/CartoDB/carto-react/blob/ab269322e4cf60d326b6538cd68c97735489631b/packages/react-widgets/src/widgets/CategoryWidget.js#L107), or HistogramWidget), when they access to the `.length` propertly.

In the past, we were ignoring `undefined` and `null` values, and `undefined` works fine because a default empty array is used. However, for `null` values, the map crashes. I was able to reproduce it with **tilesets** using **category** and **histogram** widgets, when we are dropping features.

## Type of change

- Fix

# Acceptance

- Without the change

![without-the-fix](https://github.com/CartoDB/carto-react/assets/6042873/e7e53c42-fa32-4cd9-abf4-b486526a5195)

- With the change (local environment)

![with-the-fix](https://github.com/CartoDB/carto-react/assets/6042873/340ec9d4-a342-40ed-bc72-c7620f8901b1)
