### PR TITLE
AppBar: Add new color keys in the Theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- AppBar: Add support for custom branding in the Theme [#794](https://github.com/CartoDB/carto-react/pull/794)
 - AppBar: Add support for custom branding [#792](https://github.com/CartoDB/carto-react/pull/792)
 
 ## 2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- AppBar: Add support for custom branding in the Theme [#794](https://github.com/CartoDB/carto-react/pull/794)
+- AppBar: Add new color keys in the Theme [#794](https://github.com/CartoDB/carto-react/pull/794)
 - AppBar: Add support for custom branding [#792](https://github.com/CartoDB/carto-react/pull/792)
 
 ## 2.2

--- a/packages/react-ui/src/components/organisms/AppBar/AppBar.d.ts
+++ b/packages/react-ui/src/components/organisms/AppBar/AppBar.d.ts
@@ -9,8 +9,6 @@ export type AppBarTypeMap<D extends React.ElementType<any> = 'header'> = MuiAppB
     secondaryText?: React.ReactNode;
     onClickMenu?: (event: React.MouseEvent) => void;
     showBurgerMenu?: boolean;
-    backgroundColor?: string;
-    textColor?: string;
   },
   D
 >;

--- a/packages/react-ui/src/components/organisms/AppBar/AppBar.js
+++ b/packages/react-ui/src/components/organisms/AppBar/AppBar.js
@@ -8,16 +8,14 @@ import BrandLogo from './BrandLogo';
 import BrandText from './BrandText';
 import SecondaryText from './SecondaryText';
 
-const Root = styled(MuiAppBar, {
-  shouldForwardProp: (prop) => !['backgroundColor', 'textColor'].includes(prop)
-})(({ backgroundColor, textColor, theme }) => ({
-  backgroundColor: backgroundColor || theme.palette.brand.navyBlue,
+const Root = styled(MuiAppBar)(({ theme }) => ({
+  backgroundColor: theme.palette.brand.appBarMain,
 
   '& .MuiTypography-root': {
-    color: textColor || theme.palette.common.white
+    color: theme.palette.brand.appBarContrastText
   },
   '& .MuiIconButton-root path': {
-    fill: textColor || theme.palette.common.white
+    fill: theme.palette.brand.appBarContrastText
   }
 }));
 
@@ -47,20 +45,16 @@ const AppBar = ({
   secondaryText,
   showBurgerMenu,
   onClickMenu,
-  backgroundColor,
-  textColor,
   ...otherProps
 }) => {
   return (
-    <Root backgroundColor={backgroundColor} textColor={textColor} {...otherProps}>
+    <Root {...otherProps}>
       <Toolbar>
         <BrandElements>
-          {showBurgerMenu && (
-            <BurgerMenu onClickMenu={onClickMenu} iconColor={textColor} />
-          )}
+          {showBurgerMenu && <BurgerMenu onClickMenu={onClickMenu} />}
           {brandLogo && <BrandLogo logo={brandLogo} />}
-          {brandText && <BrandText text={brandText} textColor={textColor} />}
-          {secondaryText && <SecondaryText text={secondaryText} textColor={textColor} />}
+          {brandText && <BrandText text={brandText} />}
+          {secondaryText && <SecondaryText text={secondaryText} />}
         </BrandElements>
 
         <Content>{children}</Content>
@@ -78,9 +72,7 @@ AppBar.propTypes = {
   brandText: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   secondaryText: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   onClickMenu: PropTypes.func,
-  showBurgerMenu: PropTypes.bool,
-  backgroundColor: PropTypes.string,
-  textColor: PropTypes.string
+  showBurgerMenu: PropTypes.bool
 };
 
 export default AppBar;

--- a/packages/react-ui/src/components/organisms/AppBar/BrandText.js
+++ b/packages/react-ui/src/components/organisms/AppBar/BrandText.js
@@ -16,7 +16,7 @@ export default function BrandText({ text }) {
     <Text
       component='span'
       variant='subtitle1'
-      textColor={theme.palette.brand.appBarContrastText}
+      color={theme.palette.brand.appBarContrastText}
     >
       {text}
     </Text>

--- a/packages/react-ui/src/components/organisms/AppBar/BrandText.js
+++ b/packages/react-ui/src/components/organisms/AppBar/BrandText.js
@@ -9,14 +9,14 @@ const Text = styled(Typography)({
   whiteSpace: 'nowrap'
 });
 
-export default function BrandText({ text, textColor }) {
+export default function BrandText({ text }) {
   const theme = useTheme();
 
   return (
     <Text
       component='span'
       variant='subtitle1'
-      textColor={textColor || theme.palette.common.white}
+      textColor={theme.palette.brand.appBarContrastText}
     >
       {text}
     </Text>

--- a/packages/react-ui/src/components/organisms/AppBar/BurgerMenu.js
+++ b/packages/react-ui/src/components/organisms/AppBar/BurgerMenu.js
@@ -31,7 +31,7 @@ export default function BurgerMenu({ onClickMenu }) {
         <MenuButton onClick={onClickMenu}>
           <MenuOutlined />
         </MenuButton>
-        <MenuDivider orientation='vertical' flexItem light />
+        <MenuDivider orientation='vertical' flexItem />
       </Menu>
     </Hidden>
   );

--- a/packages/react-ui/src/components/organisms/AppBar/BurgerMenu.js
+++ b/packages/react-ui/src/components/organisms/AppBar/BurgerMenu.js
@@ -12,32 +12,26 @@ const Menu = styled('div')(({ theme }) => ({
   marginRight: theme.spacing(1.5)
 }));
 
-const MenuButton = styled(IconButton, {
-  shouldForwardProp: (prop) => prop !== 'iconColor'
-})(({ iconColor, theme }) => ({
+const MenuButton = styled(IconButton)(({ theme }) => ({
   marginRight: theme.spacing(1),
 
   '&.MuiButtonBase-root svg path': {
-    fill: iconColor || theme.palette.background.paper
+    fill: theme.palette.brand.appBarContrastText
   }
 }));
 
-const MenuDivider = styled(Divider, {
-  shouldForwardProp: (prop) => prop !== 'color'
-})(({ color, theme }) => ({
-  ...(color && {
-    borderColor: alpha(color, 0.12)
-  })
+const MenuDivider = styled(Divider)(({ theme }) => ({
+  borderColor: alpha(theme.palette.brand.appBarContrastText, 0.12)
 }));
 
-export default function BurgerMenu({ onClickMenu, iconColor }) {
+export default function BurgerMenu({ onClickMenu }) {
   return (
     <Hidden mdUp>
       <Menu>
-        <MenuButton onClick={onClickMenu} iconColor={iconColor}>
+        <MenuButton onClick={onClickMenu}>
           <MenuOutlined />
         </MenuButton>
-        <MenuDivider orientation='vertical' flexItem light color={iconColor} />
+        <MenuDivider orientation='vertical' flexItem light />
       </Menu>
     </Hidden>
   );

--- a/packages/react-ui/src/components/organisms/AppBar/SecondaryText.js
+++ b/packages/react-ui/src/components/organisms/AppBar/SecondaryText.js
@@ -3,9 +3,7 @@ import { styled, useTheme } from '@mui/material/styles';
 
 import Typography from '../../atoms/Typography';
 
-const Text = styled(Typography, {
-  shouldForwardProp: (prop) => prop !== 'textColor'
-})(({ textColor, theme }) => ({
+const Text = styled(Typography)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
 
@@ -13,11 +11,11 @@ const Text = styled(Typography, {
     content: '"/"',
     margin: theme.spacing(0, 1),
     opacity: 0.6,
-    color: textColor || theme.palette.common.white
+    color: theme.palette.brand.appBarContrastText
   }
 }));
 
-export default function SecondaryText({ text, textColor }) {
+export default function SecondaryText({ text }) {
   const theme = useTheme();
 
   return (
@@ -25,7 +23,7 @@ export default function SecondaryText({ text, textColor }) {
       component='span'
       variant='body2'
       weight='strong'
-      textColor={textColor || theme.palette.common.white}
+      textColor={theme.palette.brand.appBarContrastText}
     >
       {text}
     </Text>

--- a/packages/react-ui/src/components/organisms/AppBar/SecondaryText.js
+++ b/packages/react-ui/src/components/organisms/AppBar/SecondaryText.js
@@ -23,7 +23,7 @@ export default function SecondaryText({ text }) {
       component='span'
       variant='body2'
       weight='strong'
-      textColor={theme.palette.brand.appBarContrastText}
+      color={theme.palette.brand.appBarContrastText}
     >
       {text}
     </Text>

--- a/packages/react-ui/src/theme/carto-theme.d.ts
+++ b/packages/react-ui/src/theme/carto-theme.d.ts
@@ -32,6 +32,8 @@ type CustomBrandPaletteColor = {
   locationRed: string;
   predictionBlue: string;
   softBlue: string;
+  appBarMain: string;
+  appBarContrastText: string;
 };
 type CustomTextPaletteColor = Modify<
   TypeText,

--- a/packages/react-ui/src/theme/sections/palette.js
+++ b/packages/react-ui/src/theme/sections/palette.js
@@ -181,7 +181,9 @@ export const commonPalette = {
     navyBlue: '#162945',
     locationRed: '#EB1510',
     predictionBlue: '#1785FB',
-    softBlue: '#F2F6F9'
+    softBlue: '#F2F6F9',
+    appBarMain: '#162945',
+    appBarContrastText: baseColors.common.white
   },
   white: {
     ...baseColors.shades.light

--- a/packages/react-ui/storybook/stories/foundations/Palette.stories.js
+++ b/packages/react-ui/storybook/stories/foundations/Palette.stories.js
@@ -236,6 +236,8 @@ const BrandTemplate = () => {
       <ColorBox colorVariant={'brand'} colorName={'locationRed'} />
       <ColorBox colorVariant={'brand'} colorName={'predictionBlue'} />
       <ColorBox colorVariant={'brand'} colorName={'softBlue'} />
+      <ColorBox colorVariant={'brand'} colorName={'appBarMain'} />
+      <ColorBox colorVariant={'brand'} colorName={'appBarContrastText'} />
     </Container>
   );
 };

--- a/packages/react-ui/storybook/stories/organisms/AppBar.stories.js
+++ b/packages/react-ui/storybook/stories/organisms/AppBar.stories.js
@@ -1,6 +1,16 @@
 import React from 'react';
-import { Avatar, Chip, Grid, IconButton, Menu, MenuItem } from '@mui/material';
+import {
+  Avatar,
+  Chip,
+  Grid,
+  IconButton,
+  Menu,
+  MenuItem,
+  ThemeProvider,
+  createTheme
+} from '@mui/material';
 import { CheckCircleOutline } from '@mui/icons-material';
+import { cartoThemeOptions } from '../../../src/theme/carto-theme';
 import AppBar from '../../../src/components/organisms/AppBar/AppBar';
 import Typography from '../../../src/components/atoms/Typography';
 import { DocContainer, DocLink, DocHighlight } from '../../utils/storyStyles';
@@ -90,6 +100,32 @@ const CustomTemplate = (args) => {
   );
 };
 
+const BrandingTemplate = (args) => {
+  const backgroundColor = '#e1e3e4';
+  const textColor = '#024D9E';
+
+  const theme = React.useMemo(
+    () =>
+      createTheme({
+        ...cartoThemeOptions,
+        palette: {
+          ...cartoThemeOptions.palette,
+          brand: {
+            appBarMain: backgroundColor,
+            appBarContrastText: textColor
+          }
+        }
+      }),
+    []
+  );
+
+  return (
+    <ThemeProvider theme={theme}>
+      <AppBar {...args} position='static' />
+    </ThemeProvider>
+  );
+};
+
 const DocTemplate = () => {
   return (
     <DocContainer severity='warning'>
@@ -129,12 +165,10 @@ Basic.args = { ...commonArgs };
 export const Composition = CustomTemplate.bind({});
 Composition.args = { ...commonArgs };
 
-export const CustomBranding = Template.bind({});
+export const CustomBranding = BrandingTemplate.bind({});
 CustomBranding.args = {
   ...commonArgs,
-  brandLogo: <img src='/carto-logo-dark.svg' alt='' />,
-  backgroundColor: '#e1e3e4',
-  textColor: '#024D9E'
+  brandLogo: <img src='/carto-logo-dark.svg' alt='' />
 };
 
 export const Guide = DocTemplate.bind({});


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/344453/whitelabel-issue-icons-and-other-elements-are-not-respecting-the-app-bar-text-color
[sc-344453]

Add basic support for colors customization in AppBar core components.

<img width="630" alt="Screenshot 2023-10-19 at 11 55 55" src="https://github.com/CartoDB/carto-react/assets/1934144/91ca9580-33a9-4dce-8f91-4a81bc058390">

