### PR TITLE
Breaking change in SelectField component: simplification & MultipleSelectField split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Developer API change:
   - SelectField props removal: `items` no longer available, use a children instead.
-  - Changed to a controlled component. So now it need to handle onChange function in the parent.
+  - Changed to a controlled component. So now it needs to handle onChange function in the parent.
   - For multiple selection, now use MultipleSelectField.
 - Breaking change in SelectField component: simplification & MultipleSelectField split [#743](https://github.com/CartoDB/carto-react/pull/743)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Not released
 
+- Developer API change:
+  - SelectField props removal: `items` no longer available, use a children instead.
+  - Changed to a controlled component. So now it need to handle onChange function in the parent.
+  - For multiple selection, now use MultipleSelectField.
+- Breaking change in SelectField component: simplification & MultipleSelectField split [#743](https://github.com/CartoDB/carto-react/pull/743)
+
 ## 2.1
 
 ## 2.1.8 (2023-07-07)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -213,7 +213,7 @@ For external use: `import { PasswordField } from '@carto/react-ui';`.
 
 ### SelectField
 
-This component add the `placeholder` logic on top of TextField Mui component.
+This component adds the `placeholder` logic on top of TextField Mui component.
 
 Instead of `<TextField select /> ` or `<Select />` you should use:
 `react-ui/src/components/atoms/SelectField`
@@ -222,7 +222,7 @@ For external use: `import { SelectField } from '@carto/react-ui';`.
 
 ### MultipleSelectField
 
-This component add the `multiple selection` logic on top of SelectField component.
+This component adds the `multiple selection` logic on top of SelectField component.
 
 Instead of `<Select multiple /> ` you should use:
 `react-ui/src/components/atoms/MultipleSelectField`

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -213,12 +213,21 @@ For external use: `import { PasswordField } from '@carto/react-ui';`.
 
 ### SelectField
 
-This component add the `placeholder` and `multiple selection` logic on top of TextField Mui component.
+This component add the `placeholder` logic on top of TextField Mui component.
 
 Instead of `<TextField select /> ` or `<Select />` you should use:
 `react-ui/src/components/atoms/SelectField`
 
 For external use: `import { SelectField } from '@carto/react-ui';`.
+
+### MultipleSelectField
+
+This component add the `multiple selection` logic on top of SelectField component.
+
+Instead of `<Select multiple /> ` you should use:
+`react-ui/src/components/atoms/MultipleSelectField`
+
+For external use: `import { MultipleSelectField } from '@carto/react-ui';`.
 
 ### UploadField
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
   "version": "2.1.8"

--- a/packages/react-ui/src/components/atoms/MultipleSelectField.d.ts
+++ b/packages/react-ui/src/components/atoms/MultipleSelectField.d.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+import { SelectFieldProps } from './SelectField';
+
+type MultipleSelectFieldItem = {
+  label: string | React.ReactNode;
+  value: string | number;
+};
+
+export type MultipleSelectFieldProps = SelectFieldProps & {
+  items: MultipleSelectFieldItem[];
+  itemChecked: Boolean[];
+};
+
+declare const MultipleSelectField: (props: MultipleSelectFieldProps) => JSX.Element;
+export default MultipleSelectField;

--- a/packages/react-ui/src/components/atoms/MultipleSelectField.js
+++ b/packages/react-ui/src/components/atoms/MultipleSelectField.js
@@ -66,8 +66,7 @@ const MultipleSelectField = forwardRef(
 );
 
 MultipleSelectField.defaultProps = {
-  size: 'small',
-  itemChecked: false
+  size: 'small'
 };
 
 MultipleSelectField.propTypes = {

--- a/packages/react-ui/src/components/atoms/MultipleSelectField.js
+++ b/packages/react-ui/src/components/atoms/MultipleSelectField.js
@@ -1,0 +1,83 @@
+import React, { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+import { Box, Checkbox, MenuItem, styled } from '@mui/material';
+import SelectField from './SelectField';
+import Typography from './Typography';
+
+const BoxContent = styled(Box)({
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis'
+});
+
+const MultipleSelectField = forwardRef(
+  ({ items, size, placeholder, counter, itemChecked, ...otherProps }, ref) => {
+    // forwardRef needed to be able to hold a reference, in this way it can be a child for some Mui components, like Tooltip
+    // https://mui.com/material-ui/guides/composition/#caveat-with-refs
+
+    const isSmall = size === 'small';
+    const paddingSize = isSmall ? 1.5 : 2;
+
+    return (
+      <SelectField
+        {...otherProps}
+        ref={ref}
+        multiple
+        placeholder={placeholder}
+        customRenderValue={(selected) => {
+          if (selected.length === 0) {
+            return (
+              <Typography
+                variant={isSmall ? 'body2' : 'body1'}
+                color='text.hint'
+                component='span'
+                noWrap
+                ml={paddingSize}
+              >
+                {placeholder}
+              </Typography>
+            );
+          }
+          return (
+            <BoxContent ml={paddingSize}>
+              {selected.map((value, index) => (
+                <Typography
+                  key={index}
+                  variant={isSmall ? 'body2' : 'body1'}
+                  component='span'
+                >
+                  {items.find((item) => item.value === value).label}
+                  {', '}
+                </Typography>
+              ))}
+            </BoxContent>
+          );
+        }}
+      >
+        {items.map((item, index) => (
+          <MenuItem key={index} value={item.value}>
+            <Checkbox checked={itemChecked[index]} size='small' />
+            {item.label}
+          </MenuItem>
+        ))}
+      </SelectField>
+    );
+  }
+);
+
+MultipleSelectField.defaultProps = {
+  size: 'small',
+  itemChecked: false
+};
+
+MultipleSelectField.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+      value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
+    })
+  ).isRequired,
+  itemChecked: PropTypes.arrayOf(PropTypes.bool).isRequired
+};
+
+export default MultipleSelectField;

