### PR TITLE
Add storybook documentation and fix ComparativeCategoryWidgetUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Add storybook documentation and fix ComparativeCategoryWidgetUI [#755](https://github.com/CartoDB/carto-react/pull/755)
 - Improve responsive behavior of MenuItem [#753](https://github.com/CartoDB/carto-react/pull/753)
 - Increase documentation discoverability [#751](https://github.com/CartoDB/carto-react/pull/751)
 

--- a/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/ComparativeCategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/ComparativeCategoryWidgetUI.js
@@ -22,8 +22,9 @@ import {
   SearchInput,
   Toolbar,
   Wrapper,
-  CategoryItemStyled
+  CategoryItemWrapper
 } from './comparative.styled';
+import CategoryItem from './CategoryItem';
 
 const IDENTITY_FN = (v) => v;
 const EMPTY_ARRAY = [];
@@ -292,21 +293,23 @@ function ComparativeCategoryWidgetUI({
           </>
         ) : null}
         {list.map((d) => (
-          <CategoryItemStyled
-            key={d.key}
-            item={d}
-            animation={animation}
-            animationOptions={animationOptions}
-            maxValue={maxValue}
-            showCheckbox={filterable && searchActive}
-            checkboxChecked={tempSelection.indexOf(d.key) !== -1}
-            filterable={filterable}
-            formatter={formatter}
-            tooltipFormatter={tooltipFormatter}
-            tooltip={tooltip}
-            onClick={clickHandler}
-            names={names}
-          />
+          <CategoryItemWrapper>
+            <CategoryItem
+              key={d.key}
+              item={d}
+              animation={animation}
+              animationOptions={animationOptions}
+              maxValue={maxValue}
+              showCheckbox={filterable && searchActive}
+              checkboxChecked={tempSelection.indexOf(d.key) !== -1}
+              filterable={filterable}
+              formatter={formatter}
+              tooltipFormatter={tooltipFormatter}
+              tooltip={tooltip}
+              onClick={clickHandler}
+              names={names}
+            />
+          </CategoryItemWrapper>
         ))}
       </CategoriesList>
       {showSearchToggle ? (

--- a/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/comparative.styled.js
+++ b/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/comparative.styled.js
@@ -1,5 +1,4 @@
 import { Box, TextField, Tooltip, styled } from '@mui/material';
-import CategoryItem from './CategoryItem';
 
 export const Wrapper = styled('div')(({ theme }) => ({
   padding: theme.spacing(2, 0),
@@ -100,15 +99,16 @@ export const LabelWrapper = styled(Box)(() => ({
   justifyContent: 'space-between'
 }));
 
-export const CategoryItemStyled = styled(CategoryItem, {
+export const CategoryItemWrapper = styled('div', {
   shouldForwardProp: (prop) => prop !== 'filterable'
 })(({ theme, filterable }) => ({
   '& .progressbar div': {
     backgroundColor: 'var(--color)'
   },
-  ...(filterable && {
+  ...(!filterable && {
     cursor: 'pointer',
-    '&:hover .progressbar div': {
+
+    '& > .MuiBox-root:hover .progressbar div': {
       backgroundColor: 'var(--hover-color)'
     }
   })

--- a/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/comparative.styled.js
+++ b/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/comparative.styled.js
@@ -105,10 +105,10 @@ export const CategoryItemWrapper = styled('div', {
   '& .progressbar div': {
     backgroundColor: 'var(--color)'
   },
-  ...(!filterable && {
+  ...(filterable && {
     cursor: 'pointer',
 
-    '& > .MuiBox-root:hover .progressbar div': {
+    '& .MuiBox-root:hover .progressbar div': {
       backgroundColor: 'var(--hover-color)'
     }
   })

--- a/packages/react-ui/storybook/stories/atoms/LabelWithIndicatorGuide.stories.mdx
+++ b/packages/react-ui/storybook/stories/atoms/LabelWithIndicatorGuide.stories.mdx
@@ -1,0 +1,33 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title='Atoms/LabelWithIndicator/Guide' />
+
+# LabelWithIndicator
+
+Designers had the need to mark inputs as `optional` or `required` depending on the use case. That is, in some forms, we have the optional ones marked but in others the required ones.
+
+Mui only provides a `required` bool prop to mark an input as mandatory. When is true, add an asterisk at the end of the label and the validation logic.
+
+We removed the asterisk in the theme, and handle both, required and optional indicators, with this new component. So we can use the following:
+
+Required
+
+```
+<TextField
+  {...props}
+  label={<LabelWithIndicator label={label}  type='required' />}
+/>
+```
+
+Optional
+
+```
+<TextField
+  {...props}
+  label={<LabelWithIndicator label={label} />}
+/>
+```
+
+Use `<LabelWithIndicator /> ` from: `react-ui/src/components/atoms/Avatar`
+
+For external use: `import { LabelWithIndicator } from '@carto/react-ui';`.

--- a/packages/react-ui/storybook/stories/atoms/MiltipleSelectField.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/MiltipleSelectField.stories.js
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import MultipleSelectField from '../../../src/components/atoms/MultipleSelectField';
+import { DocContainer, DocHighlight, DocLink } from '../../utils/storyStyles';
+import Typography from '../../../src/components/atoms/Typography';
 
 const options = {
   title: 'Atoms/Multiple Select Field',
@@ -109,6 +111,28 @@ const PlaygroundTemplate = ({ label, placeholder, ...rest }) => {
   );
 };
 
+const DocTemplate = () => {
+  return (
+    <DocContainer severity='warning'>
+      This component adds the <i>multiple selection</i> logic on top of SelectField
+      component.
+      <Typography mt={2}>
+        So, instead of <i>{'<Select multiple />'}</i>, you should use this one:
+        <DocHighlight component='span'>
+          react-ui/src/components/atoms/MultipleSelectField
+        </DocHighlight>
+      </Typography>
+      <Typography mt={2}>
+        For external use:
+        <DocHighlight component='span'>
+          {'import { MultipleSelectField } from "@carto/react-ui";'}
+        </DocHighlight>
+        .
+      </Typography>
+    </DocContainer>
+  );
+};
+
 const commonArgs = {
   label: 'Label text',
   placeholder: 'Placeholder text',
@@ -117,6 +141,8 @@ const commonArgs = {
 
 export const Playground = PlaygroundTemplate.bind({});
 Playground.args = { ...commonArgs };
+
+export const Guide = DocTemplate.bind({});
 
 export const Counter = PlaygroundTemplate.bind({});
 Counter.args = { ...commonArgs, counter: true };

--- a/packages/react-ui/storybook/stories/atoms/SelectField.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/SelectField.stories.js
@@ -2,7 +2,13 @@ import React, { useState } from 'react';
 import { FormControl, Grid, InputLabel, MenuItem, TextField } from '@mui/material';
 import Typography from '../../../src/components/atoms/Typography';
 import SelectField from '../../../src/components/atoms/SelectField';
-import { Container, DocContainer, DocLink, Label } from '../../utils/storyStyles';
+import {
+  Container,
+  DocContainer,
+  DocHighlight,
+  DocLink,
+  Label
+} from '../../utils/storyStyles';
 import Button from '../../../src/components/atoms/Button';
 
 const options = {
@@ -546,6 +552,28 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
   );
 };
 
+const DocTemplate = () => {
+  return (
+    <DocContainer severity='warning'>
+      This component adds the <i>placeholder</i> logic on top of TextField Mui component.
+      <Typography mt={2}>
+        So, instead of <i>{'<TextField select />'}</i> or <i>{'<Select />'}</i>, you
+        should use this one:
+        <DocHighlight component='span'>
+          react-ui/src/components/atoms/SelectField
+        </DocHighlight>
+      </Typography>
+      <Typography mt={2}>
+        For external use:
+        <DocHighlight component='span'>
+          {'import { SelectField } from "@carto/react-ui";'}
+        </DocHighlight>
+        .
+      </Typography>
+    </DocContainer>
+  );
+};
+
 const commonArgs = {
   label: 'Label text',
   placeholder: 'Placeholder text',
@@ -570,6 +598,8 @@ const disabledControlsSizeArgTypes = {
 export const Playground = PlaygroundTemplate.bind({});
 Playground.args = { ...commonArgs };
 Playground.argTypes = disabledControlsArgTypes;
+
+export const Guide = DocTemplate.bind({});
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = { ...commonArgs };

--- a/packages/react-ui/storybook/stories/icons/AddNewIcons.stories.mdx
+++ b/packages/react-ui/storybook/stories/icons/AddNewIcons.stories.mdx
@@ -1,0 +1,64 @@
+import { Meta, Description } from '@storybook/addon-docs';
+
+<Meta title='Icons/AddNewIcons' />
+
+# Adding a new icon
+
+Before you start, make sure that:
+
+- Icons that you want to add are not already in our repository.
+
+## Rules for Icons
+
+- Use icons from [Mui library](https://mui.com/material-ui/material-icons/) package instead of download them when possible.
+- Ensure you download the icon directly from the [Figma icon library](https://www.figma.com/file/Yj97O00yGzMg1ULcA0WEfl/CARTO-Icons)
+- Download it at `24x24px`
+- Open the SVG file and...
+  - Change the fill property of every `<path>` property from its harcoded color to `fill="currentColor"`
+  - Remove the general `fill-opacity` property if exists, but not the ones on path layers.
+- Place it at `src/assets/icons`
+- Add it as a js component as the example below.
+- Name the exported asset/component to the same name it has in Figma.
+
+Note, 24x24 is s general rule. [Ideogram icons](https://www.figma.com/file/Yj97O00yGzMg1ULcA0WEfl/CARTO-Icons?type=design&node-id=9225-2137&mode=design&t=C0uiWZl7YrbbfzEq-0) are at 48x48 and it’s ok to add them at this size.
+
+## Figma considerations
+
+To distinguish between custom and Mui cions, note that the name of a custom SVG icon must start with `custom_` prefix in Figma. Otherwise, it's a MUI5 icon (`MUI_` prefix).
+
+If you have an assets with different `alphas` of the same color, they normally use opacity levels to get that. So `currentColor` should works too in those cases, but please check it.
+
+Note: that `fill="#EB7F86"` color correspond to `palette/replace`, a placeholder color, not intended to be in the palette, just to display the icons in the library.
+
+## Files optimization
+
+The build does not optimize assets, so it is necessary to run optimize assets manually:
+
+- \*.svg: CLI tool [SVGO](https://www.npmjs.com/package/svgo).
+- \*.png|jpeg|jpg|fig: online tool [Optimizilla](https://imagecompressor.com/).
+
+While using `SVGO`, you should disable `removeViewBox`, as in most cases it breaks the layout of the icon.
+
+You have to validate manually that the icon is not broken after optimization.
+
+## Example
+
+```js
+import React from 'react';
+import { SvgIcon } from '@mui/material';
+
+export default function ArrowDropIcon(props) {
+  return (
+    <SvgIcon {...props}>
+      <path
+        fillRule='evenodd'
+        clipRule='evenodd'
+        d='M12.5 12.17L9.32998 9L7.91998 10.41L12.5 15L17.09 10.41L15.67 9L12.5 12.17Z'
+        fill='currentColor'
+      />
+    </SvgIcon>
+  );
+}
+```
+
+You have more info in the [Figma guide](https://www.figma.com/proto/12e7boz39jWiytTnjN674G/Ways-of-working-%2F-298130?page-id=1%3A2&node-id=26-5183&viewport=622%2C338%2C0.09&scaling=scale-down).

--- a/packages/react-ui/storybook/stories/icons/Introduction.stories.mdx
+++ b/packages/react-ui/storybook/stories/icons/Introduction.stories.mdx
@@ -36,47 +36,6 @@ Material icons are imported directly from `@mui/icons-material` library, `custom
   </a>
 </div>
 
-## Adding a new icon
-
-Before you start, make sure that:
-
-- Icons that you want to add are not already in our repository.
-
-Then:
-
-- Every icon must comply with our [icon rules](#rules-for-icons)
-- Ensure you download the icon directly from the Figma icon library
-- Place it at `src/assets/icons`
-- Add it as a js component as the example below.
-- Name the exported asset to the same name it has in the library
-- You have more info in the [Figma guide](https://www.figma.com/proto/12e7boz39jWiytTnjN674G/Ways-of-working-%2F-298130?page-id=1%3A2&node-id=26-5183&viewport=622%2C338%2C0.09&scaling=scale-down).
-
-### Rules for Icons
-
-- Download it at 24x24 px from [icons library](https://www.figma.com/file/Yj97O00yGzMg1ULcA0WEfl/CARTO-Icons)
-- fill = currentColor
-- Use them from [Mui library](https://mui.com/material-ui/material-icons/) when possible
-
-### Example
-
-```js
-import React from 'react';
-import { SvgIcon } from '@mui/material';
-
-export default function ArrowDropIcon(props) {
-  return (
-    <SvgIcon {...props}>
-      <path
-        fillRule='evenodd'
-        clipRule='evenodd'
-        d='M12.5 12.17L9.32998 9L7.91998 10.41L12.5 15L17.09 10.41L15.67 9L12.5 12.17Z'
-        fill='currentColor'
-      />
-    </SvgIcon>
-  );
-}
-```
-
 ## Using icons
 
 ### Colors
@@ -93,8 +52,8 @@ In case you don't need the icon to be filled, you can apply this class to the sv
 
 We have 3 defined sizes that can be added with the `fontSize` prop of `SvgIcon` component.
 
-- small
-- medium (default)
-- large
+- small: `12px`
+- medium (default): `18px`
+- large: `24px`
 
-Note: the most common use case is to have the icons at medium size (`18px`), there is only a few exceptions where they use other sizes.
+Note: the most common use case is to have the icons at `medium size`, there is only a few exceptions where they use other sizes.

--- a/packages/react-ui/storybook/stories/molecules/Avatar.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/Avatar.stories.js
@@ -313,7 +313,7 @@ const ColorBackgroundTemplate = ({ ...args }) => {
   return (
     <>
       <DocContainer severity='warning'>
-        We have a color function to automatically get the color for each item, it is{' '}
+        We have a color function to automatically get the color for each item, it is
         <DocHighlight component='span'>getCartoColorStylePropsForItem</DocHighlight>. It
         uses <DocHighlight component='span'>qualitativeBold</DocHighlight> CARTO colors.
         <Typography mt={2}>Check the code to se an example of how to use it.</Typography>

--- a/packages/react-ui/storybook/stories/molecules/Avatar.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/Avatar.stories.js
@@ -311,25 +311,33 @@ const ColorBackgroundTemplate = ({ ...args }) => {
   const theme = useTheme();
 
   return (
-    <Grid container direction='column' spacing={3}>
-      <Grid item>
-        <BoxContent>
-          <TitleContent variant='body2'>{'Carto qualitative bold'}</TitleContent>
-          <Grid container item spacing={6}>
-            {[...Array(15)].map((x, index) => (
-              <Grid item key={index}>
-                <Avatar
-                  {...args}
-                  style={{
-                    ...getCartoColorStylePropsForItem(theme, index)
-                  }}
-                >{`${index + 1}`}</Avatar>
-              </Grid>
-            ))}
-          </Grid>
-        </BoxContent>
+    <>
+      <DocContainer severity='warning'>
+        We have a color function to automatically get the color for each item, it is{' '}
+        <DocHighlight component='span'>getCartoColorStylePropsForItem</DocHighlight>. It
+        uses <DocHighlight component='span'>qualitativeBold</DocHighlight> CARTO colors.
+        <Typography mt={2}>Check the code to se an example of how to use it.</Typography>
+      </DocContainer>
+      <Grid container direction='column' spacing={3}>
+        <Grid item>
+          <BoxContent>
+            <TitleContent variant='body2'>{'Carto qualitative bold'}</TitleContent>
+            <Grid container item spacing={6}>
+              {[...Array(15)].map((x, index) => (
+                <Grid item key={index}>
+                  <Avatar
+                    {...args}
+                    style={{
+                      ...getCartoColorStylePropsForItem(theme, index)
+                    }}
+                  >{`${index + 1}`}</Avatar>
+                </Grid>
+              ))}
+            </Grid>
+          </BoxContent>
+        </Grid>
       </Grid>
-    </Grid>
+    </>
   );
 };
 

--- a/packages/react-ui/storybook/stories/molecules/UploadField.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/UploadField.stories.js
@@ -2,7 +2,7 @@ import { Grid } from '@mui/material';
 import React, { useState } from 'react';
 import Typography from '../../../src/components/atoms/Typography';
 import UploadField from '../../../src/components/molecules/UploadField/UploadField';
-import { Container, Label } from '../../utils/storyStyles';
+import { Container, DocContainer, DocHighlight, Label } from '../../utils/storyStyles';
 
 const options = {
   title: 'Molecules/UploadField',
@@ -397,6 +397,31 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
   );
 };
 
+const DocTemplate = () => {
+  return (
+    <DocContainer severity='warning'>
+      This component is used to display and input <i>{`type='file'`}</i>.
+      <Typography mt={2}>
+        We are replacing our old <DocHighlight component='span'>InputFile</DocHighlight>
+        component by this new one.
+      </Typography>
+      <Typography mt={2}>
+        So, instead of <i>{'<Inputfile />'}</i>, you should use this one:
+        <DocHighlight component='span'>
+          react-ui/src/components/molecules/UploadField
+        </DocHighlight>
+      </Typography>
+      <Typography mt={2}>
+        For external use:
+        <DocHighlight component='span'>
+          {'import { UploadField } from "@carto/react-ui";'}
+        </DocHighlight>
+        .
+      </Typography>
+    </DocContainer>
+  );
+};
+
 const commonArgs = {
   label: 'Label text',
   helperText: 'Upload a CSV or GeoJSON file, or a zip package with your Shapefile',
@@ -417,6 +442,8 @@ const disabledControlsSizeArgTypes = {
 
 export const Playground = Template.bind({});
 Playground.args = { ...commonArgs };
+
+export const Guide = DocTemplate.bind({});
 
 export const Variants = VariantsTemplate.bind({});
 Variants.args = { ...commonArgs };

--- a/packages/react-ui/storybook/stories/organisms/Tabs.stories.js
+++ b/packages/react-ui/storybook/stories/organisms/Tabs.stories.js
@@ -8,6 +8,7 @@ import {
   StoreOutlined
 } from '@mui/icons-material';
 import Typography from '../../../src/components/atoms/Typography';
+import { DocContainer, DocHighlight, DocLink } from '../../utils/storyStyles';
 
 const options = {
   title: 'Organisms/Tabs',
@@ -284,6 +285,21 @@ const BehaviorTemplate = ({ wrapped, ...args }) => {
   );
 };
 
+const DocTemplate = () => {
+  return (
+    <DocContainer severity='warning'>
+      Some tests rely on tab clicking, but with the new design, the click is disabled on
+      selected tab. So, if your test fails in an assert like this:
+      <Typography mt={2}>
+        <DocHighlight component='span'>{`await page.getByRole('tab', { name: 'Map' }).click()`}</DocHighlight>
+      </Typography>
+      <Typography mt={2}>
+        Before the click, yo have to check if the tab is selected.
+      </Typography>
+    </DocContainer>
+  );
+};
+
 const commonArgs = { label: 'Label', disabled: true };
 const disabledControlsVerticalArgTypes = {
   orientation: { table: { disable: true } },
@@ -316,3 +332,5 @@ Vertical.argTypes = disabledControlsVerticalArgTypes;
 
 export const Behavior = BehaviorTemplate.bind({});
 Behavior.argTypes = disabledControlsBehaviorArgTypes;
+
+export const E2ETesting = DocTemplate.bind({});

--- a/packages/react-ui/storybook/stories/widgetsUI/BarWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/BarWidgetUI.stories.js
@@ -4,7 +4,7 @@ import { buildReactPropsAsString } from '../../utils/utils';
 import { Label, ThinContainer } from '../../utils/storyStyles';
 
 const options = {
-  title: 'Organisms/Widgets/BarWidgetUI',
+  title: 'Widgets/BarWidgetUI',
   component: BarWidgetUI
 };
 

--- a/packages/react-ui/storybook/stories/widgetsUI/CategoryWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/CategoryWidgetUI.stories.js
@@ -3,7 +3,7 @@ import CategoryWidgetUI from '../../../src/widgets/CategoryWidgetUI/CategoryWidg
 import { Label, ThinContainer } from '../../utils/storyStyles';
 
 const options = {
-  title: 'Organisms/Widgets/CategoryWidgetUI',
+  title: 'Widgets/CategoryWidgetUI',
   component: CategoryWidgetUI,
   argTypes: {
     selectedCategories: {

--- a/packages/react-ui/storybook/stories/widgetsUI/ComparativeCategoryWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/ComparativeCategoryWidgetUI.stories.js
@@ -3,7 +3,7 @@ import ComparativeCategoryWidgetUI from '../../../src/widgets/comparative/Compar
 import { Label, ThinContainer } from '../../utils/storyStyles';
 
 const options = {
-  title: 'Organisms/Widgets/ComparativeCategoryWidgetUI',
+  title: 'Widgets/ComparativeCategoryWidgetUI',
   component: ComparativeCategoryWidgetUI
 };
 

--- a/packages/react-ui/storybook/stories/widgetsUI/ComparativeFormulaWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/ComparativeFormulaWidgetUI.stories.js
@@ -4,7 +4,7 @@ import { buildReactPropsAsString } from '../../utils/utils';
 import { Label, ThinContainer } from '../../utils/storyStyles';
 
 const options = {
-  title: 'Organisms/Widgets/ComparativeFormulaWidgetUI',
+  title: 'Widgets/ComparativeFormulaWidgetUI',
   component: ComparativeFormulaWidgetUI
 };
 

--- a/packages/react-ui/storybook/stories/widgetsUI/ComparativePieWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/ComparativePieWidgetUI.stories.js
@@ -4,7 +4,7 @@ import { buildReactPropsAsString } from '../../utils/utils';
 import { Label, ThinContainer } from '../../utils/storyStyles';
 
 const options = {
-  title: 'Organisms/Widgets/ComparativePieWidgetUI',
+  title: 'Widgets/ComparativePieWidgetUI',
   component: ComparativePieWidgetUI
 };
 

--- a/packages/react-ui/storybook/stories/widgetsUI/FeatureSelectionWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/FeatureSelectionWidgetUI.stories.js
@@ -6,7 +6,7 @@ import PolygonIcon from '../../../src/assets/icons/PolygonIcon';
 import RectangleIcon from '../../../src/assets/icons/RectangleIcon';
 
 const options = {
-  title: 'Organisms/Widgets/FeatureSelectionWidgetUI',
+  title: 'Widgets/FeatureSelectionWidgetUI',
   component: FeatureSelectionWidgetUI,
   argTypes: {
     enabled: {

--- a/packages/react-ui/storybook/stories/widgetsUI/FormulaWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/FormulaWidgetUI.stories.js
@@ -3,7 +3,7 @@ import FormulaWidgetUI from '../../../src/widgets/FormulaWidgetUI/FormulaWidgetU
 import { Label, ThinContainer } from '../../utils/storyStyles';
 
 const options = {
-  title: 'Organisms/Widgets/FormulaWidgetUI',
+  title: 'Widgets/FormulaWidgetUI',
   component: FormulaWidgetUI,
   argTypes: {
     formatter: {

--- a/packages/react-ui/storybook/stories/widgetsUI/HistogramWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/HistogramWidgetUI.stories.js
@@ -3,7 +3,7 @@ import HistogramWidgetUI from '../../../src/widgets/HistogramWidgetUI/HistogramW
 import { Label, ThinContainer } from '../../utils/storyStyles';
 
 const options = {
-  title: 'Organisms/Widgets/HistogramWidgetUI',
+  title: 'Widgets/HistogramWidgetUI',
   component: HistogramWidgetUI,
   parameters: {
     docs: {

--- a/packages/react-ui/storybook/stories/widgetsUI/LegendWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/LegendWidgetUI.stories.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import LegendWidgetUI from '../../../src/widgets/legend/LegendWidgetUI';
 
 const options = {
-  title: 'Organisms/Widgets/LegendWidgetUI',
+  title: 'Widgets/LegendWidgetUI',
   component: LegendWidgetUI,
   argTypes: {
     layers: {

--- a/packages/react-ui/storybook/stories/widgetsUI/NoDataAlert.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/NoDataAlert.stories.js
@@ -3,7 +3,7 @@ import NoDataAlert from '../../../src/widgets/NoDataAlert';
 import { buildReactPropsAsString } from '../../utils/utils';
 
 const options = {
-  title: 'Organisms/Widgets/NoDataAlert',
+  title: 'Widgets/NoDataAlert',
   component: NoDataAlert,
   argTypes: {
     title: {

--- a/packages/react-ui/storybook/stories/widgetsUI/PieWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/PieWidgetUI.stories.js
@@ -3,7 +3,7 @@ import PieWidgetUI from '../../../src/widgets/PieWidgetUI/PieWidgetUI';
 import { Label, ThinContainer } from '../../utils/storyStyles';
 
 const options = {
-  title: 'Organisms/Widgets/PieWidgetUI',
+  title: 'Widgets/PieWidgetUI',
   component: PieWidgetUI,
   parameters: {
     docs: {

--- a/packages/react-ui/storybook/stories/widgetsUI/RangeWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/RangeWidgetUI.stories.js
@@ -3,7 +3,7 @@ import RangeWidgetUI from '../../../src/widgets/RangeWidgetUI/RangeWidgetUI';
 import { Label, ThinContainer } from '../../utils/storyStyles';
 
 const options = {
-  title: 'Organisms/Widgets/RangeWidgetUI',
+  title: 'Widgets/RangeWidgetUI',
   component: RangeWidgetUI,
   parameters: {
     docs: {

--- a/packages/react-ui/storybook/stories/widgetsUI/ScatterPlotWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/ScatterPlotWidgetUI.stories.js
@@ -3,7 +3,7 @@ import ScatterPlotWidgetUI from '../../../src/widgets/ScatterPlotWidgetUI/Scatte
 import { Label, ThinContainer } from '../../utils/storyStyles';
 
 const options = {
-  title: 'Organisms/Widgets/ScatterPlotWidgetUI',
+  title: 'Widgets/ScatterPlotWidgetUI',
   component: ScatterPlotWidgetUI,
   parameters: {
     docs: {

--- a/packages/react-ui/storybook/stories/widgetsUI/TableWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/TableWidgetUI.stories.js
@@ -7,7 +7,7 @@ import Typography from '../../../src/components/atoms/Typography';
 import { Label, ThinContainer } from '../../utils/storyStyles';
 
 const options = {
-  title: 'Organisms/Widgets/TableWidgetUI',
+  title: 'Widgets/TableWidgetUI',
   component: TableWidgetUI,
   argTypes: {},
   parameters: {

--- a/packages/react-ui/storybook/stories/widgetsUI/TimeSeriesWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/TimeSeriesWidgetUI.stories.js
@@ -67,7 +67,7 @@ const data = [
 ];
 
 const options = {
-  title: 'Organisms/Widgets/TimeSeriesWidgetUI',
+  title: 'Widgets/TimeSeriesWidgetUI',
   component: TimeSeriesWidgetUI,
   argTypes: {
     data: {

--- a/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
@@ -5,7 +5,7 @@ import AddLocationIcon from '@mui/icons-material/AddLocation';
 import WrapperWidgetUI from '.../../../src/widgets/WrapperWidgetUI';
 
 const options = {
-  title: 'Organisms/Widgets/WrapperWidgetUI',
+  title: 'Widgets/WrapperWidgetUI',
   component: WrapperWidgetUI,
   argTypes: {
     actions: {

--- a/packages/react-ui/storybook/stories/widgetsUI/legend/LegendCategories.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/legend/LegendCategories.stories.js
@@ -9,7 +9,7 @@ const DEFAULT_LEGEND = {
 };
 
 const options = {
-  title: 'Organisms/Widgets/Legends/LegendCategories',
+  title: 'Widgets/Legends/LegendCategories',
   component: LegendCategories,
   argTypes: {
     legend: {}

--- a/packages/react-ui/storybook/stories/widgetsUI/legend/LegendIcon.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/legend/LegendIcon.stories.js
@@ -11,7 +11,7 @@ const DEFAULT_LEGEND = {
 };
 
 const options = {
-  title: 'Organisms/Widgets/Legends/LegendIcon',
+  title: 'Widgets/Legends/LegendIcon',
   component: LegendIcon,
   argTypes: {
     legend: {}

--- a/packages/react-ui/storybook/stories/widgetsUI/legend/LegendProportion.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/legend/LegendProportion.stories.js
@@ -8,7 +8,7 @@ const DEFAULT_LEGEND = {
 };
 
 const options = {
-  title: 'Organisms/Widgets/Legends/LegendProportion',
+  title: 'Widgets/Legends/LegendProportion',
   component: LegendProportion,
   argTypes: {
     legend: {}

--- a/packages/react-ui/storybook/stories/widgetsUI/legend/LegendRamp.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/legend/LegendRamp.stories.js
@@ -20,7 +20,7 @@ const DEFAULT_LEGEND_WITH_FORMATTED_LABELS = {
 };
 
 const options = {
-  title: 'Organisms/Widgets/Legends/LegendRamp',
+  title: 'Widgets/Legends/LegendRamp',
   component: LegendRamp,
   argTypes: {
     legend: {}


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/308752/tooling-c4r-increase-documentation-discoverability
[sc-308752]

- Placed Widget stories at a higher level
- Fixed ComparativeCategoryWidgetUI
- Added missing storybook documentation
- Added an extensive guide for handling icons