### PR TITLE
Fix size of image placed inside a Chip 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix size of image placed inside a Chip [#744](https://github.com/CartoDB/carto-react/pull/744)
+
 ## 2.1
 
 ## 2.1.8 (2023-07-07)
@@ -54,7 +56,6 @@
 - Mask, when set, is applied to global widgets as well as to viewport-based widgets [#704](https://github.com/CartoDB/carto-react/pull/704)
 - Support for remote scatter plot widget [#704](https://github.com/CartoDB/carto-react/pull/704)
 - Breaking change for styles: sx / classname props removal [#715](https://github.com/CartoDB/carto-react/pull/715)
-- Fix size of image placed inside a Chip [#744](https://github.com/CartoDB/carto-react/pull/744)
 
 ## 2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Mask, when set, is applied to global widgets as well as to viewport-based widgets [#704](https://github.com/CartoDB/carto-react/pull/704)
 - Support for remote scatter plot widget [#704](https://github.com/CartoDB/carto-react/pull/704)
 - Breaking change for styles: sx / classname props removal [#715](https://github.com/CartoDB/carto-react/pull/715)
+- Fix size of image placed inside a Chip [#744](https://github.com/CartoDB/carto-react/pull/744)
 
 ## 2.0
 

--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -323,6 +323,7 @@ export const dataDisplayOverrides = {
 
         '& .MuiAvatar-root': {
           width: ICON_SIZE_LARGE,
+          minWidth: ICON_SIZE_LARGE,
           height: ICON_SIZE_LARGE,
           margin: 0,
           color: theme.palette.secondary.contrastText,
@@ -335,6 +336,7 @@ export const dataDisplayOverrides = {
         },
         '& img': {
           width: ICON_SIZE_LARGE,
+          minWidth: ICON_SIZE_LARGE,
           height: ICON_SIZE_LARGE
         },
         '&.Mui-disabled': {
@@ -395,10 +397,12 @@ export const dataDisplayOverrides = {
       sizeSmall: ({ theme }) => ({
         '& img': {
           width: ICON_SIZE_MEDIUM,
+          minWidth: ICON_SIZE_MEDIUM,
           height: ICON_SIZE_MEDIUM
         },
         '& .MuiAvatar-root': {
           width: ICON_SIZE_MEDIUM,
+          minWidth: ICON_SIZE_MEDIUM,
           height: ICON_SIZE_MEDIUM
         },
         '& .MuiChip-icon': {


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/332632/sharing-with-groups-avatar-on-chips-are-not-rounded
[sc-332632]

The image placed inside a chip is not displayed properly if there is not enough space, so we're making sure always it has the needed width.