### PR TITLE
Fix MuiList: add more specificity to apply max-height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Fix MuiList: add more specificity to apply max-height [#748](https://github.com/CartoDB/carto-react/pull/748)
 - SelectField Storybook leftovers [#746](https://github.com/CartoDB/carto-react/pull/746)
 
 ## 2.2

--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -30,8 +30,10 @@ export const dataDisplayOverrides = {
   MuiList: {
     styleOverrides: {
       root: ({ theme }) => ({
-        maxHeight: theme.spacing(39), // 312px, defined by design
-        overflowY: 'auto',
+        '.MuiPopover-root &, .MuiPopper-root &': {
+          maxHeight: theme.spacing(39), // 312px, defined by design
+          overflowY: 'auto'
+        },
 
         // Indent sublevels, ugly but needed to avoid issues with hover
         '& .MuiList-root': {


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/333771/muilist-add-more-specificity-to-apply-max-height
[sc-333771]

MuiList: add more specificity to apply max-height only when is inside a `poper` or `poppover`(dropdown cases).