### PR TITLE
Use selectLoader to obtain loader from mime type

### DIFF
--- a/packages/react-api/src/hooks/FeaturesDroppedLoader.js
+++ b/packages/react-api/src/hooks/FeaturesDroppedLoader.js
@@ -1,4 +1,5 @@
 import { MVTWorkerLoader } from '@loaders.gl/mvt';
+import { selectLoader } from '@loaders.gl/core';
 
 // eslint-disable-next-line import/no-anonymous-default-export
 export default {
@@ -9,12 +10,19 @@ export default {
   // By only specifying `carto-vector-tile` the SpatialIndexLayer will not use this loader
   mimeTypes: ['application/vnd.carto-vector-tile', ...MVTWorkerLoader.mimeTypes],
   parse: async (arrayBuffer, options, context) => {
-    const isDroppingFeatures =
-      context.response.headers['features-dropped-from-tile'] === 'true';
-    const isMVT = MVTWorkerLoader.mimeTypes.includes(options.mimeType);
-    const result = isMVT
-      ? await context.parse(arrayBuffer, MVTWorkerLoader, options, context)
-      : await context.parse(arrayBuffer, options, context);
+    const { headers } = context.response;
+    const isDroppingFeatures = headers['features-dropped-from-tile'] === 'true';
+
+    // Obtain a registered loader to actually parse the data
+    let loader = null;
+    options.mimeType = options.mimeType || headers['content-type'];
+    if (MVTWorkerLoader.mimeTypes.includes(options.mimeType)) {
+      loader = MVTWorkerLoader;
+    } else {
+      const dummyBlob = new Blob([], { type: options.mimeType });
+      loader = await selectLoader(dummyBlob);
+    }
+    const result = await context.parse(arrayBuffer, loader, options, context);
     return result ? { ...result, isDroppingFeatures } : null;
   }
 };


### PR DESCRIPTION
# Description

Support change in deck.gl: https://github.com/visgl/deck.gl/pull/8076

This fix should be back-compatible with older deck.gl versions, i.e. where `loadOptions.mimeType = 'application/vnd.carto-vector-tile'` is explictly set as well as working with the new v3.2 API where the mime-type is deduced from the returned Content-Type header

## Type of change

- Feature

# Acceptance

Please describe how to validate the feature or fix

1. Build and link files with Builder, use https://github.com/CartoDB/cloud-native/pull/13701
2. test against v3.1 and v3.2 APIs by including deck.gl `8.9.23` or `8.9.26` in Builder
3. assert that MVT and binary tilesets work as expected