### PR TITLE
WrapperWidgetUI: add new headerItems prop to be more flexible the elements we can use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- WrapperWidgetUI: fix header when 2 lines is exceded [#783](https://github.com/CartoDB/carto-react/pull/783)
 
 ## 2.2
 

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.d.ts
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.d.ts
@@ -34,6 +34,7 @@ export type WrapperWidgetUIProps = {
   isLoading?: boolean;
   disabled?: boolean;
 
+  headerItems?: ReactNode;
   actions?: WrapperWidgetAction[];
   options?: WrapperWidgetOption[];
 

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.js
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.js
@@ -69,7 +69,7 @@ const HeaderButton = styled(Button, {
   alignItems: 'flex-start',
   justifyContent: 'flex-start',
   height: 'auto',
-  minHeight: theme.spacing(3),
+  minHeight: theme.spacing(4),
   cursor: expandable ? 'pointer' : 'default',
 
   '& .MuiButton-startIcon': {
@@ -112,21 +112,14 @@ const Text = styled(Typography, {
 
 const HeaderItems = styled(Grid)(({ theme }) => ({
   display: 'flex',
-  marginLeft: theme.spacing(1)
-}));
-
-const HeaderItem = styled(Box)(({ theme }) => ({
-  marginLeft: theme.spacing(1)
-}));
-
-const ActionsGrid = styled(Grid)(({ theme }) => ({
-  display: 'flex',
+  alignItems: 'center',
+  gap: theme.spacing(1),
+  marginTop: theme.spacing(-0.75),
   marginLeft: theme.spacing(1)
 }));
 
 const IconActionButton = styled(IconButton)(({ theme }) => ({
-  color: theme.palette.text.secondary,
-  margin: theme.spacing(-0.75, 0)
+  color: theme.palette.text.secondary
 }));
 
 const PaperMenu = styled(Menu)(({ theme }) => ({
@@ -208,70 +201,68 @@ function WrapperWidgetUI(props) {
           </Tooltip>
         </HeaderButton>
 
-        <HeaderItems>
-          {props.headerItems && <HeaderItem>{props.headerItems}</HeaderItem>}
+        <HeaderItems item>
+          {props.headerItems}
 
-          <ActionsGrid item>
-            {actions.length > 0 &&
-              actions.map((action) => {
-                return action.tooltip ? (
-                  <Tooltip
-                    key={action.id}
-                    title={action.tooltip.text}
-                    placement={action.tooltip.placement || 'top'}
+          {actions.length > 0 &&
+            actions.map((action) => {
+              return action.tooltip ? (
+                <Tooltip
+                  key={action.id}
+                  title={action.tooltip.text}
+                  placement={action.tooltip.placement || 'top'}
+                >
+                  {iconButtonTooltip(action)}
+                </Tooltip>
+              ) : (
+                iconButtonTooltip(action)
+              );
+            })}
+
+          {options.length > 0 && (
+            <>
+              <IconActionButton
+                aria-label='options'
+                aria-controls='options-menu'
+                aria-haspopup='true'
+                onClick={handleClick}
+              >
+                {optionsIcon}
+              </IconActionButton>
+              <PaperMenu
+                id='options-menu'
+                elevation={8}
+                anchorOrigin={{
+                  vertical: 'top',
+                  horizontal: 'right'
+                }}
+                transformOrigin={{
+                  vertical: 'top',
+                  horizontal: 'right'
+                }}
+                anchorEl={anchorEl}
+                keepMounted
+                open={open}
+                onClose={handleClose}
+              >
+                {options.map((option) => (
+                  <MenuItem
+                    key={option.id}
+                    selected={option.selected}
+                    onClick={() => handleOptionAction(option.action)}
                   >
-                    {iconButtonTooltip(action)}
-                  </Tooltip>
-                ) : (
-                  iconButtonTooltip(action)
-                );
-              })}
-
-            {options.length > 0 && (
-              <>
-                <IconActionButton
-                  aria-label='options'
-                  aria-controls='options-menu'
-                  aria-haspopup='true'
-                  onClick={handleClick}
-                >
-                  {optionsIcon}
-                </IconActionButton>
-                <PaperMenu
-                  id='options-menu'
-                  elevation={8}
-                  anchorOrigin={{
-                    vertical: 'top',
-                    horizontal: 'right'
-                  }}
-                  transformOrigin={{
-                    vertical: 'top',
-                    horizontal: 'right'
-                  }}
-                  anchorEl={anchorEl}
-                  keepMounted
-                  open={open}
-                  onClose={handleClose}
-                >
-                  {options.map((option) => (
-                    <MenuItem
-                      key={option.id}
-                      selected={option.selected}
-                      onClick={() => handleOptionAction(option.action)}
-                    >
-                      {option.name}
-                    </MenuItem>
-                  ))}
-                </PaperMenu>
-              </>
-            )}
-          </ActionsGrid>
+                    {option.name}
+                  </MenuItem>
+                ))}
+              </PaperMenu>
+            </>
+          )}
         </HeaderItems>
       </Header>
       {/* TODO: check collapse error */}
       <Collapse ref={wrapper} in={expanded} timeout='auto' unmountOnExit>
         <Box {...props.contentProps}>
-          <Box pt={2}>{props.children}</Box>
+          <Box pt={1}>{props.children}</Box>
           {props.footer ?? <Box>{props.footer}</Box>}
         </Box>
       </Collapse>

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.js
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.js
@@ -114,7 +114,7 @@ const HeaderItems = styled(Grid)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   gap: theme.spacing(1),
-  marginTop: theme.spacing(-0.75),
+  marginRight: theme.spacing(-0.5),
   marginLeft: theme.spacing(1)
 }));
 
@@ -173,7 +173,12 @@ function WrapperWidgetUI(props) {
 
   const iconButtonTooltip = (action) => {
     return (
-      <IconActionButton key={action.id} aria-label={action.label} onClick={action.action}>
+      <IconActionButton
+        key={action.id}
+        aria-label={action.label}
+        onClick={action.action}
+        size='small'
+      >
         {action.icon}
       </IconActionButton>
     );
@@ -226,6 +231,7 @@ function WrapperWidgetUI(props) {
                 aria-controls='options-menu'
                 aria-haspopup='true'
                 onClick={handleClick}
+                size='small'
               >
                 {optionsIcon}
               </IconActionButton>

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.js
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.js
@@ -68,7 +68,10 @@ const HeaderButton = styled(Button, {
   padding: 0,
   alignItems: 'flex-start',
   justifyContent: 'flex-start',
+  height: 'auto',
+  minHeight: theme.spacing(3),
   cursor: expandable ? 'pointer' : 'default',
+
   '& .MuiButton-startIcon': {
     marginTop: '3px',
     marginRight: theme.spacing(1)
@@ -255,7 +258,7 @@ function WrapperWidgetUI(props) {
       {/* TODO: check collapse error */}
       <Collapse ref={wrapper} in={expanded} timeout='auto' unmountOnExit>
         <Box {...props.contentProps}>
-          <Box pt={1}>{props.children}</Box>
+          <Box pt={2}>{props.children}</Box>
           {props.footer ?? <Box>{props.footer}</Box>}
         </Box>
       </Collapse>

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.js
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.js
@@ -110,6 +110,15 @@ const Text = styled(Typography, {
   })
 }));
 
+const HeaderItems = styled(Grid)(({ theme }) => ({
+  display: 'flex',
+  marginLeft: theme.spacing(1)
+}));
+
+const HeaderItem = styled(Box)(({ theme }) => ({
+  marginLeft: theme.spacing(1)
+}));
+
 const ActionsGrid = styled(Grid)(({ theme }) => ({
   display: 'flex',
   marginLeft: theme.spacing(1)
@@ -199,61 +208,65 @@ function WrapperWidgetUI(props) {
           </Tooltip>
         </HeaderButton>
 
-        <ActionsGrid item>
-          {actions.length > 0 &&
-            actions.map((action) => {
-              return action.tooltip ? (
-                <Tooltip
-                  key={action.id}
-                  title={action.tooltip.text}
-                  placement={action.tooltip.placement || 'top'}
-                >
-                  {iconButtonTooltip(action)}
-                </Tooltip>
-              ) : (
-                iconButtonTooltip(action)
-              );
-            })}
+        <HeaderItems>
+          {props.headerItems && <HeaderItem>{props.headerItems}</HeaderItem>}
 
-          {options.length > 0 && (
-            <>
-              <IconActionButton
-                aria-label='options'
-                aria-controls='options-menu'
-                aria-haspopup='true'
-                onClick={handleClick}
-              >
-                {optionsIcon}
-              </IconActionButton>
-              <PaperMenu
-                id='options-menu'
-                elevation={8}
-                anchorOrigin={{
-                  vertical: 'top',
-                  horizontal: 'right'
-                }}
-                transformOrigin={{
-                  vertical: 'top',
-                  horizontal: 'right'
-                }}
-                anchorEl={anchorEl}
-                keepMounted
-                open={open}
-                onClose={handleClose}
-              >
-                {options.map((option) => (
-                  <MenuItem
-                    key={option.id}
-                    selected={option.selected}
-                    onClick={() => handleOptionAction(option.action)}
+          <ActionsGrid item>
+            {actions.length > 0 &&
+              actions.map((action) => {
+                return action.tooltip ? (
+                  <Tooltip
+                    key={action.id}
+                    title={action.tooltip.text}
+                    placement={action.tooltip.placement || 'top'}
                   >
-                    {option.name}
-                  </MenuItem>
-                ))}
-              </PaperMenu>
-            </>
-          )}
-        </ActionsGrid>
+                    {iconButtonTooltip(action)}
+                  </Tooltip>
+                ) : (
+                  iconButtonTooltip(action)
+                );
+              })}
+
+            {options.length > 0 && (
+              <>
+                <IconActionButton
+                  aria-label='options'
+                  aria-controls='options-menu'
+                  aria-haspopup='true'
+                  onClick={handleClick}
+                >
+                  {optionsIcon}
+                </IconActionButton>
+                <PaperMenu
+                  id='options-menu'
+                  elevation={8}
+                  anchorOrigin={{
+                    vertical: 'top',
+                    horizontal: 'right'
+                  }}
+                  transformOrigin={{
+                    vertical: 'top',
+                    horizontal: 'right'
+                  }}
+                  anchorEl={anchorEl}
+                  keepMounted
+                  open={open}
+                  onClose={handleClose}
+                >
+                  {options.map((option) => (
+                    <MenuItem
+                      key={option.id}
+                      selected={option.selected}
+                      onClick={() => handleOptionAction(option.action)}
+                    >
+                      {option.name}
+                    </MenuItem>
+                  ))}
+                </PaperMenu>
+              </>
+            )}
+          </ActionsGrid>
+        </HeaderItems>
       </Header>
       {/* TODO: check collapse error */}
       <Collapse ref={wrapper} in={expanded} timeout='auto' unmountOnExit>
@@ -280,6 +293,7 @@ WrapperWidgetUI.propTypes = {
   onExpandedChange: PropTypes.func,
   isLoading: PropTypes.bool,
   disabled: PropTypes.bool,
+  headerItems: PropTypes.element,
   actions: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,

--- a/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
@@ -65,10 +65,14 @@ export const OnlyTitle = Template.bind({});
 OnlyTitle.args = DefaultProps;
 
 export const LongTitle = ResponsiveTemplate.bind({});
-const LongTitleProps = {
-  title: 'Default wrapper with extra long text overflowing in two lines'
+
+LongTitle.args = {
+  title: 'Default wrapper with extra long text overflowing in two lines',
+  options: [
+    { id: 'o1', name: 'Option 1', action: () => alert('Option 1!') },
+    { id: 'o2', name: 'Option 2 too long', action: () => alert('Option 2!') }
+  ]
 };
-LongTitle.args = LongTitleProps;
 
 export const Expandable = Template.bind({});
 const ExpandableProps = { title: 'Expandable', expandable: true };

--- a/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
@@ -94,6 +94,12 @@ export const Disabled = Template.bind({});
 const DisabledProps = { title: 'Disabled', disabled: true };
 Disabled.args = DisabledProps;
 
+export const WithHeaderItems = Template.bind({});
+WithHeaderItems.args = {
+  title: 'Wrapper with HeaderItems element',
+  headerItems: <ColorizeIcon />
+};
+
 export const WithActions = Template.bind({});
 WithActions.args = {
   title: 'Wrapper with actions',

--- a/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
@@ -4,6 +4,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 import AddLocationIcon from '@mui/icons-material/AddLocation';
 import WrapperWidgetUI from '.../../../src/widgets/WrapperWidgetUI';
 import { Label, ThinContainer } from '../../utils/storyStyles';
+import { Checkbox } from '@mui/material';
 
 const options = {
   title: 'Widgets/WrapperWidgetUI',
@@ -96,8 +97,8 @@ Disabled.args = DisabledProps;
 
 export const WithHeaderItems = Template.bind({});
 WithHeaderItems.args = {
-  title: 'Wrapper with HeaderItems element',
-  headerItems: <ColorizeIcon />
+  title: 'Wrapper with Header Items',
+  headerItems: <Checkbox />
 };
 
 export const WithActions = Template.bind({});
@@ -111,23 +112,6 @@ WithActions.args = {
       action: () => alert('Action!')
     }
   ]
-};
-WithActions.parameters = {
-  docs: {
-    source: {
-      code: `<WrapperWidgetUI
-  title='Wrapper with actions'
-  actions={[
-    {
-      id: 'a1',
-      name: 'Autostyle',
-      icon: <ColorizeIcon />,
-      action: () => alert('Action!')
-    }
-  ]}
-/>`
-    }
-  }
 };
 
 export const WithOptions = Template.bind({});
@@ -145,30 +129,11 @@ WithOptions.args = {
     { id: 'o9', name: 'Option 2', action: () => alert('Option 2!') }
   ]
 };
-WithOptions.parameters = {
-  docs: {
-    source: {
-      code: `<WrapperWidgetUI
-  title='Wrapper with options'
-  options={[
-    { id: 'o1', name: 'Option 1', action: () => alert('Option 1!') },
-    { id: 'o2', name: 'Option 2 too long', action: () => alert('Option 2!') },
-    { id: 'o3', name: 'Option 2', action: () => alert('Option 2!') },
-    { id: 'o4', name: 'Option 2 too long here', action: () => alert('Option 2!') },
-    { id: 'o5', name: 'Option 2', action: () => alert('Option 2!') },
-    { id: 'o6', name: 'Option 2', action: () => alert('Option 2!') },
-    { id: 'o7', name: 'Option 2', action: () => alert('Option 2!') },
-    { id: 'o8', name: 'Option 2', action: () => alert('Option 2!') },
-    { id: 'o9', name: 'Option 2', action: () => alert('Option 2!') }
-  ]}
-/>`
-    }
-  }
-};
 
-export const WithActionsAndOptions = Template.bind({});
-WithActionsAndOptions.args = {
+export const WithItemsActionsAndOptions = Template.bind({});
+WithItemsActionsAndOptions.args = {
   title: 'Wrapper with actions and options',
+  headerItems: <Checkbox />,
   actions: [
     {
       id: 'a1',
@@ -182,27 +147,6 @@ WithActionsAndOptions.args = {
     { id: 'o2', name: 'Option 2', action: () => alert('Option 2!') }
   ]
 };
-WithActionsAndOptions.parameters = {
-  docs: {
-    source: {
-      code: `<WrapperWidgetUI
-  title='Wrapper with actions and options'
-  actions={[
-    {
-      id: 'a1',
-      name: 'Autostyle',
-      icon: <ColorizeIcon />,
-      action: () => alert('Action!')
-    }
-  ]}
-  options={[
-    { id: 'o1', name: 'Option 1', action: () => alert('Option 1!') },
-    { id: 'o2', name: 'Option 2', action: () => alert('Option 2!') }
-  ]}
-/>`
-    }
-  }
-};
 
 export const WithOptionsAndCustomIcon = Template.bind({});
 WithOptionsAndCustomIcon.args = {
@@ -213,35 +157,11 @@ WithOptionsAndCustomIcon.args = {
   ],
   optionsIcon: <MenuIcon />
 };
-WithOptionsAndCustomIcon.parameters = {
-  docs: {
-    source: {
-      code: `<WrapperWidgetUI
-  title='Wrapper with options and custom icon'
-  options={[
-    { id: 'o1', name: 'Option 1', action: () => alert('Option 1!') },
-    { id: 'o2', name: 'Option 2', action: () => alert('Option 2!') }
-  ]}
-  optionsIcon={<MenuIcon />}
-/>`
-    }
-  }
-};
 
 export const WithCustomMargins = Template.bind({});
 WithCustomMargins.args = {
   title: 'Wrapper custom margins',
   margin: 100
-};
-WithCustomMargins.parameters = {
-  docs: {
-    source: {
-      code: `<WrapperWidgetUI
-  title='Wrapper custom margins'
-  margin={100}
-/>`
-    }
-  }
 };
 
 export const WithActionsTooltip = Template.bind({});
@@ -269,36 +189,6 @@ WithActionsTooltip.args = {
       }
     }
   ]
-};
-WithActionsTooltip.parameters = {
-  docs: {
-    source: {
-      code: `<WrapperWidgetUI
-  title='Wrapper with actions tooltip'
-  actions={[
-    {
-      id: 'a1',
-      name: 'Autostyle',
-      icon: <ColorizeIcon />,
-      action: () => alert('Action!'),
-      tooltip: {
-        text: 'Tooltip default'
-      }
-    },
-    {
-      id: 'a2',
-      name: 'Autostyle',
-      icon: <AddLocationIcon />,
-      action: () => alert('Action!'),
-      tooltip: {
-        text: 'Tooltip on bottom',
-        placement: 'bottom'
-      }
-    }
-  ]}
-/>`
-    }
-  }
 };
 
 export const BigScrollableContent = (args) => (

--- a/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/WrapperWidgetUI.stories.js
@@ -3,6 +3,7 @@ import ColorizeIcon from '@mui/icons-material/Colorize';
 import MenuIcon from '@mui/icons-material/Menu';
 import AddLocationIcon from '@mui/icons-material/AddLocation';
 import WrapperWidgetUI from '.../../../src/widgets/WrapperWidgetUI';
+import { Label, ThinContainer } from '../../utils/storyStyles';
 
 const options = {
   title: 'Widgets/WrapperWidgetUI',
@@ -34,12 +35,40 @@ const Template = (args) => (
   </WrapperWidgetUI>
 );
 
+const ResponsiveTemplate = (args) => {
+  return (
+    <>
+      <Label variant='body1' mb={3}>
+        {'Limited width'}
+      </Label>
+      <ThinContainer>
+        <WrapperWidgetUI {...args}>
+          <div>Your Content</div>
+        </WrapperWidgetUI>
+      </ThinContainer>
+
+      <Label variant='body1' mt={8} mb={3}>
+        {'Responsive'}
+      </Label>
+      <WrapperWidgetUI {...args}>
+        <div>Your Content</div>
+      </WrapperWidgetUI>
+    </>
+  );
+};
+
 export const Default = Template.bind({});
 const DefaultProps = { title: 'Default wrapper' };
 Default.args = DefaultProps;
 
 export const OnlyTitle = Template.bind({});
 OnlyTitle.args = DefaultProps;
+
+export const LongTitle = ResponsiveTemplate.bind({});
+const LongTitleProps = {
+  title: 'Default wrapper with extra long text overflowing in two lines'
+};
+LongTitle.args = LongTitleProps;
 
 export const Expandable = Template.bind({});
 const ExpandableProps = { title: 'Expandable', expandable: true };


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/353577/fix-cr4-builder-widgets-issue-when-2-lines-is-exceded
[sc-353577]

We needed a new prop to accept more variety of elements in the header, so we can remove custom code in Builder that is causing a UI bug.