--- a/packages/react-ui/src/components/atoms/MultipleSelectField.js
+++ b/packages/react-ui/src/components/atoms/MultipleSelectField.js
@@ -18,41 +18,47 @@ const MultipleSelectField = forwardRef(
     const isSmall = size === 'small';
     const paddingSize = isSmall ? 1.5 : 2;
 
+    const renderValue = React.useCallback(
+      (selected) => {
+        if (selected.length === 0) {
+          return (
+            <Typography
+              variant={isSmall ? 'body2' : 'body1'}
+              color='text.hint'
+              component='span'
+              noWrap
+              ml={paddingSize}
+            >
+              {placeholder}
+            </Typography>
+          );
+        }
+
+        return (
+          <BoxContent ml={paddingSize}>
+            {selected.map((value, index) => (
+              <Typography
+                key={index}
+                variant={isSmall ? 'body2' : 'body1'}
+                component='span'
+              >
+                {items.find((item) => item.value === value).label}
+                {selected.length > 1 && ', '}
+              </Typography>
+            ))}
+          </BoxContent>
+        );
+      },
+      [paddingSize, isSmall, placeholder, items]
+    );
+
     return (
       <SelectField
         {...otherProps}
         ref={ref}
         multiple
         placeholder={placeholder}
-        customRenderValue={(selected) => {
-          if (selected.length === 0) {
-            return (
-              <Typography
-                variant={isSmall ? 'body2' : 'body1'}
-                color='text.hint'
-                component='span'
-                noWrap
-                ml={paddingSize}
-              >
-                {placeholder}
-              </Typography>
-            );
-          }
-          return (
-            <BoxContent ml={paddingSize}>
-              {selected.map((value, index) => (
-                <Typography
-                  key={index}
-                  variant={isSmall ? 'body2' : 'body1'}
-                  component='span'
-                >
-                  {items.find((item) => item.value === value).label}
-                  {', '}
-                </Typography>
-              ))}
-            </BoxContent>
-          );
-        }}
+        renderValue={renderValue}
       >
         {items.map((item, index) => (
           <MenuItem key={index} value={item.value}>

--- a/packages/react-ui/src/components/atoms/SelectField.d.ts
+++ b/packages/react-ui/src/components/atoms/SelectField.d.ts
@@ -5,7 +5,6 @@ import React from 'react';
 
 export type SelectFieldProps = Omit<TextFieldProps, 'placeholder'> &
   Omit<SelectProps, 'placeholder'> & {
-    children?: React.ReactNode;
     placeholder?: React.ReactNode;
     size?: 'small' | 'medium';
     customSelectProps?: Partial<SelectProps<unknown>>;

--- a/packages/react-ui/src/components/atoms/SelectField.d.ts
+++ b/packages/react-ui/src/components/atoms/SelectField.d.ts
@@ -1,16 +1,17 @@
+import { MenuProps } from '@mui/material';
+import { SelectChangeEvent, SelectProps } from '@mui/material/Select';
 import { TextFieldProps } from '@mui/material/TextField';
+import React from 'react';
 
-type SelectFieldItem = {
-  label: string;
-  value: string | number;
-};
-
-export type SelectFieldProps = Omit<TextFieldProps, 'placeholder'> & {
-  items: SelectFieldItem[];
-  multiple?: boolean;
-  placeholder?: React.ReactNode;
-  size?: 'small' | 'medium';
-};
+export type SelectFieldProps = Omit<TextFieldProps, 'placeholder'> &
+  Omit<SelectProps, 'placeholder'> & {
+    children?: React.ReactNode;
+    placeholder?: React.ReactNode;
+    size?: 'small' | 'medium';
+    customSelectProps?: Partial<SelectProps<unknown>>;
+    customRenderValue?: (value: string[]) => React.ReactNode;
+    customMenuProps?: Partial<MenuProps>;
+  };
 
 declare const SelectField: (props: SelectFieldProps) => JSX.Element;
 export default SelectField;

--- a/packages/react-ui/src/components/atoms/SelectField.d.ts
+++ b/packages/react-ui/src/components/atoms/SelectField.d.ts
@@ -1,5 +1,5 @@
 import { MenuProps } from '@mui/material';
-import { SelectChangeEvent, SelectProps } from '@mui/material/Select';
+import { SelectProps } from '@mui/material/Select';
 import { TextFieldProps } from '@mui/material/TextField';
 import React from 'react';
 

--- a/packages/react-ui/src/components/atoms/SelectField.d.ts
+++ b/packages/react-ui/src/components/atoms/SelectField.d.ts
@@ -7,9 +7,9 @@ export type SelectFieldProps = Omit<TextFieldProps, 'placeholder'> &
   Omit<SelectProps, 'placeholder'> & {
     placeholder?: React.ReactNode;
     size?: 'small' | 'medium';
-    customSelectProps?: Partial<SelectProps<unknown>>;
-    customRenderValue?: (value: string[]) => React.ReactNode;
-    customMenuProps?: Partial<MenuProps>;
+    selectProps?: Partial<SelectProps<unknown>>;
+    renderValue?: (value: string[]) => React.ReactNode;
+    menuProps?: Partial<MenuProps>;
   };
 
 declare const SelectField: (props: SelectFieldProps) => JSX.Element;

--- a/packages/react-ui/src/components/atoms/SelectField.js
+++ b/packages/react-ui/src/components/atoms/SelectField.js
@@ -79,7 +79,6 @@ SelectField.defaultProps = {
   size: 'small'
 };
 SelectField.propTypes = {
-  children: PropTypes.node,
   placeholder: PropTypes.string,
   size: PropTypes.oneOf(['small', 'medium']),
   customSelectProps: PropTypes.object,

--- a/packages/react-ui/src/components/atoms/SelectField.js
+++ b/packages/react-ui/src/components/atoms/SelectField.js
@@ -12,9 +12,9 @@ const SelectField = forwardRef(
       size,
       multiple,
       displayEmpty,
-      customSelectProps,
-      customRenderValue,
-      customMenuProps,
+      selectProps,
+      renderValue,
+      menuProps,
       ...otherProps
     },
     ref
@@ -23,6 +23,25 @@ const SelectField = forwardRef(
     // https://mui.com/material-ui/guides/composition/#caveat-with-refs
 
     const isSmall = size === 'small';
+
+    const defaultRenderValue = React.useCallback(
+      (selected) => {
+        if (selected.length === 0) {
+          return (
+            <Typography
+              variant={isSmall ? 'body2' : 'body1'}
+              color='text.hint'
+              component='span'
+              noWrap
+            >
+              {placeholder}
+            </Typography>
+          );
+        }
+        return selected.join(', ');
+      },
+      [isSmall, placeholder]
+    );
 
     return (
       <TextField
@@ -33,29 +52,13 @@ const SelectField = forwardRef(
         size={size}
         placeholder={placeholder}
         SelectProps={{
-          ...customSelectProps,
+          ...selectProps,
           multiple: multiple,
           displayEmpty: displayEmpty || !!placeholder,
           size: size,
-          renderValue:
-            customRenderValue ||
-            ((selected) => {
-              if (selected.length === 0) {
-                return (
-                  <Typography
-                    variant={isSmall ? 'body2' : 'body1'}
-                    color='text.hint'
-                    component='span'
-                    noWrap
-                  >
-                    {placeholder}
-                  </Typography>
-                );
-              }
-              return selected.join(', ');
-            }),
+          renderValue: renderValue || defaultRenderValue,
           MenuProps: {
-            ...customMenuProps,
+            ...menuProps,
             anchorOrigin: {
               vertical: 'bottom',
               horizontal: 'left'
@@ -81,9 +84,9 @@ SelectField.defaultProps = {
 SelectField.propTypes = {
   placeholder: PropTypes.string,
   size: PropTypes.oneOf(['small', 'medium']),
-  customSelectProps: PropTypes.object,
-  customRenderValue: PropTypes.func,
-  customMenuProps: PropTypes.object
+  selectProps: PropTypes.object,
+  renderValue: PropTypes.func,
+  menuProps: PropTypes.object
 };
 
 export default SelectField;

--- a/packages/react-ui/src/components/atoms/SelectField.js
+++ b/packages/react-ui/src/components/atoms/SelectField.js
@@ -1,77 +1,61 @@
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import { Box, Checkbox, MenuItem, TextField } from '@mui/material';
-import { styled } from '@mui/material/styles';
-
+import { MenuItem, TextField } from '@mui/material';
 import Typography from './Typography';
 
-const BoxContent = styled(Box)({
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis'
-});
-
 const SelectField = forwardRef(
-  ({ placeholder, items, multiple, size, ...otherProps }, ref) => {
+  (
+    {
+      children,
+      onChange,
+      placeholder,
+      size,
+      multiple,
+      displayEmpty,
+      customSelectProps,
+      customRenderValue,
+      customMenuProps,
+      ...otherProps
+    },
+    ref
+  ) => {
     // forwardRef needed to be able to hold a reference, in this way it can be a child for some Mui components, like Tooltip
     // https://mui.com/material-ui/guides/composition/#caveat-with-refs
-    const [content, setContent] = useState([]);
-
-    const handleChange = (event) => {
-      const {
-        target: { value }
-      } = event;
-      setContent(
-        // On autofill we get a stringified value
-        typeof value === 'string' ? value.split(',') : value
-      );
-    };
 
     const isSmall = size === 'small';
-    const paddingSize = isSmall ? 1.5 : 2;
 
     return (
       <TextField
         {...otherProps}
         select
+        onChange={onChange}
         ref={ref}
-        value={content}
-        onChange={handleChange}
         size={size}
+        placeholder={placeholder}
         SelectProps={{
+          ...customSelectProps,
           multiple: multiple,
-          displayEmpty: !!placeholder,
+          displayEmpty: displayEmpty || !!placeholder,
           size: size,
-          renderValue: (selected) => {
-            if (selected.length === 0) {
-              return (
-                <BoxContent ml={multiple && paddingSize}>
+          renderValue:
+            customRenderValue ||
+            ((selected) => {
+              if (selected.length === 0) {
+                return (
                   <Typography
                     variant={isSmall ? 'body2' : 'body1'}
                     color='text.hint'
                     component='span'
+                    noWrap
                   >
                     {placeholder}
                   </Typography>
-                </BoxContent>
-              );
-            }
-            return (
-              <BoxContent ml={multiple && paddingSize}>
-                {selected.map((value, index) => (
-                  <Typography
-                    key={index}
-                    variant={isSmall ? 'body2' : 'body1'}
-                    component='span'
-                  >
-                    {items.find((item) => item.value === value).label}
-                    {multiple && ', '}
-                  </Typography>
-                ))}
-              </BoxContent>
-            );
-          },
+                );
+              }
+              return selected.join(', ');
+            }),
           MenuProps: {
+            ...customMenuProps,
             anchorOrigin: {
               vertical: 'bottom',
               horizontal: 'left'
@@ -84,14 +68,7 @@ const SelectField = forwardRef(
         }}
       >
         <MenuItem key='empty' disabled value={''}></MenuItem>
-        {items.map((item, index) => (
-          <MenuItem key={index} value={item.value}>
-            {multiple && (
-              <Checkbox checked={content.indexOf(item.value) > -1} size='small' />
-            )}
-            {item.label}
-          </MenuItem>
-        ))}
+        {children}
       </TextField>
     );
   }
@@ -102,15 +79,12 @@ SelectField.defaultProps = {
   size: 'small'
 };
 SelectField.propTypes = {
-  items: PropTypes.arrayOf(
-    PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
-    })
-  ).isRequired,
-  placeholder: PropTypes.string.isRequired,
-  multiple: PropTypes.bool,
-  size: PropTypes.oneOf(['small', 'medium'])
+  children: PropTypes.node,
+  placeholder: PropTypes.string,
+  size: PropTypes.oneOf(['small', 'medium']),
+  customSelectProps: PropTypes.object,
+  customRenderValue: PropTypes.func,
+  customMenuProps: PropTypes.object
 };
 
 export default SelectField;

--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -30,6 +30,9 @@ export const dataDisplayOverrides = {
   MuiList: {
     styleOverrides: {
       root: ({ theme }) => ({
+        maxHeight: theme.spacing(39), // 312px, defined by design
+        overflowY: 'auto',
+
         // Indent sublevels, ugly but needed to avoid issues with hover
         '& .MuiList-root': {
           '& .MuiListItem-root': {

--- a/packages/react-ui/storybook/stories/atoms/MiltipleSelectField.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/MiltipleSelectField.stories.js
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import MultipleSelectField from '../../../src/components/atoms/MultipleSelectField';
+
+const options = {
+  title: 'Atoms/Multiple Select Field',
+  component: MultipleSelectField,
+  argTypes: {
+    variant: {
+      control: {
+        type: 'select',
+        options: ['outlined', 'filled', 'standard']
+      }
+    },
+    size: {
+      control: {
+        type: 'select',
+        options: ['small', 'medium']
+      }
+    },
+    required: {
+      defaultValue: false,
+      control: {
+        type: 'boolean'
+      }
+    },
+    disabled: {
+      defaultValue: false,
+      control: {
+        type: 'boolean'
+      }
+    },
+    error: {
+      defaultValue: false,
+      control: {
+        type: 'boolean'
+      }
+    },
+    label: {
+      control: {
+        type: 'text'
+      }
+    },
+    placeholder: {
+      control: {
+        type: 'text'
+      }
+    }
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/nmaoLeo69xBJCHm9nc6lEV/CARTO-Components-1.0?node-id=1534%3A29965'
+    },
+    status: {
+      type: 'validated'
+    }
+  }
+};
+export default options;
+
+const menuItems = [
+  {
+    label: 'table_openstreetmap_pointsofinterest',
+    value: '10Long'
+  },
+  {
+    label: 'Twenty',
+    value: '20'
+  },
+  {
+    label: 'Thirty',
+    value: '30'
+  },
+  {
+    label: 'Forty',
+    value: '40'
+  },
+  {
+    label: 'Fifty',
+    value: '50'
+  }
+];
+
+const PlaygroundTemplate = ({ label, placeholder, ...rest }) => {
+  const [content, setContent] = useState([]);
+
+  const handleChange = (event) => {
+    const {
+      target: { value }
+    } = event;
+    setContent(
+      // On autofill we get a stringified value
+      typeof value === 'string' ? value.split(',') : value
+    );
+  };
+
+  const isItemSelected = menuItems.map((item) => content.includes(item.value));
+
+  return (
+    <MultipleSelectField
+      {...rest}
+      label={label}
+      placeholder={placeholder}
+      items={menuItems}
+      onChange={handleChange}
+      value={content}
+      itemChecked={isItemSelected}
+    />
+  );
+};
+
+const commonArgs = {
+  label: 'Label text',
+  placeholder: 'Placeholder text',
+  helperText: 'Helper text.'
+};
+
+export const Playground = PlaygroundTemplate.bind({});
+Playground.args = { ...commonArgs };
+
+export const Counter = PlaygroundTemplate.bind({});
+Counter.args = { ...commonArgs, counter: true };

--- a/packages/react-ui/storybook/stories/atoms/SelectField.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/SelectField.stories.js
@@ -1,16 +1,5 @@
 import React, { useState } from 'react';
-import {
-  Box,
-  Chip,
-  FormControl,
-  Grid,
-  InputLabel,
-  MenuItem,
-  OutlinedInput,
-  Select,
-  TextField,
-  styled
-} from '@mui/material';
+import { FormControl, Grid, InputLabel, Link, MenuItem, TextField } from '@mui/material';
 import Typography from '../../../src/components/atoms/Typography';
 import SelectField from '../../../src/components/atoms/SelectField';
 import { Container, Label } from '../../utils/storyStyles';
@@ -72,16 +61,6 @@ const options = {
 };
 export default options;
 
-const ChipWrapper = styled(Box, {
-  shouldForwardProp: (prop) => prop !== 'small'
-})(({ theme, small }) => ({
-  display: 'flex',
-  flexWrap: 'wrap',
-  gap: theme.spacing(1),
-  overflow: 'auto',
-  height: theme.spacing(small ? 3 : 4)
-}));
-
 const menuItems = [
   {
     label: 'Ten: super large text with overflow',
@@ -112,7 +91,63 @@ const menuItemsLong = [
   }
 ];
 
-const PlaygroundTemplate = (args) => <SelectField {...args} items={menuItems} />;
+const SelectFieldItem = ({
+  label,
+  required,
+  placeholder,
+  variant,
+  helperText,
+  size,
+  focused,
+  disabled,
+  error,
+  ...rest
+}) => {
+  const [content, setContent] = useState([]);
+
+  const handleChange = (event) => {
+    const {
+      target: { value }
+    } = event;
+    setContent(
+      // On autofill we get a stringified value
+      typeof value === 'string' ? value.split(',') : value
+    );
+  };
+
+  return (
+    <SelectField
+      {...rest}
+      label={label}
+      variant={variant}
+      placeholder={placeholder}
+      items={menuItems}
+      helperText={helperText}
+      onChange={handleChange}
+      value={content}
+      focused={focused}
+      disabled={disabled}
+      error={error}
+      size={size}
+      fullWidth={rest.fullWidth}
+    >
+      {[...Array(20)].map((item, index) => {
+        const itemText =
+          index === 1
+            ? `Very long item text with overflow ${index + 1}`
+            : `Item ${index + 1}`;
+
+        return (
+          <MenuItem key={index} value={itemText}>
+            {itemText}
+          </MenuItem>
+        );
+      })}
+    </SelectField>
+  );
+};
+
+const PlaygroundTemplate = (args) => <SelectFieldItem {...args} />;
 
 const VariantsTemplate = ({ label, required, placeholder, ...rest }) => {
   return (
@@ -120,7 +155,7 @@ const VariantsTemplate = ({ label, required, placeholder, ...rest }) => {
       <Grid item>
         <Container>
           <Label variant='body2'>{'Filled'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             variant='filled'
@@ -132,7 +167,7 @@ const VariantsTemplate = ({ label, required, placeholder, ...rest }) => {
       <Grid item>
         <Container>
           <Label variant='body2'>{'Outlined'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             variant='outlined'
@@ -144,7 +179,7 @@ const VariantsTemplate = ({ label, required, placeholder, ...rest }) => {
       <Grid item>
         <Container>
           <Label variant='body2'>{'Standard'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             variant='standard'
@@ -163,7 +198,7 @@ const LabelAndHelperTextTemplate = ({ label, placeholder, helperText, ...rest })
       <Grid item>
         <Container>
           <Label variant='body2'>{'Label + helper text'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             placeholder={placeholder}
@@ -175,13 +210,13 @@ const LabelAndHelperTextTemplate = ({ label, placeholder, helperText, ...rest })
       <Grid item>
         <Container>
           <Label variant='body2'>{'Without label + helper text'}</Label>
-          <SelectField {...rest} placeholder={placeholder} items={menuItems} />
+          <SelectFieldItem {...rest} placeholder={placeholder} items={menuItems} />
         </Container>
       </Grid>
       <Grid item>
         <Container>
           <Label variant='body2'>{'Only label'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             placeholder={placeholder}
@@ -192,7 +227,7 @@ const LabelAndHelperTextTemplate = ({ label, placeholder, helperText, ...rest })
       <Grid item>
         <Container>
           <Label variant='body2'>{'Only helper text'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             placeholder={placeholder}
             helperText={helperText}
@@ -213,7 +248,7 @@ const SizeTemplate = ({
   ...rest
 }) => {
   const [fixedValue, setFixedValue] = useState('Twenty');
-  const [fixedValue2, setFixedValue2] = useState('Ten');
+  const [fixedValue2, setFixedValue2] = useState('Twenty');
   const [fixedValue3, setFixedValue3] = useState('Thirty');
   const handleChange = (event) => {
     setFixedValue(event.target.value);
@@ -233,7 +268,7 @@ const SizeTemplate = ({
           <Typography variant='body2'>Custom component</Typography>
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='filled'
             label={label}
@@ -243,7 +278,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='outlined'
             label={label}
@@ -253,7 +288,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='standard'
             label={label}
@@ -271,37 +306,19 @@ const SizeTemplate = ({
         <Grid item xs={3}>
           <FormControl>
             <InputLabel>{label}</InputLabel>
-            <Select {...rest} variant='filled' size={size}>
-              {menuItems.map((option) => (
-                <MenuItem key={option.label} value={option.label}>
-                  {option.label}
-                </MenuItem>
-              ))}
-            </Select>
+            <SelectFieldItem {...rest} variant='filled' size={size} items={menuItems} />
           </FormControl>
         </Grid>
         <Grid item xs={3}>
           <FormControl>
             <InputLabel>{label}</InputLabel>
-            <Select {...rest} variant='outlined' size={size}>
-              {menuItems.map((option) => (
-                <MenuItem key={option.label} value={option.label}>
-                  {option.label}
-                </MenuItem>
-              ))}
-            </Select>
+            <SelectFieldItem {...rest} variant='outlined' size={size} items={menuItems} />
           </FormControl>
         </Grid>
         <Grid item xs={3}>
           <FormControl>
             <InputLabel>{label}</InputLabel>
-            <Select {...rest} variant='standard' size={size}>
-              {menuItems.map((option) => (
-                <MenuItem key={option.label} value={option.label}>
-                  {option.label}
-                </MenuItem>
-              ))}
-            </Select>
+            <SelectFieldItem {...rest} variant='standard' size={size} items={menuItems} />
           </FormControl>
         </Grid>
       </Grid>
@@ -374,7 +391,7 @@ const SizeTemplate = ({
           <Typography>Focused</Typography>
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='filled'
             label={label}
@@ -385,7 +402,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='outlined'
             label={label}
@@ -396,7 +413,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='standard'
             label={label}
@@ -413,7 +430,7 @@ const SizeTemplate = ({
           <Typography>Disabled</Typography>
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='filled'
             label={label}
@@ -424,7 +441,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='outlined'
             label={label}
@@ -435,7 +452,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='standard'
             label={label}
@@ -452,7 +469,7 @@ const SizeTemplate = ({
           <Typography>Error</Typography>
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='filled'
             label={label}
@@ -464,7 +481,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='outlined'
             label={label}
@@ -476,7 +493,7 @@ const SizeTemplate = ({
           />
         </Grid>
         <Grid item xs={3}>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             variant='standard'
             label={label}
@@ -500,73 +517,14 @@ const MultipleTemplate = ({
   size,
   ...rest
 }) => {
-  const [personName, setPersonName] = React.useState([]);
-  const isSmall = size === 'small';
-
-  const handleChange = (event) => {
-    const {
-      target: { value }
-    } = event;
-    setPersonName(
-      // On autofill we get a stringified value.
-      typeof value === 'string' ? value.split(',') : value
-    );
-  };
-
   return (
-    <Grid container direction='column' spacing={6}>
-      <Grid item>
-        <Container>
-          <Label variant='body2'>{'Default (custom component)'}</Label>
-          <SelectField
-            {...rest}
-            multiple
-            size={size}
-            label={label}
-            placeholder={placeholder}
-            items={menuItems}
-          />
-        </Container>
-      </Grid>
-      <Grid item xs={3}>
-        <Container>
-          <Label variant='body2'>{'Select (with custom chips)'}</Label>
-          <Select
-            {...rest}
-            label={label}
-            size={size}
-            multiple
-            displayEmpty
-            value={personName}
-            onChange={handleChange}
-            input={<OutlinedInput id='select-multiple-chip' label='Chip' />}
-            renderValue={(selected) => {
-              if (selected.length === 0) {
-                return (
-                  <Typography variant={isSmall ? 'body2' : 'body1'} color='text.hint'>
-                    Placeholder
-                  </Typography>
-                );
-              }
-
-              return (
-                <ChipWrapper small={isSmall}>
-                  {selected.map((value) => (
-                    <Chip size={size} color='default' key={value} label={value} />
-                  ))}
-                </ChipWrapper>
-              );
-            }}
-          >
-            {[...Array(10)].map((x, index) => (
-              <MenuItem key={index} value={`Option item ${index + 1}`}>
-                {`Option item ${index + 1}`}
-              </MenuItem>
-            ))}
-          </Select>
-        </Container>
-      </Grid>
-    </Grid>
+    <Typography variant='subtitle1'>
+      Check{' '}
+      <Link href='/?path=/docs/atoms-multiple-select-field--playground'>
+        MultipleSelectField
+      </Link>{' '}
+      component documentation
+    </Typography>
   );
 };
 
@@ -577,7 +535,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
         <Label variant='subtitle1'>{'Overflow'}</Label>
         <Container style={{ maxWidth: '440px' }}>
           <Label variant='body2'>{'Default'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             placeholder={placeholder}
@@ -593,7 +551,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
 
           <Grid container spacing={2}>
             <Grid item>
-              <SelectField
+              <SelectFieldItem
                 {...rest}
                 label={label}
                 placeholder={placeholder}
@@ -601,7 +559,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
               />
             </Grid>
             <Grid item>
-              <SelectField
+              <SelectFieldItem
                 {...rest}
                 label={label}
                 placeholder={placeholder}
@@ -616,7 +574,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
         <Label variant='subtitle1'>{'Width'}</Label>
         <Container>
           <Label variant='body2'>{'Default (fullWidth)'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             placeholder={placeholder}
@@ -625,7 +583,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
         </Container>
         <Container>
           <Label variant='body2'>{'No fullWidth'}</Label>
-          <SelectField
+          <SelectFieldItem
             {...rest}
             label={label}
             placeholder={placeholder}
@@ -643,28 +601,33 @@ const commonArgs = {
   placeholder: 'Placeholder text',
   helperText: 'Helper text.'
 };
+
 const sizeArgs = {
   helperText: 'This is a error message.'
 };
 
-const disabledControlsVariantsArgTypes = {
-  variant: { table: { disable: true } }
-};
-const disabledControlsSizeArgTypes = {
+const disabledControlsArgTypes = {
   variant: { table: { disable: true } },
+  multiple: { table: { disable: true } }
+};
+
+const disabledControlsSizeArgTypes = {
+  ...disabledControlsArgTypes,
   error: { table: { disable: true } },
   defaultValue: { table: { disable: true } }
 };
 
 export const Playground = PlaygroundTemplate.bind({});
 Playground.args = { ...commonArgs };
+Playground.argTypes = disabledControlsArgTypes;
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = { ...commonArgs };
-Variants.argTypes = disabledControlsVariantsArgTypes;
+Variants.argTypes = disabledControlsArgTypes;
 
 export const LabelAndHelperText = LabelAndHelperTextTemplate.bind({});
 LabelAndHelperText.args = { ...commonArgs };
+LabelAndHelperText.argTypes = disabledControlsArgTypes;
 
 export const Medium = SizeTemplate.bind({});
 Medium.args = { ...commonArgs, ...sizeArgs, size: 'medium' };
@@ -676,6 +639,8 @@ Small.argTypes = disabledControlsSizeArgTypes;
 
 export const MultipleSelection = MultipleTemplate.bind({});
 MultipleSelection.args = { ...commonArgs };
+MultipleSelection.argTypes = disabledControlsArgTypes;
 
 export const Behavior = BehaviorTemplate.bind({});
 Behavior.args = { ...commonArgs };
+Behavior.argTypes = disabledControlsArgTypes;


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/303604/core-refactor-selectfield
[sc-303604]

Split functionality into two different components, one for multiple select, more restringed based on design specs.
The other one is a more generic select field with the addition of a placeholder.