### PR TITLE
WrapperWidgetUI: fix header when 2 lines is exceded 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- WrapperWidgetUI: fix header when 2 lines is exceded [#783](https://github.com/CartoDB/carto-react/pull/783)
 
 ## 2.2
 

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.js
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.js
@@ -68,7 +68,10 @@ const HeaderButton = styled(Button, {
   padding: 0,
   alignItems: 'flex-start',
   justifyContent: 'flex-start',
+  height: 'auto',
+  minHeight: theme.spacing(3),
   cursor: expandable ? 'pointer' : 'default',
+
   '& .MuiButton-startIcon': {
     marginTop: '3px',
     marginRight: theme.spacing(1)
@@ -255,7 +258,7 @@ function WrapperWidgetUI(props) {
       {/* TODO: check collapse error */}
       <Collapse ref={wrapper} in={expanded} timeout='auto' unmountOnExit>
         <Box {...props.contentProps}>
-          <Box pt={1}>{props.children}</Box>
+          <Box pt={2}>{props.children}</Box>
           {props.footer ?? <Box>{props.footer}</Box>}
         </Box>
       </Collapse>

--- a/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
@@ -65,10 +65,14 @@ export const OnlyTitle = Template.bind({});
 OnlyTitle.args = DefaultProps;
 
 export const LongTitle = ResponsiveTemplate.bind({});
-const LongTitleProps = {
-  title: 'Default wrapper with extra long text overflowing in two lines'
+
+LongTitle.args = {
+  title: 'Default wrapper with extra long text overflowing in two lines',
+  options: [
+    { id: 'o1', name: 'Option 1', action: () => alert('Option 1!') },
+    { id: 'o2', name: 'Option 2 too long', action: () => alert('Option 2!') }
+  ]
 };
-LongTitle.args = LongTitleProps;
 
 export const Expandable = Template.bind({});
 const ExpandableProps = { title: 'Expandable', expandable: true };

--- a/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
@@ -3,6 +3,7 @@ import ColorizeIcon from '@mui/icons-material/Colorize';
 import MenuIcon from '@mui/icons-material/Menu';
 import AddLocationIcon from '@mui/icons-material/AddLocation';
 import WrapperWidgetUI from '.../../../src/widgets/WrapperWidgetUI';
+import { Label, ThinContainer } from '../../utils/storyStyles';
 
 const options = {
   title: 'Widgets/WrapperWidgetUI',
@@ -34,12 +35,40 @@ const Template = (args) => (
   </WrapperWidgetUI>
 );
 
+const ResponsiveTemplate = (args) => {
+  return (
+    <>
+      <Label variant='body1' mb={3}>
+        {'Limited width'}
+      </Label>
+      <ThinContainer>
+        <WrapperWidgetUI {...args}>
+          <div>Your Content</div>
+        </WrapperWidgetUI>
+      </ThinContainer>
+
+      <Label variant='body1' mt={8} mb={3}>
+        {'Responsive'}
+      </Label>
+      <WrapperWidgetUI {...args}>
+        <div>Your Content</div>
+      </WrapperWidgetUI>
+    </>
+  );
+};
+
 export const Default = Template.bind({});
 const DefaultProps = { title: 'Default wrapper' };
 Default.args = DefaultProps;
 
 export const OnlyTitle = Template.bind({});
 OnlyTitle.args = DefaultProps;
+
+export const LongTitle = ResponsiveTemplate.bind({});
+const LongTitleProps = {
+  title: 'Default wrapper with extra long text overflowing in two lines'
+};
+LongTitle.args = LongTitleProps;
 
 export const Expandable = Template.bind({});
 const ExpandableProps = { title: 'Expandable', expandable: true };


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/353577/fix-cr4-builder-widgets-issue-when-2-lines-is-exceded
[sc-353577]
