### PR TITLE
Hotfix array columns not working properly in TableWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Fix TableWidget cannot render columns when it contains an array [#802](https://github.com/CartoDB/carto-react/pull/802)
 - Allow server-side table widget without hard limit [#798](https://github.com/CartoDB/carto-react/pull/798)
 
 ## 2.2

--- a/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
+++ b/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
@@ -185,6 +185,10 @@ function TableBodyComponent({ columns, rows, onRowClick }) {
               })?.[1];
               if (typeof cellValue === 'bigint') {
                 cellValue = cellValue.toString(); // otherwise TableCell will fail for displaying it
+              } else if (Array.isArray(cellValue)) {
+                cellValue = `[${cellValue
+                  .map((c) => (typeof c === 'string' ? `"${c}"` : c))
+                  .join(', ')}]`;
               }
               return (
                 (headerName || field) && (

--- a/packages/react-widgets/src/models/utils.js
+++ b/packages/react-widgets/src/models/utils.js
@@ -65,6 +65,8 @@ export function formatTableNameWithFilters(props) {
 export function normalizeObjectKeys(el) {
   if (Array.isArray(el)) {
     return el.map(normalizeObjectKeys);
+  } else if (typeof el !== 'object') {
+    return el;
   }
 
   return Object.entries(el).reduce((acc, [key, value]) => {


### PR DESCRIPTION
# Description

Shortcut: ([link](https://app.shortcut.com/cartoteam/story/365844/eqt-partners-carto-3-account-map-breaks-on-opening-map))

<img width="124" alt="image" src="https://github.com/CartoDB/carto-react/assets/7818205/60da1a0d-367b-4b12-9a41-a48d81544c8f">


## Type of change

- Fix