### PR TITLE
Fix TableWidget not displaying quadbin field for a table with spatial index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix TableWidget not displaying quadbin field for a table with spatial index [#799](https://github.com/CartoDB/carto-react/pull/799)
+
 ## 2.2
 
 ### 2.2.14 (2023-10-25)

--- a/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
+++ b/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
@@ -180,9 +180,12 @@ function TableBodyComponent({ columns, rows, onRowClick }) {
             onClick={() => onRowClick && onRowClick(row)}
           >
             {columns.map(({ field, headerName, align, component }) => {
-              const cellValue = Object.entries(row).find(([key]) => {
+              let cellValue = Object.entries(row).find(([key]) => {
                 return key.toUpperCase() === field.toUpperCase();
               })?.[1];
+              if (typeof cellValue === 'bigint') {
+                cellValue = cellValue.toString(); // otherwise TableCell will fail for displaying it
+              }
               return (
                 (headerName || field) && (
                   <TableCellStyled


### PR DESCRIPTION
# Description
Shortcut: #364189

Fix TableWidget not displaying BigInt value coming from quadbin id

## Type of change

- Fix

# Acceptance

TableWidget displays correctly the internal field for 'quadbin', like this:
![image](https://github.com/CartoDB/carto-react/assets/458196/f0b909ea-cd70-45ae-839e-731710ec62a5)

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
