### PR TITLE
SelectField refactor

### DIFF
--- a/packages/react-ui/src/components/atoms/MultipleSelectField.d.ts
+++ b/packages/react-ui/src/components/atoms/MultipleSelectField.d.ts
@@ -1,0 +1,14 @@
+import React from 'react';
+import { SelectFieldProps } from './SelectField';
+
+type MultipleSelectFieldItem = {
+  label: string | React.ReactNode;
+  value: string | number;
+};
+
+export type MultipleSelectFieldProps = SelectFieldProps & {
+  items: MultipleSelectFieldItem[];
+};
+
+declare const MultipleSelectField: (props: MultipleSelectFieldProps) => JSX.Element;
+export default MultipleSelectField;

--- a/packages/react-ui/src/components/atoms/MultipleSelectField.js
+++ b/packages/react-ui/src/components/atoms/MultipleSelectField.js
@@ -1,42 +1,85 @@
 import React, { forwardRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Checkbox, MenuItem } from '@mui/material';
+import { Box, Checkbox, MenuItem, styled } from '@mui/material';
 import SelectField from './SelectField';
+import Typography from './Typography';
 
-const MultipleSelectField = forwardRef(({ items, ...otherProps }, ref) => {
-  // forwardRef needed to be able to hold a reference, in this way it can be a child for some Mui components, like Tooltip
-  // https://mui.com/material-ui/guides/composition/#caveat-with-refs
-  const [content, setContent] = useState([]);
-
-  const handleChange = (event) => {
-    const {
-      target: { value }
-    } = event;
-    setContent(
-      // On autofill we get a stringified value
-      typeof value === 'string' ? value.split(',') : value
-    );
-  };
-
-  return (
-    <SelectField
-      {...otherProps}
-      ref={ref}
-      value={content}
-      onChange={handleChange}
-      customSelectProps={{
-        multiple: true
-      }}
-    >
-      {items.map((item, index) => (
-        <MenuItem key={index} value={item.value}>
-          <Checkbox checked={content.indexOf(item.value) > -1} size='small' />
-          {item.label}
-        </MenuItem>
-      ))}
-    </SelectField>
-  );
+const BoxContent = styled(Box)({
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis'
 });
+
+const MultipleSelectField = forwardRef(
+  ({ items, size, placeholder, counter, ...otherProps }, ref) => {
+    // forwardRef needed to be able to hold a reference, in this way it can be a child for some Mui components, like Tooltip
+    // https://mui.com/material-ui/guides/composition/#caveat-with-refs
+    const [content, setContent] = useState([]);
+
+    const handleChange = (event) => {
+      const {
+        target: { value }
+      } = event;
+      setContent(
+        // On autofill we get a stringified value
+        typeof value === 'string' ? value.split(',') : value
+      );
+    };
+
+    const isSmall = size === 'small';
+    const paddingSize = isSmall ? 1.5 : 2;
+
+    return (
+      <SelectField
+        {...otherProps}
+        ref={ref}
+        value={content}
+        onChange={handleChange}
+        multiple
+        customRenderValue={(selected) => {
+          if (selected.length === 0) {
+            return (
+              <Typography
+                variant={isSmall ? 'body2' : 'body1'}
+                color='text.hint'
+                component='span'
+                noWrap
+                ml={paddingSize}
+              >
+                {placeholder}
+              </Typography>
+            );
+          }
+          return (
+            <BoxContent ml={paddingSize}>
+              {selected.map((value, index) => (
+                <Typography
+                  key={index}
+                  variant={isSmall ? 'body2' : 'body1'}
+                  component='span'
+                >
+                  {items.find((item) => item.value === value).label}
+                  {', '}
+                </Typography>
+              ))}
+            </BoxContent>
+          );
+        }}
+      >
+        {items.map((item, index) => (
+          <MenuItem key={index} value={item.value}>
+            <Checkbox checked={content.indexOf(item.value) > -1} size='small' />
+            {item.label}
+          </MenuItem>
+        ))}
+      </SelectField>
+    );
+  }
+);
+
+MultipleSelectField.defaultProps = {
+  size: 'small'
+};
 
 MultipleSelectField.propTypes = {
   items: PropTypes.arrayOf(

--- a/packages/react-ui/src/components/atoms/MultipleSelectField.js
+++ b/packages/react-ui/src/components/atoms/MultipleSelectField.js
@@ -1,0 +1,50 @@
+import React, { forwardRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Checkbox, MenuItem } from '@mui/material';
+import SelectField from './SelectField';
+
+const MultipleSelectField = forwardRef(({ items, ...otherProps }, ref) => {
+  // forwardRef needed to be able to hold a reference, in this way it can be a child for some Mui components, like Tooltip
+  // https://mui.com/material-ui/guides/composition/#caveat-with-refs
+  const [content, setContent] = useState([]);
+
+  const handleChange = (event) => {
+    const {
+      target: { value }
+    } = event;
+    setContent(
+      // On autofill we get a stringified value
+      typeof value === 'string' ? value.split(',') : value
+    );
+  };
+
+  return (
+    <SelectField
+      {...otherProps}
+      ref={ref}
+      value={content}
+      onChange={handleChange}
+      customSelectProps={{
+        multiple: true
+      }}
+    >
+      {items.map((item, index) => (
+        <MenuItem key={index} value={item.value}>
+          <Checkbox checked={content.indexOf(item.value) > -1} size='small' />
+          {item.label}
+        </MenuItem>
+      ))}
+    </SelectField>
+  );
+});
+
+MultipleSelectField.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+      value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
+    })
+  ).isRequired
+};
+
+export default MultipleSelectField;

