### PR TITLE
AppBar: Add support for custom branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- AppBar: Add support for custom branding [#792](https://github.com/CartoDB/carto-react/pull/792)
+
 ## 2.2
 
 ### 2.2.13 (2023-10-16)

--- a/packages/react-ui/src/components/organisms/AppBar/AppBar.d.ts
+++ b/packages/react-ui/src/components/organisms/AppBar/AppBar.d.ts
@@ -9,6 +9,8 @@ export type AppBarTypeMap<D extends React.ElementType<any> = 'header'> = MuiAppB
     secondaryText?: React.ReactNode;
     onClickMenu?: (event: React.MouseEvent) => void;
     showBurgerMenu?: boolean;
+    backgroundColor?: string;
+    textColor?: string;
   },
   D
 >;

--- a/packages/react-ui/src/components/organisms/AppBar/AppBar.js
+++ b/packages/react-ui/src/components/organisms/AppBar/AppBar.js
@@ -9,9 +9,16 @@ import BrandText from './BrandText';
 import SecondaryText from './SecondaryText';
 
 const Root = styled(MuiAppBar, {
-  shouldForwardProp: (prop) => prop !== 'backgroundColor'
-})(({ backgroundColor, theme }) => ({
-  backgroundColor: backgroundColor || theme.palette.brand.navyBlue
+  shouldForwardProp: (prop) => !['backgroundColor', 'textColor'].includes(prop)
+})(({ backgroundColor, textColor, theme }) => ({
+  backgroundColor: backgroundColor || theme.palette.brand.navyBlue,
+
+  '& .MuiTypography-root': {
+    color: textColor || theme.palette.common.white
+  },
+  '& .MuiIconButton-root path': {
+    fill: textColor || theme.palette.common.white
+  }
 }));
 
 const BrandElements = styled('div')(({ theme }) => ({
@@ -45,7 +52,7 @@ const AppBar = ({
   ...otherProps
 }) => {
   return (
-    <Root backgroundColor={backgroundColor} {...otherProps}>
+    <Root backgroundColor={backgroundColor} textColor={textColor} {...otherProps}>
       <Toolbar>
         <BrandElements>
           {showBurgerMenu && (

--- a/packages/react-ui/src/components/organisms/AppBar/AppBar.js
+++ b/packages/react-ui/src/components/organisms/AppBar/AppBar.js
@@ -8,6 +8,20 @@ import BrandLogo from './BrandLogo';
 import BrandText from './BrandText';
 import SecondaryText from './SecondaryText';
 
+const Root = styled(MuiAppBar, {
+  shouldForwardProp: (prop) =>
+    !['textColor', 'backgroundColor', 'hasCloseButton'].includes(prop)
+})(({ textColor, backgroundColor, theme }) => ({
+  backgroundColor: backgroundColor || theme.palette.brand.navyBlue,
+
+  '& .MuiTypography-root': {
+    color: textColor || theme.palette.common.white
+  },
+  '& .MuiIconButton-root svg:not(.doNotFillIcon) path': {
+    fill: textColor || theme.palette.common.white
+  }
+}));
+
 const BrandElements = styled('div')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
@@ -34,10 +48,12 @@ const AppBar = ({
   secondaryText,
   showBurgerMenu,
   onClickMenu,
+  backgroundColor,
+  textColor,
   ...otherProps
 }) => {
   return (
-    <MuiAppBar {...otherProps}>
+    <Root textColor={textColor} backgroundColor={backgroundColor} {...otherProps}>
       <Toolbar>
         <BrandElements>
           {showBurgerMenu && <BurguerMenu onClickMenu={onClickMenu} />}
@@ -48,7 +64,7 @@ const AppBar = ({
 
         <Content>{children}</Content>
       </Toolbar>
-    </MuiAppBar>
+    </Root>
   );
 };
 
@@ -61,7 +77,9 @@ AppBar.propTypes = {
   brandText: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   secondaryText: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   onClickMenu: PropTypes.func,
-  showBurgerMenu: PropTypes.bool
+  showBurgerMenu: PropTypes.bool,
+  backgroundColor: PropTypes.string,
+  textColor: PropTypes.string
 };
 
 export default AppBar;

--- a/packages/react-ui/src/components/organisms/AppBar/AppBar.js
+++ b/packages/react-ui/src/components/organisms/AppBar/AppBar.js
@@ -9,17 +9,9 @@ import BrandText from './BrandText';
 import SecondaryText from './SecondaryText';
 
 const Root = styled(MuiAppBar, {
-  shouldForwardProp: (prop) =>
-    !['textColor', 'backgroundColor', 'hasCloseButton'].includes(prop)
-})(({ textColor, backgroundColor, theme }) => ({
-  backgroundColor: backgroundColor || theme.palette.brand.navyBlue,
-
-  '& .MuiTypography-root': {
-    color: textColor || theme.palette.common.white
-  },
-  '& .MuiIconButton-root svg:not(.doNotFillIcon) path': {
-    fill: textColor || theme.palette.common.white
-  }
+  shouldForwardProp: (prop) => prop !== 'backgroundColor'
+})(({ backgroundColor, theme }) => ({
+  backgroundColor: backgroundColor || theme.palette.brand.navyBlue
 }));
 
 const BrandElements = styled('div')(({ theme }) => ({
@@ -53,23 +45,21 @@ const AppBar = ({
   ...otherProps
 }) => {
   return (
-    <Root textColor={textColor} backgroundColor={backgroundColor} {...otherProps}>
+    <Root backgroundColor={backgroundColor} {...otherProps}>
       <Toolbar>
         <BrandElements>
-          {showBurgerMenu && <BurguerMenu onClickMenu={onClickMenu} />}
+          {showBurgerMenu && (
+            <BurguerMenu onClickMenu={onClickMenu} iconColor={textColor} />
+          )}
           {brandLogo && <BrandLogo logo={brandLogo} />}
-          {brandText && <BrandText text={brandText} />}
-          {secondaryText && <SecondaryText text={secondaryText} />}
+          {brandText && <BrandText text={brandText} textColor={textColor} />}
+          {secondaryText && <SecondaryText text={secondaryText} textColor={textColor} />}
         </BrandElements>
 
         <Content>{children}</Content>
       </Toolbar>
     </Root>
   );
-};
-
-AppBar.defaultProps = {
-  showBurgerMenu: false
 };
 
 AppBar.propTypes = {
@@ -80,6 +70,10 @@ AppBar.propTypes = {
   showBurgerMenu: PropTypes.bool,
   backgroundColor: PropTypes.string,
   textColor: PropTypes.string
+};
+
+AppBar.defaultProps = {
+  showBurgerMenu: false
 };
 
 export default AppBar;

--- a/packages/react-ui/src/components/organisms/AppBar/AppBar.js
+++ b/packages/react-ui/src/components/organisms/AppBar/AppBar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { AppBar as MuiAppBar, Toolbar } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
-import BurguerMenu from './BurguerMenu';
+import BurgerMenu from './BurgerMenu';
 import BrandLogo from './BrandLogo';
 import BrandText from './BrandText';
 import SecondaryText from './SecondaryText';
@@ -56,7 +56,7 @@ const AppBar = ({
       <Toolbar>
         <BrandElements>
           {showBurgerMenu && (
-            <BurguerMenu onClickMenu={onClickMenu} iconColor={textColor} />
+            <BurgerMenu onClickMenu={onClickMenu} iconColor={textColor} />
           )}
           {brandLogo && <BrandLogo logo={brandLogo} />}
           {brandText && <BrandText text={brandText} textColor={textColor} />}

--- a/packages/react-ui/src/components/organisms/AppBar/AppBar.js
+++ b/packages/react-ui/src/components/organisms/AppBar/AppBar.js
@@ -69,6 +69,10 @@ const AppBar = ({
   );
 };
 
+AppBar.defaultProps = {
+  showBurgerMenu: false
+};
+
 AppBar.propTypes = {
   brandLogo: PropTypes.element,
   brandText: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
@@ -77,10 +81,6 @@ AppBar.propTypes = {
   showBurgerMenu: PropTypes.bool,
   backgroundColor: PropTypes.string,
   textColor: PropTypes.string
-};
-
-AppBar.defaultProps = {
-  showBurgerMenu: false
 };
 
 export default AppBar;

--- a/packages/react-ui/src/components/organisms/AppBar/BrandText.js
+++ b/packages/react-ui/src/components/organisms/AppBar/BrandText.js
@@ -3,11 +3,11 @@ import { styled, useTheme } from '@mui/material/styles';
 
 import Typography from '../../atoms/Typography';
 
-const Text = styled(Typography)(({ theme }) => ({
+const Text = styled(Typography)({
   display: 'flex',
   alignItems: 'center',
   whiteSpace: 'nowrap'
-}));
+});
 
 export default function BrandText({ text, textColor }) {
   const theme = useTheme();

--- a/packages/react-ui/src/components/organisms/AppBar/BrandText.js
+++ b/packages/react-ui/src/components/organisms/AppBar/BrandText.js
@@ -3,15 +3,21 @@ import { styled } from '@mui/material/styles';
 
 import Typography from '../../atoms/Typography';
 
-const Text = styled(Typography)({
+const Text = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== 'textColor'
+})(({ textColor, theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  whiteSpace: 'nowrap'
-});
+  whiteSpace: 'nowrap',
 
-export default function BrandText({ text }) {
+  '&.MuiTypography-root': {
+    color: textColor || theme.palette.common.white
+  }
+}));
+
+export default function BrandText({ text, textColor }) {
   return (
-    <Text component='span' variant='subtitle1'>
+    <Text component='span' variant='subtitle1' textColor={textColor}>
       {text}
     </Text>
   );

--- a/packages/react-ui/src/components/organisms/AppBar/BrandText.js
+++ b/packages/react-ui/src/components/organisms/AppBar/BrandText.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled } from '@mui/material/styles';
+import { styled, useTheme } from '@mui/material/styles';
 
 import Typography from '../../atoms/Typography';
 
@@ -8,16 +8,18 @@ const Text = styled(Typography, {
 })(({ textColor, theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  whiteSpace: 'nowrap',
-
-  '&.MuiTypography-root': {
-    color: textColor || theme.palette.common.white
-  }
+  whiteSpace: 'nowrap'
 }));
 
 export default function BrandText({ text, textColor }) {
+  const theme = useTheme();
+
   return (
-    <Text component='span' variant='subtitle1' textColor={textColor}>
+    <Text
+      component='span'
+      variant='subtitle1'
+      textColor={textColor || theme.palette.common.white}
+    >
       {text}
     </Text>
   );

--- a/packages/react-ui/src/components/organisms/AppBar/BrandText.js
+++ b/packages/react-ui/src/components/organisms/AppBar/BrandText.js
@@ -3,9 +3,7 @@ import { styled, useTheme } from '@mui/material/styles';
 
 import Typography from '../../atoms/Typography';
 
-const Text = styled(Typography, {
-  shouldForwardProp: (prop) => prop !== 'textColor'
-})(({ textColor, theme }) => ({
+const Text = styled(Typography)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   whiteSpace: 'nowrap'

--- a/packages/react-ui/src/components/organisms/AppBar/BurgerMenu.js
+++ b/packages/react-ui/src/components/organisms/AppBar/BurgerMenu.js
@@ -30,7 +30,7 @@ const MenuDivider = styled(Divider, {
   })
 }));
 
-export default function BurguerMenu({ onClickMenu, iconColor }) {
+export default function BurgerMenu({ onClickMenu, iconColor }) {
   return (
     <Hidden mdUp>
       <Menu>

--- a/packages/react-ui/src/components/organisms/AppBar/BurguerMenu.js
+++ b/packages/react-ui/src/components/organisms/AppBar/BurguerMenu.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Divider, Hidden, IconButton } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { alpha, styled } from '@mui/material/styles';
 import { MenuOutlined } from '@mui/icons-material';
 
 import { APPBAR_SIZE } from '../../../theme/themeConstants';
@@ -22,6 +22,14 @@ const MenuButton = styled(IconButton, {
   }
 }));
 
+const MenuDivider = styled(Divider, {
+  shouldForwardProp: (prop) => prop !== 'color'
+})(({ color, theme }) => ({
+  ...(color && {
+    borderColor: alpha(color, 0.12)
+  })
+}));
+
 export default function BurguerMenu({ onClickMenu, iconColor }) {
   return (
     <Hidden mdUp>
@@ -29,7 +37,7 @@ export default function BurguerMenu({ onClickMenu, iconColor }) {
         <MenuButton onClick={onClickMenu} iconColor={iconColor}>
           <MenuOutlined />
         </MenuButton>
-        <Divider orientation='vertical' flexItem light />
+        <MenuDivider orientation='vertical' flexItem light color={iconColor} />
       </Menu>
     </Hidden>
   );

--- a/packages/react-ui/src/components/organisms/AppBar/BurguerMenu.js
+++ b/packages/react-ui/src/components/organisms/AppBar/BurguerMenu.js
@@ -12,19 +12,21 @@ const Menu = styled('div')(({ theme }) => ({
   marginRight: theme.spacing(1.5)
 }));
 
-const MenuButton = styled(IconButton)(({ theme }) => ({
+const MenuButton = styled(IconButton, {
+  shouldForwardProp: (prop) => prop !== 'iconColor'
+})(({ iconColor, theme }) => ({
   marginRight: theme.spacing(1),
 
   '&.MuiButtonBase-root svg path': {
-    fill: theme.palette.background.paper
+    fill: iconColor || theme.palette.background.paper
   }
 }));
 
-export default function BurguerMenu({ onClickMenu }) {
+export default function BurguerMenu({ onClickMenu, iconColor }) {
   return (
     <Hidden mdUp>
       <Menu>
-        <MenuButton onClick={onClickMenu}>
+        <MenuButton onClick={onClickMenu} iconColor={iconColor}>
           <MenuOutlined />
         </MenuButton>
         <Divider orientation='vertical' flexItem light />

--- a/packages/react-ui/src/components/organisms/AppBar/SecondaryText.js
+++ b/packages/react-ui/src/components/organisms/AppBar/SecondaryText.js
@@ -3,19 +3,27 @@ import { styled } from '@mui/material/styles';
 
 import Typography from '../../atoms/Typography';
 
-const Text = styled(Typography)(({ theme }) => ({
+const Text = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== 'textColor'
+})(({ textColor, theme }) => ({
   display: 'flex',
   alignItems: 'center',
+
+  '&.MuiTypography-root': {
+    color: textColor || theme.palette.common.white
+  },
+
   '&::before': {
     content: '"/"',
     margin: theme.spacing(0, 1),
-    color: theme.palette.white[60]
+    opacity: 0.6,
+    color: textColor || theme.palette.common.white
   }
 }));
 
-export default function SecondaryText({ text }) {
+export default function SecondaryText({ text, textColor }) {
   return (
-    <Text component='span' variant='body2' weight='strong'>
+    <Text component='span' variant='body2' weight='strong' textColor={textColor}>
       {text}
     </Text>
   );

--- a/packages/react-ui/src/components/organisms/AppBar/SecondaryText.js
+++ b/packages/react-ui/src/components/organisms/AppBar/SecondaryText.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { styled } from '@mui/material/styles';
+import { styled, useTheme } from '@mui/material/styles';
 
 import Typography from '../../atoms/Typography';
 
@@ -8,10 +8,6 @@ const Text = styled(Typography, {
 })(({ textColor, theme }) => ({
   display: 'flex',
   alignItems: 'center',
-
-  '&.MuiTypography-root': {
-    color: textColor || theme.palette.common.white
-  },
 
   '&::before': {
     content: '"/"',
@@ -22,8 +18,15 @@ const Text = styled(Typography, {
 }));
 
 export default function SecondaryText({ text, textColor }) {
+  const theme = useTheme();
+
   return (
-    <Text component='span' variant='body2' weight='strong' textColor={textColor}>
+    <Text
+      component='span'
+      variant='body2'
+      weight='strong'
+      textColor={textColor || theme.palette.common.white}
+    >
       {text}
     </Text>
   );

--- a/packages/react-ui/src/theme/sections/components/surfaces.js
+++ b/packages/react-ui/src/theme/sections/components/surfaces.js
@@ -21,12 +21,6 @@ export const surfacesOverrides = {
           padding: theme.spacing(0, 1),
           minHeight: APPBAR_SIZE
         },
-        '& .MuiTypography-root': {
-          color: theme.palette.common.white
-        },
-        '& .MuiIconButton-root path': {
-          fill: theme.palette.common.white
-        },
         '& .MuiAvatar-root': {
           width: theme.spacing(4),
           height: theme.spacing(4)

--- a/packages/react-ui/storybook/assets/carto-logo-dark.svg
+++ b/packages/react-ui/storybook/assets/carto-logo-dark.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">
+    <g fill="none" fill-rule="evenodd">
+        <g fill="#2C3032">
+            <g transform="translate(-61 -10) translate(61 10)">
+                <path d="M14.03 28C21.746 28 28 21.732 28 14S21.746 0 14.03 0C6.315 0 .06 6.268.06 14s6.255 14 13.97 14z" opacity=".2"/>
+                <ellipse cx="14.03" cy="14" rx="4.657" ry="4.667"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/packages/react-ui/storybook/stories/molecules/Table.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/Table.stories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   Chip,
@@ -11,7 +11,9 @@ import {
   TableBody,
   Table,
   IconButton,
-  MenuItem
+  MenuItem,
+  TableFooter,
+  TablePagination
 } from '@mui/material';
 import SelectField from '../../../src/components/atoms/SelectField';
 import { MoreVertOutlined } from '@mui/icons-material';
@@ -52,7 +54,15 @@ const rows = [
 const options = {
   title: 'Molecules/Table',
   component: Table,
-  argTypes: {},
+  argTypes: {
+    size: {
+      defaultValue: 'medium',
+      control: {
+        type: 'select',
+        options: ['medium', 'small']
+      }
+    }
+  },
   parameters: {
     design: {
       type: 'figma',
@@ -69,7 +79,7 @@ export default options;
 const PlaygroundTemplate = (args) => {
   return (
     <TableContainer>
-      <Table aria-label='simple table'>
+      <Table {...args} aria-label='simple table'>
         <TableHead>
           <TableRow>
             <TableCell>#</TableCell>
@@ -145,7 +155,7 @@ const PlaygroundTemplate = (args) => {
 const ScrollTemplate = (args) => (
   <Box sx={{ width: '100%', overflow: 'hidden' }}>
     <TableContainer sx={{ maxWidth: 440, maxHeight: 300 }}>
-      <Table aria-label='simple table'>
+      <Table {...args} aria-label='simple table'>
         <TableHead>
           <TableRow>
             <TableCell>#</TableCell>
@@ -218,8 +228,110 @@ const ScrollTemplate = (args) => (
   </Box>
 );
 
+const PaginationTemplate = (args) => {
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <TableContainer>
+      <Table {...args} aria-label='simple table'>
+        <TableHead>
+          <TableRow>
+            <TableCell>#</TableCell>
+            <TableCell>Name</TableCell>
+            <TableCell>Type</TableCell>
+            <TableCell>Mode</TableCell>
+            <TableCell>Description</TableCell>
+            <TableCell>Actions</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row, index) => (
+            <TableRow hover key={index}>
+              <TableCell component='th' scope='row'>
+                {index + 1}
+              </TableCell>
+              <TableCell sx={{ maxWidth: 160 }}>
+                {index === 1 ? (
+                  <Tooltip title={row.name}>
+                    <Typography variant='inherit' noWrap>
+                      {row.name}
+                    </Typography>
+                  </Tooltip>
+                ) : (
+                  row.name
+                )}
+              </TableCell>
+              <TableCell>
+                <Chip size='small' color='default' label={row.type} />
+              </TableCell>
+              <TableCell>
+                <SelectField
+                  size='small'
+                  placeholder='Placeholder'
+                  onChange={() => void 0}
+                  value={[]}
+                >
+                  {[...Array(3)].map((item, index) => {
+                    const itemText = `${index + 1}`;
+
+                    return (
+                      <MenuItem key={index} value={itemText}>
+                        {itemText}
+                      </MenuItem>
+                    );
+                  })}
+                </SelectField>
+              </TableCell>
+              <TableCell sx={{ maxWidth: 160 }}>
+                {index === 3 ? (
+                  <Tooltip title={row.description}>
+                    <Typography variant='inherit' noWrap>
+                      {row.description}
+                    </Typography>
+                  </Tooltip>
+                ) : (
+                  row.description
+                )}
+              </TableCell>
+              <TableCell padding='checkbox'>
+                <IconButton size='small'>
+                  <MoreVertOutlined />
+                </IconButton>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TablePagination
+              count={100}
+              page={page}
+              onPageChange={handleChangePage}
+              rowsPerPage={rowsPerPage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
+            />
+          </TableRow>
+        </TableFooter>
+      </Table>
+    </TableContainer>
+  );
+};
+
 export const Playground = PlaygroundTemplate.bind({});
 Playground.args = {};
 
 export const Scroll = ScrollTemplate.bind({});
 ScrollTemplate.args = {};
+
+export const WithPagination = PaginationTemplate.bind({});
+PaginationTemplate.args = {};

--- a/packages/react-ui/storybook/stories/organisms/AppBar.stories.js
+++ b/packages/react-ui/storybook/stories/organisms/AppBar.stories.js
@@ -73,7 +73,7 @@ const CustomTemplate = (args) => {
         <Grid container justifyContent='flex-end' spacing={2}>
           <Grid item>
             <IconButton onClick={handleClick}>
-              <CheckCircleOutline />
+              <CheckCircleOutline className='doNotFillIcon' />
             </IconButton>
             <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
               <MenuItem onClick={handleClose}>Profile</MenuItem>
@@ -127,6 +127,14 @@ export const Basic = Template.bind({});
 Basic.args = { ...commonArgs };
 
 export const Composition = CustomTemplate.bind({});
-Composition.args = { ...commonArgs, backgroundColor: 'aliceblue', textColor: 'red' };
+Composition.args = { ...commonArgs };
+
+export const CustomBranding = Template.bind({});
+CustomBranding.args = {
+  ...commonArgs,
+  brandLogo: <img src='/carto-logo-dark.svg' alt='' />,
+  backgroundColor: '#e1e3e4',
+  textColor: '#024D9E'
+};
 
 export const Guide = DocTemplate.bind({});

--- a/packages/react-ui/storybook/stories/organisms/AppBar.stories.js
+++ b/packages/react-ui/storybook/stories/organisms/AppBar.stories.js
@@ -127,6 +127,6 @@ export const Basic = Template.bind({});
 Basic.args = { ...commonArgs };
 
 export const Composition = CustomTemplate.bind({});
-Composition.args = { ...commonArgs };
+Composition.args = { ...commonArgs, backgroundColor: 'aliceblue', textColor: 'red' };
 
 export const Guide = DocTemplate.bind({});


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/344453/whitelabel-issue-icons-and-other-elements-are-not-respecting-the-app-bar-text-color
[sc-344453]

Add basic support for colors customization in AppBar core components.

<img width="630" alt="Screenshot 2023-10-19 at 11 55 55" src="https://github.com/CartoDB/carto-react/assets/1934144/91ca9580-33a9-4dce-8f91-4a81bc058390">

