### PR TITLE
[Pie widget] Removed unnecessary copies if not filterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## Not released
+- [Pie widget] Removed unnecessary copies if not filterable [#815](https://github.com/CartoDB/carto-react/pull/815)
 
 ## 2.3
 

--- a/packages/react-ui/src/widgets/PieWidgetUI/PieWidgetUI.js
+++ b/packages/react-ui/src/widgets/PieWidgetUI/PieWidgetUI.js
@@ -204,21 +204,23 @@ function PieWidgetUI({
 
   return (
     <>
-      <OptionsBar container>
-        <Typography variant='caption' color='textSecondary'>
-          {selectedCategories.length
-            ? intlConfig.formatMessage(
-                { id: 'c4r.widgets.pie.selectedItems' },
-                { items: selectedCategories.length }
-              )
-            : intlConfig.formatMessage({ id: 'c4r.widgets.pie.allSelected' })}
-        </Typography>
-        {selectedCategories.length > 0 && (
-          <Link variant='caption' onClick={handleClearSelectedCategories}>
-            {intlConfig.formatMessage({ id: 'c4r.widgets.pie.clear' })}
-          </Link>
-        )}
-      </OptionsBar>
+      {filterable && (
+        <OptionsBar container>
+          <Typography variant='caption' color='textSecondary'>
+            {selectedCategories.length
+              ? intlConfig.formatMessage(
+                  { id: 'c4r.widgets.pie.selectedItems' },
+                  { items: selectedCategories.length }
+                )
+              : intlConfig.formatMessage({ id: 'c4r.widgets.pie.allSelected' })}
+          </Typography>
+          {selectedCategories.length > 0 && (
+            <Link variant='caption' onClick={handleClearSelectedCategories}>
+              {intlConfig.formatMessage({ id: 'c4r.widgets.pie.clear' })}
+            </Link>
+          )}
+        </OptionsBar>
+      )}
 
       <ChartContent height={height} width={width}>
         <PieCentralText data={processedData} selectedCategories={selectedCategories} />


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/372083/histogram-remove-the-copy-all-from-the-widget-when-the-cross-filtering-option-is-deactivated

## Type of change

- Fix