### PR TITLE
cleanup: distribute only src and dist files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- (chore) Include only required files in published packages [#780](https://github.com/CartoDB/carto-react/pull/780)
+
 ## 2.2
 
 ### 2.2.7 (2023-09-13)

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -14,6 +14,10 @@
   },
   "license": "BSD-3-Clause",
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
   "directories": {
     "lib": "src",
     "test": "__tests__"

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -15,6 +15,10 @@
   },
   "license": "BSD-3-Clause",
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
   "directories": {
     "lib": "src",
     "test": "__tests__"

--- a/packages/react-basemaps/package.json
+++ b/packages/react-basemaps/package.json
@@ -15,6 +15,10 @@
   },
   "license": "BSD-3-Clause",
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
   "directories": {
     "lib": "src",
     "test": "__tests__"

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -14,6 +14,10 @@
   },
   "license": "BSD-3-Clause",
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
   "directories": {
     "lib": "src",
     "test": "__tests__"

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -14,6 +14,10 @@
   },
   "license": "BSD-3-Clause",
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
   "directories": {
     "lib": "src",
     "test": "__tests__"

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -15,6 +15,10 @@
   },
   "license": "BSD-3-Clause",
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
   "directories": {
     "lib": "src",
     "test": "__tests__"

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -16,6 +16,10 @@
   },
   "license": "BSD-3-Clause",
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
   "directories": {
     "lib": "src",
     "test": "__tests__"

--- a/packages/react-workers/package.json
+++ b/packages/react-workers/package.json
@@ -14,6 +14,10 @@
   },
   "license": "BSD-3-Clause",
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "src"
+  ],
   "directories": {
     "lib": "src",
     "test": "__tests__"


### PR DESCRIPTION
# Description

c4r publishes packages may contain lots of random files, are there reasons not to skip them

examples:
* react-ui: https://unpkg.com/browse/@carto/react-ui@2.2.7/
  * storybook-static/0.3e376249.iframe.bundle.js.LICENSE.txt …
  * storybook/*
  * firebase.json !!!
  * .firebase/… some cache …
* other packages:
  * __tests__
  * babel.config.js
   * jest.config.js
   * webpack.config.js 

I don’t think they are needed by common user, they are not going to transpile stuff or run tests against compiled base
package is not place for those

re> what others do
[deck.gl](http://deck.gl/) doesn’t package any “internal” stuff like tests or configs used to build bundles

Yes, some files are randomly picked from non-clean workspaces, but my point here is that we should only package files that we know are needed, rest should be ignored


## Type of change

(choose one and remove the others)

- Fix

# Acceptance

Distributed packages shouldn't contain internal files. They should contain only:
 * `src/*`
 * `dist/*`
 * `package.json`
 * `LICENSE.*`
 * `README.*`
 
# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
