### PR TITLE
Add click event to GoogleMap component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Not released
 
 - SelectField Storybook leftovers [#746](https://github.com/CartoDB/carto-react/pull/746)
-- Add onClick event handler to GoogleMap component [#XXX](https://github.com/CartoDB/carto-react/pull/XXX)
+- Add onClick event handler to GoogleMap component [#747](https://github.com/CartoDB/carto-react/pull/747)
 
 ## 2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Not released
 
 - SelectField Storybook leftovers [#746](https://github.com/CartoDB/carto-react/pull/746)
+- Add onClick event handler to GoogleMap component [#XXX](https://github.com/CartoDB/carto-react/pull/XXX)
 
 ## 2.2
 

--- a/packages/react-basemaps/src/basemaps/GoogleMap.js
+++ b/packages/react-basemaps/src/basemaps/GoogleMap.js
@@ -11,6 +11,7 @@ import { debounce } from '@carto/react-core';
  * @param { Object } props.viewState - Viewstate, as defined by deck.gl. Just center and zoom level are supported
  * @param { Layer[] } props.layers - deck.gl layers array
  * @param { function } props.getTooltip - (Optional) Tooltip handler
+ * @param { function } props.onClick - (Optional) onClick handler
  * @param { function } props.onResize - (Optional) onResize handler
  * @param { function } props.onViewStateChange - (Optional) onViewStateChange handler
  * @param { string } props.apiKey - Google Maps API Key
@@ -24,6 +25,7 @@ export function GoogleMap(props) {
     viewState,
     layers,
     getTooltip,
+    onClick,
     onResize,
     onViewStateChange,
     apiKey,
@@ -90,6 +92,9 @@ export function GoogleMap(props) {
 
       const handleViewportChangeDebounced = debounce(handleViewportChange, 200);
       map.addListener('bounds_changed', handleViewportChangeDebounced);
+      if (onClick) {
+        map.addListener('click', onClick);
+      }
       map.addListener('resize', () => {
         onResize &&
           onResize({


### PR DESCRIPTION
# Description

[Shortcut](https://app.shortcut.com/cartoteam/story/333679/decathlon-add-click-event-to-google-maps-component-in-c4r)

Propagate `onClick` event to `GoogleMap` component (already included for `DeckGLComponent`, but not available yet for Google basemaps).

## Type of change

- Feature

# Acceptance

- Add `onClick` property to `GoogleMap` component:

![Screenshot from 2023-07-21 12-00-31](https://github.com/CartoDB/carto-react/assets/6042873/354cbb6a-6988-418b-9c98-a28f437e9b00)

![click-event](https://github.com/CartoDB/carto-react/assets/6042873/0535f01d-f7ff-44ef-b08c-ef52456e24a0)
