### PR TITLE
Pie Widget: Add number of selected categories + clear button

### DIFF
--- a/packages/react-ui/src/theme/sections/components/navigation.js
+++ b/packages/react-ui/src/theme/sections/components/navigation.js
@@ -152,6 +152,12 @@ export const navigationOverrides = {
   MuiLink: {
     defaultProps: {
       underline: 'hover'
+    },
+
+    styleOverrides: {
+      root: ({ theme }) => ({
+        cursor: 'pointer'
+      })
     }
   }
 };

--- a/packages/react-ui/src/widgets/PieWidgetUI/PieWidgetUI.js
+++ b/packages/react-ui/src/widgets/PieWidgetUI/PieWidgetUI.js
@@ -1,10 +1,18 @@
 import React, { useMemo, useRef, useEffect, useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import ReactEcharts from '../../custom-components/echarts-for-react';
-import { useTheme } from '@mui/material';
+import { Grid, Link, styled, useTheme } from '@mui/material';
 import { disableSerie, setColor } from '../utils/chartUtils';
 import { processFormatterRes } from '../utils/formatterUtils';
 import PieSkeleton from './PieSkeleton';
+import Typography from '../../components/atoms/Typography';
+
+export const OptionsBar = styled(Grid)(({ theme: { spacing, palette } }) => ({
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: spacing(1.5)
+}));
 
 function PieWidgetUI({
   name,
@@ -215,15 +223,31 @@ function PieWidgetUI({
     }
   };
 
+  const handleClearClicked = () => {
+    onSelectedCategoriesChange([]);
+  };
+
   if (isLoading) return <PieSkeleton height={height} />;
 
   return (
-    <ReactEcharts
-      option={options}
-      onEvents={onEvents}
-      lazyUpdate={true}
-      style={{ maxHeight: height }}
-    />
+    <>
+      <OptionsBar container>
+        <Typography variant='caption' color='textSecondary'>
+          {selectedCategories.length ? selectedCategories.length : 'All'} selected
+        </Typography>
+        {selectedCategories.length > 0 && (
+          <Link variant='caption' onClick={handleClearClicked}>
+            Clear
+          </Link>
+        )}
+      </OptionsBar>
+      <ReactEcharts
+        option={options}
+        onEvents={onEvents}
+        lazyUpdate={true}
+        style={{ maxHeight: height }}
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/343962/add-clear-and-number-of-selected-categories-to-piewidget

To allow in Pie Widget, the same 'All selected | N selected' + 'Clear' option available in CategoryWidget and others.

## Type of change

- Feature

<img width="583" alt="Screenshot 2023-09-12 at 17 40 04" src="https://github.com/CartoDB/carto-react/assets/1934144/c67dca39-30f5-400d-a098-d61f1d374a78">
<img width="586" alt="Screenshot 2023-09-12 at 17 39 53" src="https://github.com/CartoDB/carto-react/assets/1934144/1671e64a-b299-435b-aef6-775334d64e6c">