--- a/packages/react-ui/src/components/atoms/SelectField.d.ts
+++ b/packages/react-ui/src/components/atoms/SelectField.d.ts
@@ -1,15 +1,12 @@
 import { TextFieldProps } from '@mui/material/TextField';
-
-type SelectFieldItem = {
-  label: string;
-  value: string | number;
-};
+import React from 'react';
 
 export type SelectFieldProps = Omit<TextFieldProps, 'placeholder'> & {
-  items: SelectFieldItem[];
-  multiple?: boolean;
+  children: React.ReactNode;
+  onChange: Function;
   placeholder?: React.ReactNode;
   size?: 'small' | 'medium';
+  customSelectProps?: Object;
 };
 
 declare const SelectField: (props: SelectFieldProps) => JSX.Element;

--- a/packages/react-ui/src/components/atoms/SelectField.d.ts
+++ b/packages/react-ui/src/components/atoms/SelectField.d.ts
@@ -6,7 +6,7 @@ export type SelectFieldProps = Omit<TextFieldProps, 'placeholder'> & {
   onChange: Function;
   placeholder?: React.ReactNode;
   size?: 'small' | 'medium';
-  customSelectProps?: Object;
+  customRenderValue?: (value) => React.ReactNode;
 };
 
 declare const SelectField: (props: SelectFieldProps) => JSX.Element;

--- a/packages/react-ui/src/components/atoms/SelectField.js
+++ b/packages/react-ui/src/components/atoms/SelectField.js
@@ -1,6 +1,6 @@
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import { Box, Checkbox, MenuItem, TextField } from '@mui/material';
+import { Box, MenuItem, TextField } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
 import Typography from './Typography';
