### PR TITLE
ToggleButtonGroup component: Add support for variant and backgroundColor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- ToggleButtonGroup component: Add support for variant [#824](https://github.com/CartoDB/carto-react/pull/824)
+
 ## 2.3
 
 ### 2.3.7 (2024-01-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- ToggleButtonGroup component: Add support for variant [#824](https://github.com/CartoDB/carto-react/pull/824)
+- ToggleButtonGroup component: Add support for variant and backgroundColor [#824](https://github.com/CartoDB/carto-react/pull/824)
 
 ## 2.3
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -204,6 +204,17 @@ So, instead of Mui Button, the component you should use to create buttons is thi
 
 For external use: `import { Button } from '@carto/react-ui';`.
 
+### ToggleButtonGroup
+
+We have a `ToggleButtonGroup` component that uses `Mui ToggleButtonGroup` and extends it with some extra props:
+
+- variant
+
+So, instead of Mui ToggleButtonGroup, the component you should use is this one:
+`react-ui/src/components/atoms/ToggleButtonGroup`
+
+For external use: `import { ToggleButtonGroup } from '@carto/react-ui';`.
+
 ### AppBar
 
 We have a custom component to build the basic structure and styles on top of AppBar Mui component.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -209,6 +209,7 @@ For external use: `import { Button } from '@carto/react-ui';`.
 We have a `ToggleButtonGroup` component that uses `Mui ToggleButtonGroup` and extends it with some extra props:
 
 - variant
+- backgroundColor
 
 So, instead of Mui ToggleButtonGroup, the component you should use is this one:
 `react-ui/src/components/atoms/ToggleButtonGroup`

--- a/packages/react-ui/src/components/atoms/ToggleButtonGroup.d.ts
+++ b/packages/react-ui/src/components/atoms/ToggleButtonGroup.d.ts
@@ -1,0 +1,8 @@
+import { ToggleButtonGroupProps as MuiToggleButtonGroupProps } from '@mui/material';
+
+export type ToggleButtonGroupProps = MuiToggleButtonGroupProps & {
+  variant?: 'contained' | 'text';
+};
+
+declare const ToggleButtonGroup: (props: ToggleButtonGroupProps) => JSX.Element;
+export default ToggleButtonGroup;

--- a/packages/react-ui/src/components/atoms/ToggleButtonGroup.d.ts
+++ b/packages/react-ui/src/components/atoms/ToggleButtonGroup.d.ts
@@ -1,7 +1,8 @@
 import { ToggleButtonGroupProps as MuiToggleButtonGroupProps } from '@mui/material';
 
 export type ToggleButtonGroupProps = MuiToggleButtonGroupProps & {
-  variant?: 'contained' | 'text';
+  variant?: 'contained' | 'floating' | 'unbounded';
+  backgroundColor?: 'primary' | 'secondary' | 'transparent';
 };
 
 declare const ToggleButtonGroup: (props: ToggleButtonGroupProps) => JSX.Element;

--- a/packages/react-ui/src/components/atoms/ToggleButtonGroup.js
+++ b/packages/react-ui/src/components/atoms/ToggleButtonGroup.js
@@ -11,6 +11,7 @@ const StyledToggleButtonGroup = styled(MuiToggleButtonGroup, {
   }),
   ...(variant === 'unbounded' && {
     boxShadow: 'none',
+    borderRadius: theme.spacing(0.5),
 
     '& .MuiDivider-root': {
       height: theme.spacing(4),
@@ -19,8 +20,8 @@ const StyledToggleButtonGroup = styled(MuiToggleButtonGroup, {
         height: theme.spacing(4)
       },
       '&.MuiToggleButtonGroup-groupedVertical': {
-        width: theme.spacing(4),
         height: 'auto',
+        width: theme.spacing(4),
         margin: `${theme.spacing(0.5, 0, 1)} !important`,
         borderRadius: '0 !important'
       }
@@ -29,10 +30,14 @@ const StyledToggleButtonGroup = styled(MuiToggleButtonGroup, {
     '& .MuiToggleButton-sizeSmall': {
       margin: 0,
 
+      '&.MuiToggleButtonGroup-grouped:not(.MuiDivider-root)': {
+        margin: 0
+      },
       '& + .MuiDivider-root.MuiToggleButtonGroup-groupedHorizontal': {
         height: theme.spacing(3)
       },
       '& + .MuiDivider-root.MuiToggleButtonGroup-groupedVertical': {
+        height: 'auto',
         width: theme.spacing(3)
       }
     },
@@ -41,14 +46,10 @@ const StyledToggleButtonGroup = styled(MuiToggleButtonGroup, {
       margin: 0,
 
       '&:first-of-type': {
-        marginLeft: 0,
-        borderRadius: theme.spacing(1, 0.5, 0.5, 1)
+        marginLeft: 0
       },
       '&:not(:last-of-type)': {
         marginRight: theme.spacing(0.5)
-      },
-      '&:last-of-type': {
-        borderRadius: theme.spacing(0.5, 1, 1, 0.5)
       }
     },
     '&.MuiToggleButtonGroup-horizontal:not(.MuiDivider-root)': {
@@ -60,15 +61,11 @@ const StyledToggleButtonGroup = styled(MuiToggleButtonGroup, {
       '.MuiToggleButtonGroup-grouped': {
         margin: theme.spacing(0, 0, 0.5),
 
-        '&:first-of-type': {
-          borderRadius: theme.spacing(1, 1, 0.5, 0.5)
-        },
         '&:not(:last-of-type)': {
           marginRight: 0
         },
         '&:last-of-type': {
-          marginBottom: 0,
-          borderRadius: theme.spacing(0.5, 0.5, 1, 1)
+          marginBottom: 0
         }
       }
     }

--- a/packages/react-ui/src/components/atoms/ToggleButtonGroup.js
+++ b/packages/react-ui/src/components/atoms/ToggleButtonGroup.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ToggleButtonGroup as MuiToggleButtonGroup, styled } from '@mui/material';
+
+const StyledToggleButtonGroup = styled(MuiToggleButtonGroup, {
+  shouldForwardProp: (prop) => prop !== 'variant'
+})(({ variant, theme }) => ({
+  boxShadow: variant === 'contained' ? 'none' : undefined,
+  backgroundColor: variant === 'contained' ? theme.palette.background.default : undefined
+}));
+
+const ToggleButtonGroup = ({ children, variant, ...rest }) => {
+  return (
+    <StyledToggleButtonGroup {...rest} variant={variant}>
+      {children}
+    </StyledToggleButtonGroup>
+  );
+};
+
+ToggleButtonGroup.defaultProps = {
+  variant: 'text'
+};
+
+ToggleButtonGroup.propTypes = {
+  variant: PropTypes.oneOf(['text', 'contained'])
+};
+
+export default ToggleButtonGroup;

--- a/packages/react-ui/src/components/atoms/ToggleButtonGroup.js
+++ b/packages/react-ui/src/components/atoms/ToggleButtonGroup.js
@@ -5,8 +5,10 @@ import { ToggleButtonGroup as MuiToggleButtonGroup, styled } from '@mui/material
 const StyledToggleButtonGroup = styled(MuiToggleButtonGroup, {
   shouldForwardProp: (prop) => prop !== 'variant'
 })(({ variant, theme }) => ({
-  boxShadow: variant === 'contained' ? 'none' : undefined,
-  backgroundColor: variant === 'contained' ? theme.palette.background.default : undefined
+  ...(variant === 'contained' && {
+    boxShadow: 'none',
+    backgroundColor: theme.palette.background.default
+  })
 }));
 
 const ToggleButtonGroup = ({ children, variant, ...rest }) => {

--- a/packages/react-ui/src/components/atoms/ToggleButtonGroup.js
+++ b/packages/react-ui/src/components/atoms/ToggleButtonGroup.js
@@ -3,28 +3,85 @@ import PropTypes from 'prop-types';
 import { ToggleButtonGroup as MuiToggleButtonGroup, styled } from '@mui/material';
 
 const StyledToggleButtonGroup = styled(MuiToggleButtonGroup, {
-  shouldForwardProp: (prop) => prop !== 'variant'
-})(({ variant, theme }) => ({
+  shouldForwardProp: (prop) => !['variant', 'backgroundColor'].includes(prop)
+})(({ variant, backgroundColor, theme }) => ({
+  // Variants
   ...(variant === 'contained' && {
+    boxShadow: 'none'
+  }),
+  ...(variant === 'unbounded' && {
     boxShadow: 'none',
+
+    '.MuiToggleButtonGroup-grouped': {
+      margin: 0,
+
+      '&.MuiToggleButton-sizeSmall': {
+        margin: 0
+      },
+
+      '&:first-of-type': {
+        marginLeft: 0,
+        borderRadius: theme.spacing(1, 0.5, 0.5, 1)
+      },
+      '&:not(:last-of-type)': {
+        marginRight: theme.spacing(0.5)
+      },
+      '&:last-of-type': {
+        borderRadius: theme.spacing(0.5, 1, 1, 0.5)
+      }
+    },
+    '&.MuiToggleButtonGroup-vertical': {
+      '.MuiToggleButtonGroup-grouped': {
+        margin: theme.spacing(0, 0, 0.5),
+
+        '&:first-of-type': {
+          borderRadius: theme.spacing(1, 1, 0.5, 0.5)
+        },
+        '&:not(:last-of-type)': {
+          marginRight: 0
+        },
+        '&:last-of-type': {
+          marginBottom: 0,
+          borderRadius: theme.spacing(0.5, 0.5, 1, 1)
+        }
+      }
+    }
+  }),
+
+  // Colors
+  ...(backgroundColor === 'primary' && {
+    backgroundColor: theme.palette.background.paper
+  }),
+  ...(backgroundColor === 'secondary' && {
     backgroundColor: theme.palette.background.default
+  }),
+  ...(backgroundColor === 'transparent' && {
+    backgroundColor: 'transparent'
   })
 }));
 
-const ToggleButtonGroup = ({ children, variant, ...rest }) => {
+const ToggleButtonGroup = ({ children, variant, backgroundColor, ...rest }) => {
+  const isUnbounded = variant === 'unbounded';
+  const defaultColor = isUnbounded ? 'transparent' : 'primary';
+
   return (
-    <StyledToggleButtonGroup {...rest} variant={variant}>
+    <StyledToggleButtonGroup
+      {...rest}
+      variant={variant}
+      backgroundColor={backgroundColor || defaultColor}
+    >
       {children}
     </StyledToggleButtonGroup>
   );
 };
 
 ToggleButtonGroup.defaultProps = {
-  variant: 'text'
+  variant: 'floating'
 };
 
 ToggleButtonGroup.propTypes = {
-  variant: PropTypes.oneOf(['text', 'contained'])
+  variant: PropTypes.oneOf(['floating', 'contained', 'unbounded']),
+  backgroundColor: PropTypes.oneOf(['primary', 'secondary', 'transparent'])
 };
 
 export default ToggleButtonGroup;

--- a/packages/react-ui/src/components/atoms/ToggleButtonGroup.js
+++ b/packages/react-ui/src/components/atoms/ToggleButtonGroup.js
@@ -12,12 +12,33 @@ const StyledToggleButtonGroup = styled(MuiToggleButtonGroup, {
   ...(variant === 'unbounded' && {
     boxShadow: 'none',
 
-    '.MuiToggleButtonGroup-grouped': {
+    '& .MuiDivider-root': {
+      height: theme.spacing(4),
+
+      '&.MuiToggleButtonGroup-groupedHorizontal': {
+        height: theme.spacing(4)
+      },
+      '&.MuiToggleButtonGroup-groupedVertical': {
+        width: theme.spacing(4),
+        height: 'auto',
+        margin: `${theme.spacing(0.5, 0, 1)} !important`,
+        borderRadius: '0 !important'
+      }
+    },
+
+    '& .MuiToggleButton-sizeSmall': {
       margin: 0,
 
-      '&.MuiToggleButton-sizeSmall': {
-        margin: 0
+      '& + .MuiDivider-root.MuiToggleButtonGroup-groupedHorizontal': {
+        height: theme.spacing(3)
       },
+      '& + .MuiDivider-root.MuiToggleButtonGroup-groupedVertical': {
+        width: theme.spacing(3)
+      }
+    },
+
+    '.MuiToggleButtonGroup-grouped:not(.MuiDivider-root)': {
+      margin: 0,
 
       '&:first-of-type': {
         marginLeft: 0,
@@ -30,7 +51,12 @@ const StyledToggleButtonGroup = styled(MuiToggleButtonGroup, {
         borderRadius: theme.spacing(0.5, 1, 1, 0.5)
       }
     },
-    '&.MuiToggleButtonGroup-vertical': {
+    '&.MuiToggleButtonGroup-horizontal:not(.MuiDivider-root)': {
+      '.MuiToggleButtonGroup-grouped': {
+        margin: theme.spacing(0, 0.5)
+      }
+    },
+    '&.MuiToggleButtonGroup-vertical:not(.MuiDivider-root)': {
       '.MuiToggleButtonGroup-grouped': {
         margin: theme.spacing(0, 0, 0.5),
 

--- a/packages/react-ui/src/index.d.ts
+++ b/packages/react-ui/src/index.d.ts
@@ -37,8 +37,11 @@ import Typography, {
   TypographyProps
 } from './components/atoms/Typography';
 import Button, { ButtonProps } from './components/atoms/Button';
-import PasswordField, { PasswordFieldProps } from './components/atoms/PasswordField';
 import SelectField, { SelectFieldProps } from './components/atoms/SelectField';
+import PasswordField, { PasswordFieldProps } from './components/atoms/PasswordField';
+import ToggleButtonGroup, {
+  ToggleButtonGroupProps
+} from './components/atoms/ToggleButtonGroup';
 import UploadField, {
   UploadFieldProps
 } from './components/molecules/UploadField/UploadField';
@@ -101,6 +104,8 @@ export {
   CartoFontWeight,
   Button,
   ButtonProps,
+  ToggleButtonGroup,
+  ToggleButtonGroupProps,
   PasswordField,
   PasswordFieldProps,
   SelectField,

--- a/packages/react-ui/src/index.js
+++ b/packages/react-ui/src/index.js
@@ -31,6 +31,7 @@ import CircleIcon from './assets/icons/CircleIcon';
 import ArrowDropIcon from './assets/icons/ArrowDropIcon';
 import Typography from './components/atoms/Typography';
 import Button from './components/atoms/Button';
+import ToggleButtonGroup from './components/atoms/ToggleButtonGroup';
 import PasswordField from './components/atoms/PasswordField';
 import SelectField from './components/atoms/SelectField';
 import UploadField from './components/molecules/UploadField/UploadField';
@@ -86,6 +87,7 @@ export {
   LegendRamp,
   Typography,
   Button,
+  ToggleButtonGroup,
   PasswordField,
   SelectField,
   UploadField,

--- a/packages/react-ui/src/theme/sections/components/buttons.js
+++ b/packages/react-ui/src/theme/sections/components/buttons.js
@@ -397,9 +397,25 @@ export const buttonsOverrides = {
             borderRadius: radius
           },
         '.MuiDivider-root': {
-          height: sizeLarge,
-          margin: theme.spacing(0, 1),
-          marginLeft: theme.spacing(0.5)
+          '&.MuiToggleButtonGroup-groupedHorizontal': {
+            height: sizeLarge,
+            margin: theme.spacing(0, 1),
+            marginLeft: theme.spacing(0.5)
+          },
+          '&.MuiToggleButtonGroup-groupedVertical': {
+            width: sizeLarge,
+            margin: theme.spacing(1, 0),
+            marginTop: theme.spacing(0.5)
+          }
+        },
+
+        '.MuiToggleButton-sizeSmall': {
+          '& + .MuiDivider-root.MuiToggleButtonGroup-groupedHorizontal': {
+            height: sizeMedium
+          },
+          '& + .MuiDivider-root.MuiToggleButtonGroup-groupedVertical': {
+            width: sizeMedium
+          }
         }
       }),
       // Styles applied to the children if orientation="horizontal"
@@ -412,19 +428,24 @@ export const buttonsOverrides = {
           marginLeft: 0,
           borderLeft: 'none'
         },
-        '&:first-of-type': {
+        '&:first-of-type:not(.MuiDivider-root)': {
           marginLeft: theme.spacing(1)
         },
-        '&.MuiToggleButton-sizeSmall': {
+        '&.MuiToggleButton-sizeSmall:not(.MuiDivider-root)': {
           height: sizeSmall,
           margin: theme.spacing(0.5),
 
           '&:not(:first-of-type)': {
             marginLeft: 0
-          },
-          '& + .MuiDivider-root': {
-            height: sizeMedium
           }
+          /*           '& + .MuiDivider-root': {
+            '&.MuiToggleButtonGroup-groupedHorizontal': {
+              height: sizeMedium
+            },
+            '&.MuiToggleButtonGroup-groupedVertical': {
+              width: sizeMedium
+            }
+          } */
         }
       }),
       // Styles applied to the children if orientation="vertical"

--- a/packages/react-ui/src/theme/sections/components/buttons.js
+++ b/packages/react-ui/src/theme/sections/components/buttons.js
@@ -438,14 +438,6 @@ export const buttonsOverrides = {
           '&:not(:first-of-type)': {
             marginLeft: 0
           }
-          /*           '& + .MuiDivider-root': {
-            '&.MuiToggleButtonGroup-groupedHorizontal': {
-              height: sizeMedium
-            },
-            '&.MuiToggleButtonGroup-groupedVertical': {
-              width: sizeMedium
-            }
-          } */
         }
       }),
       // Styles applied to the children if orientation="vertical"

--- a/packages/react-ui/src/theme/sections/components/buttons.js
+++ b/packages/react-ui/src/theme/sections/components/buttons.js
@@ -434,7 +434,11 @@ export const buttonsOverrides = {
 
         '&.MuiToggleButton-root': {
           marginLeft: theme.spacing(1),
-          marginBottom: theme.spacing(0.5)
+          marginBottom: theme.spacing(0.5),
+
+          '&:last-of-type': {
+            marginBottom: theme.spacing(1)
+          }
         },
         '&.MuiToggleButton-sizeSmall': {
           width: sizeSmall,
@@ -442,6 +446,9 @@ export const buttonsOverrides = {
 
           '&:not(:first-of-type)': {
             marginTop: 0
+          },
+          '&:last-of-type': {
+            marginBottom: theme.spacing(0.5)
           }
         }
       })

--- a/packages/react-ui/storybook/stories/molecules/ToggleButton.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/ToggleButton.stories.js
@@ -9,6 +9,7 @@ import {
 } from '@mui/icons-material';
 import Typography from '../../../src/components/atoms/Typography';
 import ToggleButtonGroup from '../../../src/components/atoms/ToggleButtonGroup';
+import { DocContainer, DocHighlight, DocLink } from '../../utils/storyStyles';
 
 const options = {
   title: 'Molecules/Toggle Button',
@@ -119,6 +120,32 @@ const ToggleRow = ({ label, divider, fullWidth, exclusive, ...rest }) => {
         {label ? label : <FormatAlignJustify />}
       </ToggleButton>
     </ToggleButtonGroup>
+  );
+};
+
+const DocTemplate = () => {
+  return (
+    <DocContainer severity='warning'>
+      We have our own
+      <DocLink href='https://github.com/CartoDB/carto-react/blob/master/packages/react-ui/src/components/atoms/ToggleButtonGroup.js'>
+        ToggleButtonGroup
+      </DocLink>
+      component that extends <i>Mui ToggleButtonGroup</i> with some props (variant
+      support).
+      <Typography mt={2}>
+        So, instead of Mui ToggleButtonGroup, you should use this one:
+        <DocHighlight component='span'>
+          react-ui/src/components/atoms/ToggleButtonGroup
+        </DocHighlight>
+      </Typography>
+      <Typography mt={2}>
+        For external use:
+        <DocHighlight component='span'>
+          {'import { ToggleButtonGroup } from "@carto/react-ui";'}
+        </DocHighlight>
+        .
+      </Typography>
+    </DocContainer>
   );
 };
 
@@ -254,6 +281,8 @@ const BehaviorTemplate = ({ exclusive, ...args }) => {
 };
 
 export const Playground = ToggleRow.bind({});
+
+export const Guide = DocTemplate.bind({});
 
 export const Icon = IconTemplate.bind({});
 

--- a/packages/react-ui/storybook/stories/molecules/ToggleButton.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/ToggleButton.stories.js
@@ -78,7 +78,7 @@ const options = {
 };
 export default options;
 
-const Toggle = ({ label, exclusive, ...rest }) => {
+const Toggle = ({ label, ...rest }) => {
   const [selected, setSelected] = React.useState(false);
 
   return (
@@ -96,8 +96,10 @@ const Toggle = ({ label, exclusive, ...rest }) => {
   );
 };
 
-const ToggleRow = ({ label, divider, fullWidth, exclusive, ...rest }) => {
+const ToggleRow = ({ label, divider, fullWidth, exclusive, orientation, ...rest }) => {
   const [selected, setSelected] = React.useState(() => ['AlignLeft']);
+  const isVertical = orientation === 'vertical';
+  const dividerOrientation = isVertical ? 'horizontal' : 'vertical';
 
   const handleAlignment = (event, newAlignment) => {
     setSelected(newAlignment);
@@ -110,6 +112,7 @@ const ToggleRow = ({ label, divider, fullWidth, exclusive, ...rest }) => {
       onChange={handleAlignment}
       fullWidth={fullWidth}
       exclusive={exclusive}
+      orientation={orientation}
       aria-label='text alignment'
     >
       <ToggleButton value='AlignLeft' aria-label='AlignLeft'>
@@ -118,7 +121,9 @@ const ToggleRow = ({ label, divider, fullWidth, exclusive, ...rest }) => {
       <ToggleButton value='AlignCenter' aria-label='AlignCenter'>
         {label ? label : <FormatAlignCenter />}
       </ToggleButton>
-      {divider && <Divider flexItem orientation='vertical' />}
+      {divider && (
+        <Divider flexItem={!isVertical ? true : false} orientation={dividerOrientation} />
+      )}
       <ToggleButton value='AlignRight' aria-label='AlignRight'>
         {label ? label : <FormatAlignRight />}
       </ToggleButton>
@@ -155,7 +160,7 @@ const DocTemplate = () => {
   );
 };
 
-const IconTemplate = ({ exclusive, ...args }) => {
+const IconTemplate = (args) => {
   return (
     <Grid container alignItems='center' spacing={4}>
       <Grid item>
@@ -171,7 +176,7 @@ const IconTemplate = ({ exclusive, ...args }) => {
   );
 };
 
-const TextTemplate = ({ exclusive, ...args }) => {
+const TextTemplate = (args) => {
   return (
     <Grid container alignItems='center' spacing={4}>
       <Grid item>
@@ -184,7 +189,7 @@ const TextTemplate = ({ exclusive, ...args }) => {
   );
 };
 
-const GroupTemplate = ({ exclusive, ...args }) => {
+const GroupTemplate = (args) => {
   return (
     <Grid container direction='column' spacing={4}>
       <Grid item>
@@ -197,7 +202,7 @@ const GroupTemplate = ({ exclusive, ...args }) => {
   );
 };
 
-const VerticalGroupTemplate = ({ exclusive, ...args }) => {
+const VerticalGroupTemplate = (args) => {
   return (
     <Grid container spacing={4}>
       <Grid item>
@@ -210,7 +215,7 @@ const VerticalGroupTemplate = ({ exclusive, ...args }) => {
   );
 };
 
-const DividedTemplate = ({ exclusive, ...args }) => {
+const DividedTemplate = (args) => {
   return (
     <Grid container direction='column' spacing={4}>
       <Grid item>
@@ -223,7 +228,7 @@ const DividedTemplate = ({ exclusive, ...args }) => {
   );
 };
 
-const VariantTemplate = ({ ...args }) => {
+const VariantTemplate = (args) => {
   return (
     <Grid container direction='column' spacing={4}>
       <Grid item>
@@ -239,7 +244,7 @@ const VariantTemplate = ({ ...args }) => {
   );
 };
 
-const BgColorTemplate = ({ ...args }) => {
+const BgColorTemplate = (args) => {
   return (
     <Grid container direction='column' spacing={4}>
       <Grid item>

--- a/packages/react-ui/storybook/stories/molecules/ToggleButton.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/ToggleButton.stories.js
@@ -16,10 +16,16 @@ const options = {
   component: ToggleButtonGroup,
   argTypes: {
     variant: {
-      defaultValue: 'text',
+      defaultValue: 'floating',
       control: {
         type: 'select',
-        options: ['text', 'contained']
+        options: ['floating', 'contained', 'unbounded']
+      }
+    },
+    backgroundColor: {
+      control: {
+        type: 'select',
+        options: ['primary', 'secondary', 'transparent']
       }
     },
     size: {
@@ -66,7 +72,7 @@ const options = {
       url: 'https://www.figma.com/file/nmaoLeo69xBJCHm9nc6lEV/CARTO-Components-1.0?node-id=1534%3A36258'
     },
     status: {
-      type: 'validated'
+      type: 'readyToReview'
     }
   }
 };
@@ -130,8 +136,8 @@ const DocTemplate = () => {
       <DocLink href='https://github.com/CartoDB/carto-react/blob/master/packages/react-ui/src/components/atoms/ToggleButtonGroup.js'>
         ToggleButtonGroup
       </DocLink>
-      component that extends <i>Mui ToggleButtonGroup</i> with some props (variant
-      support).
+      component that extends <i>Mui ToggleButtonGroup</i> with some props (variant and
+      backgroundColor support).
       <Typography mt={2}>
         So, instead of Mui ToggleButtonGroup, you should use this one:
         <DocHighlight component='span'>
@@ -221,10 +227,29 @@ const VariantTemplate = ({ ...args }) => {
   return (
     <Grid container direction='column' spacing={4}>
       <Grid item>
-        <ToggleRow {...args} variant='text' />
+        <ToggleRow {...args} variant='floating' />
       </Grid>
       <Grid item>
         <ToggleRow {...args} variant='contained' />
+      </Grid>
+      <Grid item>
+        <ToggleRow {...args} variant='unbounded' />
+      </Grid>
+    </Grid>
+  );
+};
+
+const BgColorTemplate = ({ ...args }) => {
+  return (
+    <Grid container direction='column' spacing={4}>
+      <Grid item>
+        <ToggleRow {...args} backgroundColor='primary' />
+      </Grid>
+      <Grid item>
+        <ToggleRow {...args} backgroundColor='secondary' />
+      </Grid>
+      <Grid item>
+        <ToggleRow {...args} backgroundColor='transparent' />
       </Grid>
     </Grid>
   );
@@ -302,5 +327,7 @@ export const MultipleSelectionGroup = GroupTemplate.bind({});
 MultipleSelectionGroup.args = { exclusive: false };
 
 export const Variant = VariantTemplate.bind({});
+
+export const BackgroundColor = BgColorTemplate.bind({});
 
 export const Behavior = BehaviorTemplate.bind({});

--- a/packages/react-ui/storybook/stories/molecules/ToggleButton.stories.js
+++ b/packages/react-ui/storybook/stories/molecules/ToggleButton.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ToggleButtonGroup, ToggleButton, Grid, Divider } from '@mui/material';
+import { ToggleButton, Grid, Divider } from '@mui/material';
 import {
   CheckCircleOutline,
   FormatAlignCenter,
@@ -8,11 +8,19 @@ import {
   FormatAlignRight
 } from '@mui/icons-material';
 import Typography from '../../../src/components/atoms/Typography';
+import ToggleButtonGroup from '../../../src/components/atoms/ToggleButtonGroup';
 
 const options = {
   title: 'Molecules/Toggle Button',
   component: ToggleButtonGroup,
   argTypes: {
+    variant: {
+      defaultValue: 'text',
+      control: {
+        type: 'select',
+        options: ['text', 'contained']
+      }
+    },
     size: {
       defaultValue: 'medium',
       control: {
@@ -182,6 +190,19 @@ const DividedTemplate = ({ exclusive, ...args }) => {
   );
 };
 
+const VariantTemplate = ({ ...args }) => {
+  return (
+    <Grid container direction='column' spacing={4}>
+      <Grid item>
+        <ToggleRow {...args} variant='text' />
+      </Grid>
+      <Grid item>
+        <ToggleRow {...args} variant='contained' />
+      </Grid>
+    </Grid>
+  );
+};
+
 const BehaviorTemplate = ({ exclusive, ...args }) => {
   const [selected, setSelected] = React.useState(() => ['opt1']);
   const [selected2, setSelected2] = React.useState(() => ['opt1']);
@@ -250,5 +271,7 @@ HorizontalTextGroup.args = { label: 'Text' };
 
 export const MultipleSelectionGroup = GroupTemplate.bind({});
 MultipleSelectionGroup.args = { exclusive: false };
+
+export const Variant = VariantTemplate.bind({});
 
 export const Behavior = BehaviorTemplate.bind({});


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/282036/core-refactor-toggle-button-add-new-contained-variant
[sc-282036]

We need to create a component to extend ToggleButtonGroup, as it doesn't support variant & backgroundColor and It won't soon: https://github.com/mui/material-ui/issues/23446