### PR TITLE
Chip component: Add new colors to the theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Chip component: Add new colors to the theme [#821](https://github.com/CartoDB/carto-react/pull/821)
 - UploadField component: UI fixes and extract pure UI components [#817](https://github.com/CartoDB/carto-react/pull/817)
 
 ## 2.3

--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -406,45 +406,57 @@ export const dataDisplayOverrides = {
         borderColor: theme.palette.secondary.main
       }),
 
-      // Other colors
+      // Status colors
       colorSuccess: ({ theme }) => ({
         '&.MuiChip-outlined': {
-          color: theme.palette.success.main,
+          color: theme.palette.success.dark,
           borderColor: theme.palette.success.main
         },
         '&.MuiChip-filled': {
-          color: theme.palette.success.main,
+          color: theme.palette.success.dark,
           backgroundColor: theme.palette.success.relatedLight
+        },
+        '& .MuiChip-icon': {
+          color: theme.palette.success.main
         }
       }),
       colorInfo: ({ theme }) => ({
         '&.MuiChip-outlined': {
-          color: theme.palette.primary.main,
+          color: theme.palette.primary.dark,
           borderColor: theme.palette.primary.main
         },
         '&.MuiChip-filled': {
-          color: theme.palette.primary.main,
+          color: theme.palette.primary.dark,
           backgroundColor: theme.palette.primary.relatedLight
+        },
+        '& .MuiChip-icon': {
+          color: theme.palette.info.main
         }
       }),
       colorError: ({ theme }) => ({
         '&.MuiChip-outlined': {
-          color: theme.palette.error.main,
+          color: theme.palette.error.dark,
           borderColor: theme.palette.error.main
         },
         '&.MuiChip-filled': {
-          color: theme.palette.error.main,
+          color: theme.palette.error.dark,
           backgroundColor: theme.palette.error.relatedLight
+        },
+        '& .MuiChip-icon': {
+          color: theme.palette.error.main
         }
       }),
       colorWarning: ({ theme }) => ({
         '&.MuiChip-outlined': {
-          color: theme.palette.warning.main,
+          color: theme.palette.warning.relatedDark,
           borderColor: theme.palette.warning.main
         },
         '&.MuiChip-filled': {
-          color: theme.palette.warning.main,
+          color: theme.palette.warning.relatedDark,
           backgroundColor: theme.palette.warning.relatedLight
+        },
+        '& .MuiChip-icon': {
+          color: theme.palette.warning.main
         }
       }),
 

--- a/packages/react-ui/src/theme/sections/components/dataDisplay.js
+++ b/packages/react-ui/src/theme/sections/components/dataDisplay.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { alpha } from '@mui/material/styles';
 import { ICON_SIZE_MEDIUM, ICON_SIZE_LARGE, ICON_SIZE_SMALL } from '../../themeConstants';
 import Typography from '../../../components/atoms/Typography';
 import TablePaginationActions from '../../../components/molecules/Table/TablePaginationActions';
@@ -344,7 +345,7 @@ export const dataDisplayOverrides = {
           minWidth: ICON_SIZE_LARGE,
           height: ICON_SIZE_LARGE
         },
-        '&.Mui-disabled': {
+        '&.MuiChip-root.Mui-disabled': {
           color: theme.palette.text.disabled,
           backgroundColor: theme.palette.action.disabledBackground,
           opacity: 1,
@@ -368,13 +369,20 @@ export const dataDisplayOverrides = {
 
         '& .MuiChip-iconColorPrimary': {
           color: theme.palette.primary.contrastText
+        },
+        '& .MuiChip-deleteIcon:hover': {
+          color: theme.palette.text.primary
         }
       }),
       filledPrimary: ({ theme }) => ({
         backgroundColor: theme.palette.primary.main,
 
         '& .MuiChip-deleteIcon': {
-          color: theme.palette.white[60]
+          color: theme.palette.white[60],
+
+          '&:hover': {
+            color: theme.palette.common.white
+          }
         }
       }),
       filledSecondary: ({ theme }) => ({
@@ -383,7 +391,7 @@ export const dataDisplayOverrides = {
       outlined: ({ theme }) => ({
         borderColor: theme.palette.default.outlinedBorder,
 
-        '&.Mui-disabled': {
+        '&.MuiChip-root.Mui-disabled': {
           borderColor: theme.palette.default.outlinedBorder,
           backgroundColor: 'transparent'
         },
@@ -396,6 +404,48 @@ export const dataDisplayOverrides = {
       }),
       outlinedSecondary: ({ theme }) => ({
         borderColor: theme.palette.secondary.main
+      }),
+
+      // Other colors
+      colorSuccess: ({ theme }) => ({
+        '&.MuiChip-outlined': {
+          color: theme.palette.success.main,
+          borderColor: theme.palette.success.main
+        },
+        '&.MuiChip-filled': {
+          color: theme.palette.success.main,
+          backgroundColor: theme.palette.success.relatedLight
+        }
+      }),
+      colorInfo: ({ theme }) => ({
+        '&.MuiChip-outlined': {
+          color: theme.palette.primary.main,
+          borderColor: theme.palette.primary.main
+        },
+        '&.MuiChip-filled': {
+          color: theme.palette.primary.main,
+          backgroundColor: theme.palette.primary.relatedLight
+        }
+      }),
+      colorError: ({ theme }) => ({
+        '&.MuiChip-outlined': {
+          color: theme.palette.error.main,
+          borderColor: theme.palette.error.main
+        },
+        '&.MuiChip-filled': {
+          color: theme.palette.error.main,
+          backgroundColor: theme.palette.error.relatedLight
+        }
+      }),
+      colorWarning: ({ theme }) => ({
+        '&.MuiChip-outlined': {
+          color: theme.palette.warning.main,
+          borderColor: theme.palette.warning.main
+        },
+        '&.MuiChip-filled': {
+          color: theme.palette.warning.main,
+          backgroundColor: theme.palette.warning.relatedLight
+        }
       }),
 
       // Sizes
@@ -431,15 +481,7 @@ export const dataDisplayOverrides = {
         margin: 0,
         marginLeft: '2px', // Forced to a non-standard value to meet with design
         marginRight: '3px', // Forced to a non-standard value to meet with design
-        transition: 'color 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-
-        '&.MuiChip-deleteIconColorDefault': {
-          color: theme.palette.text.secondary,
-
-          '&:hover': {
-            color: theme.palette.text.primary
-          }
-        }
+        transition: 'color 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms'
       }),
       deleteIconSmall: ({ theme }) => ({
         width: theme.spacing(2),
@@ -470,6 +512,22 @@ export const dataDisplayOverrides = {
             },
             '&.MuiChip-colorDefault': {
               borderColor: theme.palette.default.dark
+            },
+            '&.MuiChip-colorSuccess': {
+              color: theme.palette.success.dark,
+              borderColor: theme.palette.success.dark
+            },
+            '&.MuiChip-colorInfo': {
+              color: theme.palette.info.dark,
+              borderColor: theme.palette.info.dark
+            },
+            '&.MuiChip-colorError': {
+              color: theme.palette.error.dark,
+              borderColor: theme.palette.error.dark
+            },
+            '&.MuiChip-colorWarning': {
+              color: theme.palette.warning.dark,
+              borderColor: theme.palette.warning.dark
             }
           }
         },
@@ -480,6 +538,18 @@ export const dataDisplayOverrides = {
             },
             '&.MuiChip-colorDefault': {
               backgroundColor: theme.palette.default.dark
+            },
+            '&.MuiChip-colorSuccess': {
+              backgroundColor: alpha(theme.palette.success.main, 0.25)
+            },
+            '&.MuiChip-colorInfo': {
+              backgroundColor: alpha(theme.palette.info.main, 0.12)
+            },
+            '&.MuiChip-colorError': {
+              backgroundColor: alpha(theme.palette.error.main, 0.12)
+            },
+            '&.MuiChip-colorWarning': {
+              backgroundColor: alpha(theme.palette.warning.main, 0.25)
             }
           }
         }

--- a/packages/react-ui/storybook/stories/molecules/Chip.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/Chip.stories.js
@@ -21,7 +21,15 @@ const options = {
     color: {
       control: {
         type: 'select',
-        options: ['primary', 'secondary', 'default']
+        options: [
+          'primary',
+          'secondary',
+          'default',
+          'success',
+          'info',
+          'error',
+          'warning'
+        ]
       }
     },
     deleteIcon: {
@@ -103,7 +111,7 @@ const PrefixTemplate = ({ ...args }) => {
       <Grid item>
         <Container>
           <Label variant='body2'>{'Primary'}</Label>
-          <Grid container item spacing={6}>
+          <Grid container item spacing={2}>
             <Grid item>
               <Chip {...args} avatar={<Avatar>M</Avatar>} />
             </Grid>
@@ -133,7 +141,7 @@ const PrefixTemplate = ({ ...args }) => {
       <Grid item>
         <Container>
           <Label variant='body2'>{'Secondary'}</Label>
-          <Grid container item spacing={6}>
+          <Grid container item spacing={2}>
             <Grid item>
               <Chip {...args} color='secondary' avatar={<Avatar>M</Avatar>} />
             </Grid>
@@ -178,7 +186,7 @@ const PrefixTemplate = ({ ...args }) => {
       <Grid item>
         <Container>
           <Label variant='body2'>{'Default'}</Label>
-          <Grid container item spacing={6}>
+          <Grid container item spacing={2}>
             <Grid item>
               <Chip {...args} color='default' avatar={<Avatar>M</Avatar>} />
             </Grid>
@@ -212,6 +220,186 @@ const PrefixTemplate = ({ ...args }) => {
               <Chip
                 {...args}
                 color='default'
+                variant='outlined'
+                icon={<FileUploadOutlined />}
+              />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Container>
+          <Label variant='body2'>{'Success'}</Label>
+          <Grid container item spacing={2}>
+            <Grid item>
+              <Chip {...args} color='success' avatar={<Avatar>M</Avatar>} />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='success'
+                variant='outlined'
+                avatar={<Avatar>M</Avatar>}
+              />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='success'
+                avatar={<Avatar label='Avatar' src='/avatar.jpeg' />}
+              />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='success'
+                variant='outlined'
+                avatar={<Avatar label='Avatar' src='/avatar.jpeg' />}
+              />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='success' icon={<FileUploadOutlined />} />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='success'
+                variant='outlined'
+                icon={<FileUploadOutlined />}
+              />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Container>
+          <Label variant='body2'>{'Info'}</Label>
+          <Grid container item spacing={2}>
+            <Grid item>
+              <Chip {...args} color='info' avatar={<Avatar>M</Avatar>} />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='info'
+                variant='outlined'
+                avatar={<Avatar>M</Avatar>}
+              />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='info'
+                avatar={<Avatar label='Avatar' src='/avatar.jpeg' />}
+              />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='info'
+                variant='outlined'
+                avatar={<Avatar label='Avatar' src='/avatar.jpeg' />}
+              />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='info' icon={<FileUploadOutlined />} />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='info'
+                variant='outlined'
+                icon={<FileUploadOutlined />}
+              />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Container>
+          <Label variant='body2'>{'Error'}</Label>
+          <Grid container item spacing={2}>
+            <Grid item>
+              <Chip {...args} color='error' avatar={<Avatar>M</Avatar>} />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='error'
+                variant='outlined'
+                avatar={<Avatar>M</Avatar>}
+              />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='error'
+                avatar={<Avatar label='Avatar' src='/avatar.jpeg' />}
+              />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='error'
+                variant='outlined'
+                avatar={<Avatar label='Avatar' src='/avatar.jpeg' />}
+              />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='error' icon={<FileUploadOutlined />} />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='error'
+                variant='outlined'
+                icon={<FileUploadOutlined />}
+              />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Container>
+          <Label variant='body2'>{'Warning'}</Label>
+          <Grid container item spacing={2}>
+            <Grid item>
+              <Chip {...args} color='warning' avatar={<Avatar>M</Avatar>} />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='warning'
+                variant='outlined'
+                avatar={<Avatar>M</Avatar>}
+              />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='warning'
+                avatar={<Avatar label='Avatar' src='/avatar.jpeg' />}
+              />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='warning'
+                variant='outlined'
+                avatar={<Avatar label='Avatar' src='/avatar.jpeg' />}
+              />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='warning' icon={<FileUploadOutlined />} />
+            </Grid>
+            <Grid item>
+              <Chip
+                {...args}
+                color='warning'
                 variant='outlined'
                 icon={<FileUploadOutlined />}
               />
@@ -267,6 +455,62 @@ const RemovableTemplate = ({ ...args }) => {
           </Grid>
         </Container>
       </Grid>
+
+      <Grid item>
+        <Container>
+          <Label variant='body2'>{'Success'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='success' />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='success' variant='outlined' />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Container>
+          <Label variant='body2'>{'Info'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='info' />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='info' variant='outlined' />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Container>
+          <Label variant='body2'>{'Error'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='error' />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='error' variant='outlined' />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Container>
+          <Label variant='body2'>{'Warning'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='warning' />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='warning' variant='outlined' />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
     </Grid>
   );
 };
@@ -287,6 +531,7 @@ const ColorsTemplate = ({ ...args }) => {
           </Grid>
         </Container>
       </Grid>
+
       <Grid item>
         <Container>
           <Label variant='body2'>{'Secondary'}</Label>
@@ -300,6 +545,7 @@ const ColorsTemplate = ({ ...args }) => {
           </Grid>
         </Container>
       </Grid>
+
       <Grid item>
         <Container>
           <Label variant='body2'>{'Default'}</Label>
@@ -309,6 +555,62 @@ const ColorsTemplate = ({ ...args }) => {
             </Grid>
             <Grid item>
               <Chip {...args} color='default' variant='outlined' />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Container>
+          <Label variant='body2'>{'Success'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='success' />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='success' variant='outlined' />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Container>
+          <Label variant='body2'>{'Info'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='info' />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='info' variant='outlined' />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Container>
+          <Label variant='body2'>{'Error'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='error' />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='error' variant='outlined' />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Container>
+          <Label variant='body2'>{'Warning'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='warning' />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='warning' variant='outlined' />
             </Grid>
           </Grid>
         </Container>
@@ -426,6 +728,154 @@ const SizeTemplate = ({ ...args }) => {
             </Grid>
             <Grid item>
               <Chip {...args} color='default' variant='outlined' disabled />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Header variant='subtitle1'>{'Success'}</Header>
+        <Container>
+          <Label variant='body2'>{'Default (hover icon)'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='success' />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='success' variant='outlined' />
+            </Grid>
+          </Grid>
+        </Container>
+        <Container>
+          <Label variant='body2'>{'Clickable (hover chip)'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='success' clickable />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='success' variant='outlined' clickable />
+            </Grid>
+          </Grid>
+        </Container>
+        <Container>
+          <Label variant='body2'>{'Disabled'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='success' disabled />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='success' variant='outlined' disabled />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Header variant='subtitle1'>{'Info'}</Header>
+        <Container>
+          <Label variant='body2'>{'Default (hover icon)'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='info' />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='info' variant='outlined' />
+            </Grid>
+          </Grid>
+        </Container>
+        <Container>
+          <Label variant='body2'>{'Clickable (hover chip)'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='info' clickable />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='info' variant='outlined' clickable />
+            </Grid>
+          </Grid>
+        </Container>
+        <Container>
+          <Label variant='body2'>{'Disabled'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='info' disabled />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='info' variant='outlined' disabled />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Header variant='subtitle1'>{'Error'}</Header>
+        <Container>
+          <Label variant='body2'>{'Default (hover icon)'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='error' />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='error' variant='outlined' />
+            </Grid>
+          </Grid>
+        </Container>
+        <Container>
+          <Label variant='body2'>{'Clickable (hover chip)'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='error' clickable />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='error' variant='outlined' clickable />
+            </Grid>
+          </Grid>
+        </Container>
+        <Container>
+          <Label variant='body2'>{'Disabled'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='error' disabled />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='error' variant='outlined' disabled />
+            </Grid>
+          </Grid>
+        </Container>
+      </Grid>
+
+      <Grid item>
+        <Header variant='subtitle1'>{'Warning'}</Header>
+        <Container>
+          <Label variant='body2'>{'Default (hover icon)'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='warning' />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='warning' variant='outlined' />
+            </Grid>
+          </Grid>
+        </Container>
+        <Container>
+          <Label variant='body2'>{'Clickable (hover chip)'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='warning' clickable />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='warning' variant='outlined' clickable />
+            </Grid>
+          </Grid>
+        </Container>
+        <Container>
+          <Label variant='body2'>{'Disabled'}</Label>
+          <Grid container item spacing={6}>
+            <Grid item>
+              <Chip {...args} color='warning' disabled />
+            </Grid>
+            <Grid item>
+              <Chip {...args} color='warning' variant='outlined' disabled />
             </Grid>
           </Grid>
         </Container>


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/375276/expired-join-requests-can-t-be-approved
[sc-375276]

Add color definition to the theme to simplify the UI of AccountInvitationsStatus.tsx. 
It is also useful to simplify WorkflowSidebarStatus.tsx

![Screenshot 2024-01-11 at 17 11 00](https://github.com/CartoDB/carto-react/assets/1934144/959b4a84-f4c6-41e8-8033-5b7078103e8f)