@@ -12,40 +12,27 @@ const BoxContent = styled(Box)({
 });
 
 const SelectField = forwardRef(
-  ({ placeholder, items, multiple, size, ...otherProps }, ref) => {
+  ({ children, onChange, placeholder, size, customSelectProps, ...otherProps }, ref) => {
     // forwardRef needed to be able to hold a reference, in this way it can be a child for some Mui components, like Tooltip
     // https://mui.com/material-ui/guides/composition/#caveat-with-refs
-    const [content, setContent] = useState([]);
-
-    const handleChange = (event) => {
-      const {
-        target: { value }
-      } = event;
-      setContent(
-        // On autofill we get a stringified value
-        typeof value === 'string' ? value.split(',') : value
-      );
-    };
 
     const isSmall = size === 'small';
-    const paddingSize = isSmall ? 1.5 : 2;
 
     return (
       <TextField
         {...otherProps}
         select
+        onChange={onChange}
         ref={ref}
-        value={content}
-        onChange={handleChange}
         size={size}
         SelectProps={{
-          multiple: multiple,
+          ...customSelectProps,
           displayEmpty: !!placeholder,
           size: size,
           renderValue: (selected) => {
             if (selected.length === 0) {
               return (
-                <BoxContent ml={multiple && paddingSize}>
+                <BoxContent>
                   <Typography
                     variant={isSmall ? 'body2' : 'body1'}
                     color='text.hint'
@@ -56,20 +43,7 @@ const SelectField = forwardRef(
                 </BoxContent>
               );
             }
-            return (
-              <BoxContent ml={multiple && paddingSize}>
-                {selected.map((value, index) => (
-                  <Typography
-                    key={index}
-                    variant={isSmall ? 'body2' : 'body1'}
-                    component='span'
-                  >
-                    {items.find((item) => item.value === value).label}
-                    {multiple && ', '}
-                  </Typography>
-                ))}
-              </BoxContent>
-            );
+            return selected.join(', ');
           },
           MenuProps: {
             anchorOrigin: {
@@ -84,33 +58,21 @@ const SelectField = forwardRef(
         }}
       >
         <MenuItem key='empty' disabled value={''}></MenuItem>
-        {items.map((item, index) => (
-          <MenuItem key={index} value={item.value}>
-            {multiple && (
-              <Checkbox checked={content.indexOf(item.value) > -1} size='small' />
-            )}
-            {item.label}
-          </MenuItem>
-        ))}
+        {children}
       </TextField>
     );
   }
 );
 
 SelectField.defaultProps = {
-  multiple: false,
   size: 'small'
 };
 SelectField.propTypes = {
-  items: PropTypes.arrayOf(
-    PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
-    })
-  ).isRequired,
-  placeholder: PropTypes.string.isRequired,
-  multiple: PropTypes.bool,
-  size: PropTypes.oneOf(['small', 'medium'])
+  children: PropTypes.node.isRequired,
+  onChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
+  size: PropTypes.oneOf(['small', 'medium']),
+  customSelectProps: PropTypes.object
 };
 
 export default SelectField;

--- a/packages/react-ui/src/components/atoms/SelectField.js
+++ b/packages/react-ui/src/components/atoms/SelectField.js
@@ -1,18 +1,13 @@
 import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import { Box, MenuItem, TextField } from '@mui/material';
-import { styled } from '@mui/material/styles';
-
+import { MenuItem, TextField } from '@mui/material';
 import Typography from './Typography';
 
-const BoxContent = styled(Box)({
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis'
-});
-
 const SelectField = forwardRef(
-  ({ children, onChange, placeholder, size, customSelectProps, ...otherProps }, ref) => {
+  (
+    { children, onChange, placeholder, size, multiple, customRenderValue, ...otherProps },
+    ref
+  ) => {
     // forwardRef needed to be able to hold a reference, in this way it can be a child for some Mui components, like Tooltip
     // https://mui.com/material-ui/guides/composition/#caveat-with-refs
 
@@ -26,25 +21,26 @@ const SelectField = forwardRef(
         ref={ref}
         size={size}
         SelectProps={{
-          ...customSelectProps,
+          multiple: multiple,
           displayEmpty: !!placeholder,
           size: size,
-          renderValue: (selected) => {
-            if (selected.length === 0) {
-              return (
-                <BoxContent>
+          renderValue:
+            customRenderValue ||
+            ((selected) => {
+              if (selected.length === 0) {
+                return (
                   <Typography
                     variant={isSmall ? 'body2' : 'body1'}
                     color='text.hint'
                     component='span'
+                    noWrap
                   >
                     {placeholder}
                   </Typography>
-                </BoxContent>
-              );
-            }
-            return selected.join(', ');
-          },
+                );
+              }
+              return selected.join(', ');
+            }),
           MenuProps: {
             anchorOrigin: {
               vertical: 'bottom',
@@ -65,6 +61,7 @@ const SelectField = forwardRef(
 );
 
 SelectField.defaultProps = {
+  multiple: false,
   size: 'small'
 };
 SelectField.propTypes = {
@@ -72,7 +69,7 @@ SelectField.propTypes = {
   onChange: PropTypes.func.isRequired,
   placeholder: PropTypes.string,
   size: PropTypes.oneOf(['small', 'medium']),
-  customSelectProps: PropTypes.object
+  customRenderValue: PropTypes.func
 };
 
 export default SelectField;

--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -30,6 +30,9 @@ export const dataDisplayOverrides = {
   MuiList: {
     styleOverrides: {
       root: ({ theme }) => ({
+        maxHeight: theme.spacing(39), // 312px, defined by design
+        overflowY: 'auto',
+
         // Indent sublevels, ugly but needed to avoid issues with hover
         '& .MuiList-root': {
           '& .MuiListItem-root': {

--- a/packages/react-ui/storybook/stories/atoms/MiltipleSelectField.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/MiltipleSelectField.stories.js
@@ -1,0 +1,230 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Chip,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  OutlinedInput,
+  Select,
+  TextField,
+  styled
+} from '@mui/material';
+import Typography from '../../../src/components/atoms/Typography';
+import MultipleSelectField from '../../../src/components/atoms/MultipleSelectField';
+import { Container, Label } from '../../utils/storyStyles';
+
+const options = {
+  title: 'Atoms/Multiple Select Field',
+  component: MultipleSelectField,
+  argTypes: {
+    variant: {
+      control: {
+        type: 'select',
+        options: ['outlined', 'filled', 'standard']
+      }
+    },
+    size: {
+      control: {
+        type: 'select',
+        options: ['small', 'medium']
+      }
+    },
+    required: {
+      defaultValue: false,
+      control: {
+        type: 'boolean'
+      }
+    },
+    disabled: {
+      defaultValue: false,
+      control: {
+        type: 'boolean'
+      }
+    },
+    error: {
+      defaultValue: false,
+      control: {
+        type: 'boolean'
+      }
+    },
+    label: {
+      control: {
+        type: 'text'
+      }
+    },
+    placeholder: {
+      control: {
+        type: 'text'
+      }
+    }
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/nmaoLeo69xBJCHm9nc6lEV/CARTO-Components-1.0?node-id=1534%3A29965'
+    },
+    status: {
+      type: 'validated'
+    }
+  }
+};
+export default options;
+
+const ChipWrapper = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'small'
+})(({ theme, small }) => ({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: theme.spacing(1),
+  overflow: 'auto',
+  height: theme.spacing(small ? 3 : 4)
+}));
+
+const menuItems = [
+  {
+    label: 'Ten: super large text with overflow',
+    value: '10'
+  },
+  {
+    label: 'Twenty',
+    value: '20'
+  },
+  {
+    label: 'Thirty',
+    value: '30'
+  }
+];
+
+const menuItemsLong = [
+  {
+    label: 'table_openstreetmap_pointsofinterest',
+    value: '10Long'
+  },
+  {
+    label: 'Twenty',
+    value: '20'
+  },
+  {
+    label: 'Thirty',
+    value: '30'
+  }
+];
+
+const MultipleSelectFieldItem = ({ label, required, placeholder, ...rest }) => {
+  const [content, setContent] = useState([]);
+
+  const handleChange = (event) => {
+    const {
+      target: { value }
+    } = event;
+    setContent(
+      // On autofill we get a stringified value
+      typeof value === 'string' ? value.split(',') : value
+    );
+  };
+
+  return (
+    <MultipleSelectField
+      {...rest}
+      label={label}
+      placeholder={placeholder}
+      items={menuItems}
+      onChange={handleChange}
+      value={content}
+    />
+  );
+};
+
+const PlaygroundTemplate = (args) => <MultipleSelectFieldItem {...args} />;
+
+const MultipleTemplate = ({
+  label,
+  placeholder,
+  defaultValue,
+  helperText,
+  size,
+  ...rest
+}) => {
+  const [personName, setPersonName] = React.useState([]);
+  const isSmall = size === 'small';
+
+  const handleChange = (event) => {
+    const {
+      target: { value }
+    } = event;
+    setPersonName(
+      // On autofill we get a stringified value.
+      typeof value === 'string' ? value.split(',') : value
+    );
+  };
+
+  return (
+    <Grid container direction='column' spacing={6}>
+      <Grid item>
+        <Container>
+          <Label variant='body2'>{'Default (custom component)'}</Label>
+          <MultipleSelectFieldItem
+            {...rest}
+            multiple
+            size={size}
+            label={label}
+            placeholder={placeholder}
+            items={menuItems}
+          />
+        </Container>
+      </Grid>
+      <Grid item xs={3}>
+        <Container>
+          <Label variant='body2'>{'Select (with custom chips)'}</Label>
+          <Select
+            {...rest}
+            label={label}
+            size={size}
+            multiple
+            displayEmpty
+            value={personName}
+            onChange={handleChange}
+            input={<OutlinedInput id='select-multiple-chip' label='Chip' />}
+            renderValue={(selected) => {
+              if (selected.length === 0) {
+                return (
+                  <Typography variant={isSmall ? 'body2' : 'body1'} color='text.hint'>
+                    Placeholder
+                  </Typography>
+                );
+              }
+
+              return (
+                <ChipWrapper small={isSmall}>
+                  {selected.map((value) => (
+                    <Chip size='inherit' color='default' key={value} label={value} />
+                  ))}
+                </ChipWrapper>
+              );
+            }}
+          >
+            {[...Array(10)].map((x, index) => (
+              <MenuItem key={index} value={`Option item ${index + 1}`}>
+                {`Option item ${index + 1}`}
+              </MenuItem>
+            ))}
+          </Select>
+        </Container>
+      </Grid>
+    </Grid>
+  );
+};
+
+const commonArgs = {
+  label: 'Label text',
+  placeholder: 'Placeholder text',
+  helperText: 'Helper text.'
+};
+
+export const Playground = PlaygroundTemplate.bind({});
+Playground.args = { ...commonArgs };
+
+export const MultipleSelection = MultipleTemplate.bind({});
+MultipleSelection.args = { ...commonArgs };

--- a/packages/react-ui/storybook/stories/atoms/MiltipleSelectField.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/MiltipleSelectField.stories.js
@@ -1,16 +1,5 @@
 import React, { useState } from 'react';
-import {
-  Box,
-  Chip,
-  FormControl,
-  Grid,
-  InputLabel,
-  MenuItem,
-  OutlinedInput,
-  Select,
-  TextField,
-  styled
-} from '@mui/material';
+import { Box, Chip, Grid, MenuItem, OutlinedInput, Select, styled } from '@mui/material';
 import Typography from '../../../src/components/atoms/Typography';
 import MultipleSelectField from '../../../src/components/atoms/MultipleSelectField';
 import { Container, Label } from '../../utils/storyStyles';
@@ -84,21 +73,6 @@ const ChipWrapper = styled(Box, {
 
 const menuItems = [
   {
-    label: 'Ten: super large text with overflow',
-    value: '10'
-  },
-  {
-    label: 'Twenty',
-    value: '20'
-  },
-  {
-    label: 'Thirty',
-    value: '30'
-  }
-];
-
-const menuItemsLong = [
-  {
     label: 'table_openstreetmap_pointsofinterest',
     value: '10Long'
   },
@@ -109,10 +83,18 @@ const menuItemsLong = [
   {
     label: 'Thirty',
     value: '30'
+  },
+  {
+    label: 'Forty',
+    value: '40'
+  },
+  {
+    label: 'Fifty',
+    value: '50'
   }
 ];
 
-const MultipleSelectFieldItem = ({ label, required, placeholder, ...rest }) => {
+const PlaygroundTemplate = ({ label, placeholder, ...rest }) => {
   const [content, setContent] = useState([]);
 
   const handleChange = (event) => {
@@ -137,86 +119,6 @@ const MultipleSelectFieldItem = ({ label, required, placeholder, ...rest }) => {
   );
 };
 
-const PlaygroundTemplate = (args) => <MultipleSelectFieldItem {...args} />;
-
-const MultipleTemplate = ({
-  label,
-  placeholder,
-  defaultValue,
-  helperText,
-  size,
-  ...rest
-}) => {
-  const [personName, setPersonName] = React.useState([]);
-  const isSmall = size === 'small';
-
-  const handleChange = (event) => {
-    const {
-      target: { value }
-    } = event;
-    setPersonName(
-      // On autofill we get a stringified value.
-      typeof value === 'string' ? value.split(',') : value
-    );
-  };
-
-  return (
-    <Grid container direction='column' spacing={6}>
-      <Grid item>
-        <Container>
-          <Label variant='body2'>{'Default (custom component)'}</Label>
-          <MultipleSelectFieldItem
-            {...rest}
-            multiple
-            size={size}
-            label={label}
-            placeholder={placeholder}
-            items={menuItems}
-          />
-        </Container>
-      </Grid>
-      <Grid item xs={3}>
-        <Container>
-          <Label variant='body2'>{'Select (with custom chips)'}</Label>
-          <Select
-            {...rest}
-            label={label}
-            size={size}
-            multiple
-            displayEmpty
-            value={personName}
-            onChange={handleChange}
-            input={<OutlinedInput id='select-multiple-chip' label='Chip' />}
-            renderValue={(selected) => {
-              if (selected.length === 0) {
-                return (
-                  <Typography variant={isSmall ? 'body2' : 'body1'} color='text.hint'>
-                    Placeholder
-                  </Typography>
-                );
-              }
-
-              return (
-                <ChipWrapper small={isSmall}>
-                  {selected.map((value) => (
-                    <Chip size='inherit' color='default' key={value} label={value} />
-                  ))}
-                </ChipWrapper>
-              );
-            }}
-          >
-            {[...Array(10)].map((x, index) => (
-              <MenuItem key={index} value={`Option item ${index + 1}`}>
-                {`Option item ${index + 1}`}
-              </MenuItem>
-            ))}
-          </Select>
-        </Container>
-      </Grid>
-    </Grid>
-  );
-};
-
 const commonArgs = {
   label: 'Label text',
   placeholder: 'Placeholder text',
@@ -226,5 +128,5 @@ const commonArgs = {
 export const Playground = PlaygroundTemplate.bind({});
 Playground.args = { ...commonArgs };
 
-export const MultipleSelection = MultipleTemplate.bind({});
-MultipleSelection.args = { ...commonArgs };
+export const Counter = PlaygroundTemplate.bind({});
+Counter.args = { ...commonArgs, counter: true };

--- a/packages/react-ui/storybook/stories/atoms/SelectField.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/SelectField.stories.js
@@ -1,15 +1,12 @@
 import React, { useState } from 'react';
 import {
-  Box,
-  Chip,
   FormControl,
   Grid,
   InputLabel,
+  Link,
   MenuItem,
-  OutlinedInput,
   Select,
-  TextField,
-  styled
+  TextField
 } from '@mui/material';
 import Typography from '../../../src/components/atoms/Typography';
 import SelectField from '../../../src/components/atoms/SelectField';
@@ -72,16 +69,6 @@ const options = {
 };
 export default options;
 
-const ChipWrapper = styled(Box, {
-  shouldForwardProp: (prop) => prop !== 'small'
-})(({ theme, small }) => ({
-  display: 'flex',
-  flexWrap: 'wrap',
-  gap: theme.spacing(1),
-  overflow: 'auto',
-  height: theme.spacing(small ? 3 : 4)
-}));
-
 const menuItems = [
   {
     label: 'Ten: super large text with overflow',
@@ -112,7 +99,58 @@ const menuItemsLong = [
   }
 ];
 
-const PlaygroundTemplate = (args) => <SelectField {...args} items={menuItems} />;
+const SelectFieldItem = ({
+  label,
+  required,
+  placeholder,
+  variant,
+  helperText,
+  size,
+  focused,
+  disabled,
+  error,
+  ...rest
+}) => {
+  const [content, setContent] = useState([]);
+
+  const handleChange = (event) => {
+    const {
+      target: { value }
+    } = event;
+    setContent(
+      // On autofill we get a stringified value
+      typeof value === 'string' ? value.split(',') : value
+    );
+  };
+
+  return (
+    <SelectField
+      {...rest}
+      label={label}
+      variant={variant}
+      placeholder={placeholder}
+      items={menuItems}
+      helperText={helperText}
+      onChange={handleChange}
+      value={content}
+      focused={focused}
+      disabled={disabled}
+      error={error}
+      size={size}
+      fullWidth={rest.fullWidth}
+    >
+      {[...Array(20)].map((item, index) => {
+        return (
+          <MenuItem key={index} value={`Item ${index + 1}`}>
+            Item {index + 1}
+          </MenuItem>
+        );
+      })}
+    </SelectField>
+  );
+};
+
+const PlaygroundTemplate = (args) => <SelectFieldItem {...args} />;
 
 const VariantsTemplate = ({ label, required, placeholder, ...rest }) => {
   return (
@@ -120,7 +158,7 @@ const VariantsTemplate = ({ label, required, placeholder, ...rest }) => {
       <Grid item>
         <Container>
           <Label variant='body2'>{'Filled'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             variant='filled'
@@ -132,7 +170,7 @@ const VariantsTemplate = ({ label, required, placeholder, ...rest }) => {
       <Grid item>
         <Container>
           <Label variant='body2'>{'Outlined'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             variant='outlined'
@@ -144,7 +182,7 @@ const VariantsTemplate = ({ label, required, placeholder, ...rest }) => {
       <Grid item>
         <Container>
           <Label variant='body2'>{'Standard'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             variant='standard'
@@ -163,7 +201,7 @@ const LabelAndHelperTextTemplate = ({ label, placeholder, helperText, ...rest })
       <Grid item>
         <Container>
           <Label variant='body2'>{'Label + helper text'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             placeholder={placeholder}
@@ -175,13 +213,13 @@ const LabelAndHelperTextTemplate = ({ label, placeholder, helperText, ...rest })
       <Grid item>
         <Container>
           <Label variant='body2'>{'Without label + helper text'}</Label>
-          <SelectField {...rest} placeholder={placeholder} items={menuItems} />
+          <SelectFieldItem {...rest} placeholder={placeholder} items={menuItems} />
         </Container>
       </Grid>
       <Grid item>
         <Container>
           <Label variant='body2'>{'Only label'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             placeholder={placeholder}
@@ -192,7 +230,7 @@ const LabelAndHelperTextTemplate = ({ label, placeholder, helperText, ...rest })
       <Grid item>
         <Container>
           <Label variant='body2'>{'Only helper text'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             placeholder={placeholder}
             helperText={helperText}
@@ -233,7 +271,7 @@ const SizeTemplate = ({
           <Typography variant='body2'>Custom component</Typography>
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='filled'
             label={label}
@@ -243,7 +281,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='outlined'
             label={label}
@@ -253,7 +291,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='standard'
             label={label}
@@ -374,7 +412,7 @@ const SizeTemplate = ({
           <Typography>Focused</Typography>
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='filled'
             label={label}
@@ -385,7 +423,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='outlined'
             label={label}
@@ -396,7 +434,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='standard'
             label={label}
@@ -413,7 +451,7 @@ const SizeTemplate = ({
           <Typography>Disabled</Typography>
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='filled'
             label={label}
@@ -424,7 +462,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='outlined'
             label={label}
@@ -435,7 +473,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='standard'
             label={label}
@@ -452,7 +490,7 @@ const SizeTemplate = ({
           <Typography>Error</Typography>
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='filled'
             label={label}
@@ -464,7 +502,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='outlined'
             label={label}
@@ -476,7 +514,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='standard'
             label={label}
@@ -500,73 +538,14 @@ const MultipleTemplate = ({
   size,
   ...rest
 }) => {
-  const [personName, setPersonName] = React.useState([]);
-  const isSmall = size === 'small';
-
-  const handleChange = (event) => {
-    const {
-      target: { value }
-    } = event;
-    setPersonName(
-      // On autofill we get a stringified value.
-      typeof value === 'string' ? value.split(',') : value
-    );
-  };
-
   return (
-    <Grid container direction='column' spacing={6}>
-      <Grid item>
-        <Container>
-          <Label variant='body2'>{'Default (custom component)'}</Label>
-          <SelectField
-            {...rest}
-            multiple
-            size={size}
-            label={label}
-            placeholder={placeholder}
-            items={menuItems}
-          />
-        </Container>
-      </Grid>
-      <Grid item xs={3}>
-        <Container>
-          <Label variant='body2'>{'Select (with custom chips)'}</Label>
-          <Select
-            {...rest}
-            label={label}
-            size={size}
-            multiple
-            displayEmpty
-            value={personName}
-            onChange={handleChange}
-            input={<OutlinedInput id='select-multiple-chip' label='Chip' />}
-            renderValue={(selected) => {
-              if (selected.length === 0) {
-                return (
-                  <Typography variant={isSmall ? 'body2' : 'body1'} color='text.hint'>
-                    Placeholder
-                  </Typography>
-                );
-              }
-
-              return (
-                <ChipWrapper small={isSmall}>
-                  {selected.map((value) => (
-                    <Chip size={size} color='default' key={value} label={value} />
-                  ))}
-                </ChipWrapper>
-              );
-            }}
-          >
-            {[...Array(10)].map((x, index) => (
-              <MenuItem key={index} value={`Option item ${index + 1}`}>
-                {`Option item ${index + 1}`}
-              </MenuItem>
-            ))}
-          </Select>
-        </Container>
-      </Grid>
-    </Grid>
+    <Typography variant='subtitle1'>
+      Check{' '}
+      <Link href='/?path=/docs/atoms-multiple-select-field--playground'>
+        MultipleSelectField
+      </Link>{' '}
+      component documentation
+    </Typography>
   );
 };
 
@@ -577,7 +556,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
         <Label variant='subtitle1'>{'Overflow'}</Label>
         <Container style={{ maxWidth: '440px' }}>
           <Label variant='body2'>{'Default'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             placeholder={placeholder}
@@ -593,7 +572,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
 
           <Grid container spacing={2}>
             <Grid item>
-              <SelectField
+              <SelectFieldItem
                 {...rest}
                 label={label}
                 placeholder={placeholder}
@@ -601,7 +580,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
               />
             </Grid>
             <Grid item>
-              <SelectField
+              <SelectFieldItem
                 {...rest}
                 label={label}
                 placeholder={placeholder}
@@ -616,7 +595,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
         <Label variant='subtitle1'>{'Width'}</Label>
         <Container>
           <Label variant='body2'>{'Default (fullWidth)'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             placeholder={placeholder}
@@ -625,7 +604,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
         </Container>
         <Container>
           <Label variant='body2'>{'No fullWidth'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             placeholder={placeholder}
@@ -643,28 +622,33 @@ const commonArgs = {
   placeholder: 'Placeholder text',
   helperText: 'Helper text.'
 };
+
 const sizeArgs = {
   helperText: 'This is a error message.'
 };
 
-const disabledControlsVariantsArgTypes = {
-  variant: { table: { disable: true } }
-};
-const disabledControlsSizeArgTypes = {
+const disabledControlsArgTypes = {
   variant: { table: { disable: true } },
+  multiple: { table: { disable: true } }
+};
+
+const disabledControlsSizeArgTypes = {
+  ...disabledControlsArgTypes,
   error: { table: { disable: true } },
   defaultValue: { table: { disable: true } }
 };
 
 export const Playground = PlaygroundTemplate.bind({});
 Playground.args = { ...commonArgs };
+Playground.argTypes = disabledControlsArgTypes;
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = { ...commonArgs };
-Variants.argTypes = disabledControlsVariantsArgTypes;
+Variants.argTypes = disabledControlsArgTypes;
 
 export const LabelAndHelperText = LabelAndHelperTextTemplate.bind({});
 LabelAndHelperText.args = { ...commonArgs };
+LabelAndHelperText.argTypes = disabledControlsArgTypes;
 
 export const Medium = SizeTemplate.bind({});
 Medium.args = { ...commonArgs, ...sizeArgs, size: 'medium' };
@@ -676,6 +660,8 @@ Small.argTypes = disabledControlsSizeArgTypes;
 
 export const MultipleSelection = MultipleTemplate.bind({});
 MultipleSelection.args = { ...commonArgs };
+MultipleSelection.argTypes = disabledControlsArgTypes;
 
 export const Behavior = BehaviorTemplate.bind({});
 Behavior.args = { ...commonArgs };
+Behavior.argTypes = disabledControlsArgTypes;

--- a/packages/react-ui/storybook/stories/atoms/SelectField.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/SelectField.stories.js
@@ -140,9 +140,14 @@ const SelectFieldItem = ({
       fullWidth={rest.fullWidth}
     >
       {[...Array(20)].map((item, index) => {
+        const itemText =
+          index === 1
+            ? `Very long item text with overflow ${index + 1}`
+            : `Item ${index + 1}`;
+
         return (
-          <MenuItem key={index} value={`Item ${index + 1}`}>
-            Item {index + 1}
+          <MenuItem key={index} value={itemText}>
+            {itemText}
           </MenuItem>
         );
       })}
@@ -309,37 +314,19 @@ const SizeTemplate = ({
         <Grid item xs={3}>
           <FormControl>
             <InputLabel>{label}</InputLabel>
-            <Select {...rest} variant='filled' size={size}>
-              {menuItems.map((option) => (
-                <MenuItem key={option.label} value={option.label}>
-                  {option.label}
-                </MenuItem>
-              ))}
-            </Select>
+            <SelectFieldItem {...rest} variant='filled' size={size} items={menuItems} />
           </FormControl>
         </Grid>
         <Grid item xs={3}>
           <FormControl>
             <InputLabel>{label}</InputLabel>
-            <Select {...rest} variant='outlined' size={size}>
-              {menuItems.map((option) => (
-                <MenuItem key={option.label} value={option.label}>
-                  {option.label}
-                </MenuItem>
-              ))}
-            </Select>
+            <SelectFieldItem {...rest} variant='outlined' size={size} items={menuItems} />
           </FormControl>
         </Grid>
         <Grid item xs={3}>
           <FormControl>
             <InputLabel>{label}</InputLabel>
-            <Select {...rest} variant='standard' size={size}>
-              {menuItems.map((option) => (
-                <MenuItem key={option.label} value={option.label}>
-                  {option.label}
-                </MenuItem>
-              ))}
-            </Select>
+            <SelectFieldItem {...rest} variant='standard' size={size} items={menuItems} />
           </FormControl>
         </Grid>
       </Grid>


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/303604/core-refactor-selectfield
[sc-303604]

Split functionality into two different components, one for multiple select, more limited based on design specs (uncontrolled component). The other one, is a more generic select field with the addition of a placeholder (controlled component).