### PR TITLE
Release v2.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## Not released
 
+## 2.2
+
+### 2.2.11 (2023-10-05)
+
 - PieWidgetUI: Refactor & New CentralText component [#779](https://github.com/CartoDB/carto-react/pull/779)
 - Pie widget: New ChartLegend component from scratch [#777](https://github.com/CartoDB/carto-react/pull/777)
 - Pie Widget: Add maxNumber of elements + a sorted by size desc by default [#774](https://github.com/CartoDB/carto-react/pull/774)
 - Pie Widget: Add number of selected categories + clear button [#771](https://github.com/CartoDB/carto-react/pull/771)
-
-## 2.2
 
 ### 2.2.10 (2023-10-05)
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "2.2.10"
+  "version": "2.2.11"
 }

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -68,9 +68,9 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.2.10",
-    "@carto/react-redux": "^2.2.10",
-    "@carto/react-workers": "^2.2.10",
+    "@carto/react-core": "^2.2.11",
+    "@carto/react-redux": "^2.2.11",
+    "@carto/react-workers": "^2.2.11",
     "@deck.gl/carto": "^8.9.18",
     "@deck.gl/core": "^8.9.18",
     "@deck.gl/extensions": "^8.9.18",

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-api",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "CARTO for React - Api",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-auth",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "CARTO for React - Auth",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -68,7 +68,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.2.10",
+    "@carto/react-core": "^2.2.11",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x"
   }

--- a/packages/react-basemaps/package.json
+++ b/packages/react-basemaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-basemaps",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "CARTO for React - Basemaps",
   "keywords": [
     "carto",

--- a/packages/react-basemaps/package.json
+++ b/packages/react-basemaps/package.json
@@ -68,7 +68,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.2.10",
+    "@carto/react-core": "^2.2.11",
     "@deck.gl/google-maps": "^8.9.18",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x"

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-core",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "CARTO for React - Core",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-redux",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "CARTO for React - Redux",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -67,8 +67,8 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.2.10",
-    "@carto/react-workers": "^2.2.10",
+    "@carto/react-core": "^2.2.11",
+    "@carto/react-workers": "^2.2.11",
     "@deck.gl/carto": "^8.9.18",
     "@deck.gl/core": "^8.9.18",
     "@reduxjs/toolkit": "^1.5.0"

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -82,7 +82,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^2.2.10",
+    "@carto/react-core": "^2.2.11",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@mui/icons-material": "^5.11.16",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-ui",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "CARTO for React - UI",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-widgets",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "CARTO for React - Widgets",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -69,11 +69,11 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-api": "^2.2.10",
-    "@carto/react-core": "^2.2.10",
-    "@carto/react-redux": "^2.2.10",
-    "@carto/react-ui": "^2.2.10",
-    "@carto/react-workers": "^2.2.10",
+    "@carto/react-api": "^2.2.11",
+    "@carto/react-core": "^2.2.11",
+    "@carto/react-redux": "^2.2.11",
+    "@carto/react-ui": "^2.2.11",
+    "@carto/react-workers": "^2.2.11",
     "@deck.gl/core": "^8.9.18",
     "@deck.gl/layers": "^8.9.18",
     "@emotion/react": "^11.10.6",

--- a/packages/react-workers/package.json
+++ b/packages/react-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-workers",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "description": "CARTO for React - Workers",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.9",
-    "@carto/react-core": "^2.2.10",
+    "@carto/react-core": "^2.2.11",
     "@turf/bbox-polygon": "^6.3.0",
     "@turf/boolean-intersects": "^6.3.0",
     "@turf/boolean-within": "^6.3.0",


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/343965/integrate-piewidget-in-builder
[sc-343965]

Pie widget release