### PR TITLE
Improve regex to detect coordinate pairs on search location widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not released
 
 - Fix to build more accurate ranges for time filters [#655](https://github.com/CartoDB/carto-react/pull/655)
+- Improve regex to detect coordinate pairs on search location widget [#742](https://github.com/CartoDB/carto-react/pull/742)
 
 ## 2.1
 

--- a/packages/react-widgets/__tests__/widgets/utils/validateCoordinates.test.js
+++ b/packages/react-widgets/__tests__/widgets/utils/validateCoordinates.test.js
@@ -43,6 +43,7 @@ test('isCoordinate should return true for valid coordinates', () => {
   expect(isCoordinate('-12.345 67.890')).toBe(true);
   expect(isCoordinate('0.1234 -45.6789')).toBe(true);
   expect(isCoordinate('12.3456789 0')).toBe(true);
+  expect(isCoordinate('12.3456789123456789 123.4567891234567891')).toBe(true);
 });
 
 test('isCoordinate should return false for invalid coordinates', () => {
@@ -50,12 +51,18 @@ test('isCoordinate should return false for invalid coordinates', () => {
   expect(isCoordinate('120,90')).toBe(false);
   expect(isCoordinate('-100 180')).toBe(false);
   expect(isCoordinate('abc 45')).toBe(false);
+  expect(isCoordinate('-90.001,123.456')).toBe(false);
+  expect(isCoordinate('-120.123,45.678')).toBe(false);
+  expect(isCoordinate('12.34567891234567891 123.456')).toBe(false);
 
   // Invalid longitude
   expect(isCoordinate('0 181')).toBe(false);
   expect(isCoordinate('45 -181')).toBe(false);
   expect(isCoordinate('12.345 200')).toBe(false);
   expect(isCoordinate('45 def')).toBe(false);
+  expect(isCoordinate('12.345,180.001')).toBe(false);
+  expect(isCoordinate('12.345,250')).toBe(false);
+  expect(isCoordinate('12.345 123.45678912345678912')).toBe(false);
 
   // Extra characters
   expect(isCoordinate('0 0 extra')).toBe(false);

--- a/packages/react-widgets/src/widgets/utils/validateCoordinates.js
+++ b/packages/react-widgets/src/widgets/utils/validateCoordinates.js
@@ -8,7 +8,7 @@ export const isLongitude = (lng) => {
 
 export const isCoordinate = (str) => {
   const coordinateRegexp =
-    /^-?(\d{1,2}|[1-8]\d|\d{1,2}\.\d{1,9}|[1-8]\d\.\d{1,9}|90(\.0{1,9})?)(\s|-|,\s?)-?(\d{1,2}|1[0-7]\d|\d{1,2}\.\d{1,9}|1[0-7]\d\.\d{1,9}|180(\.0{1,6})?)$/;
+    /^-?([1-8]?\d(\.\d{1,16})?|90(\.0{1,16})?)(,?\s?)-?((1?[0-7]|\d)?\d(\.\d{1,16})?|180(\.0{1,16})?)$/;
   return coordinateRegexp.test(str);
 };
 


### PR DESCRIPTION
# Description

[Shortcut story](https://app.shortcut.com/cartoteam/story/330496/support-pinea-geocode-by-lat-lon-in-builder-uses-lds-api-if-coordinate-pair-is-long)

The scope of this task would be to improve the regex we use to detect a coordinate pair on the search location widget:

- We are not supporting more than 9 decimal digits (for example, when we copy a coordinate from Google Maps, it is using ~15 decimal digits).
- We are allowing some invalid coordinates, like latitudes or longitudes out of range.

## Type of change

- Fix

# Acceptance

- Use a long coordinate pair on the search location widget:

![search-location](https://github.com/CartoDB/carto-react/assets/6042873/0bbcbb60-30ed-4126-a24a-dae6b9eb9cf0)

