### PR TITLE
Fix gmaps basemap types

### DIFF
--- a/packages/react-basemaps/src/basemaps/basemaps.d.ts
+++ b/packages/react-basemaps/src/basemaps/basemaps.d.ts
@@ -11,19 +11,19 @@ declare enum CartoUrlBasemaps {
 }
 
 export enum GMapsBasemapsNames {
-  ROADMAP = 'roadmap',
-  SATELLITE = 'satellite',
-  HYBRID = 'hybrid',
-  CUSTOM = 'custom'
+  GOOGLE_ROADMAP = 'roadmap',
+  GOOGLE_SATELLITE = 'satellite',
+  GOOGLE_HYBRID = 'hybrid',
+  GOOGLE_CUSTOM = 'custom'
 }
 
 export const POSITRON: CartoBasemapsNames.POSITRON;
 export const VOYAGER: CartoBasemapsNames.VOYAGER;
 export const DARK_MATTER: CartoBasemapsNames.DARK_MATTER;
-export const GOOGLE_ROADMAP: GMapsBasemapsNames.ROADMAP;
-export const GOOGLE_SATELLITE: GMapsBasemapsNames.SATELLITE;
-export const GOOGLE_HYBRID: GMapsBasemapsNames.HYBRID;
-export const GOOGLE_CUSTOM: GMapsBasemapsNames.CUSTOM;
+export const GOOGLE_ROADMAP: GMapsBasemapsNames.GOOGLE_ROADMAP;
+export const GOOGLE_SATELLITE: GMapsBasemapsNames.GOOGLE_SATELLITE;
+export const GOOGLE_HYBRID: GMapsBasemapsNames.GOOGLE_HYBRID;
+export const GOOGLE_CUSTOM: GMapsBasemapsNames.GOOGLE_CUSTOM;
 
 type CartoBasemaps = {
   [B in CartoBasemapsNames]: {


### PR DESCRIPTION
# Description

Shortcut: [sc-339329](https://app.shortcut.com/cartoteam/story/339329/wrong-type-in-google-basemap-in-carto-for-react)

Wrong basemap type for google basemap

## Type of change

- [x] Fix
- Feature
- Refactor
- Tests
- Documentation

# Acceptance

Consume 'GOOGLE_SATELLITE' as a coorect basemap type, without TS errors, in a carto-react-template using TS 

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
