### PR TITLE
SelectField: Remove empty space at the beginning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- SelectField: Remove empty item at the beginning [#772](https://github.com/CartoDB/carto-react/pull/772)
+- SelectField: Remove empty space at the beginning [#772](https://github.com/CartoDB/carto-react/pull/772)
 - WrapperWidgetUI: contentProps property to support scrolling [#769](https://github.com/CartoDB/carto-react/pull/769)
 
 ## 2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- SelectField: Remove empty item at the beginning [#772](https://github.com/CartoDB/carto-react/pull/772)
 - WrapperWidgetUI: contentProps property to support scrolling [#769](https://github.com/CartoDB/carto-react/pull/769)
 
 ## 2.2

--- a/packages/react-ui/src/components/atoms/SelectField.js
+++ b/packages/react-ui/src/components/atoms/SelectField.js
@@ -70,7 +70,6 @@ const SelectField = forwardRef(
           }
         }}
       >
-        <MenuItem key='empty' disabled value={''}></MenuItem>
         {children}
       </TextField>
     );

--- a/packages/react-ui/src/components/atoms/SelectField.js
+++ b/packages/react-ui/src/components/atoms/SelectField.js
@@ -70,6 +70,7 @@ const SelectField = forwardRef(
           }
         }}
       >
+        <MenuItem key='empty' disabled value={''}></MenuItem>
         {children}
       </TextField>
     );

--- a/packages/react-ui/src/theme/sections/components/navigation.js
+++ b/packages/react-ui/src/theme/sections/components/navigation.js
@@ -40,6 +40,7 @@ export const navigationOverrides = {
         },
         '&.Mui-disabled:empty': {
           height: 0,
+          minHeight: 0,
           padding: 0
         },
         '& .MuiCheckbox-root, & > .MuiSvgIcon-root': {


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/343957/qa-ui-export-a-workflow

The empty option was added due to some issues with tab navigation, but is not needed anymore and is causing an unwanted blank space.

Remove the white space at the beginning, that white space looks like something failed to render.

This change also affects `MultipleSelectField` component.

Current UI
<img width="1042" alt="Screenshot 2023-09-13 at 11 21 50" src="https://github.com/CartoDB/carto-react/assets/1934144/81315df1-2014-4c6b-94e4-a5522ae0ff44">


Fix
<img width="553" alt="Screenshot 2023-09-13 at 11 22 11" src="https://github.com/CartoDB/carto-react/assets/1934144/6e9e5878-de4b-4547-9e1f-ea337313d06c">

