### PR TITLE
TextField component: Add support for readOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- TexField component: Add support for readOnly [#825](https://github.com/CartoDB/carto-react/pull/825
+
 ## 2.3
 
 ### 2.3.7 (2024-01-11)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -251,7 +251,7 @@ For external use: `import { PasswordField } from '@carto/react-ui';`.
 
 ### SelectField
 
-This component adds the `placeholder` logic on top of TextField Mui component.
+This component adds the `placeholder` logic on top of Select Mui component.
 
 Instead of `<TextField select /> ` or `<Select />` you should use:
 `react-ui/src/components/atoms/SelectField`

--- a/packages/react-ui/src/components/atoms/PasswordField.js
+++ b/packages/react-ui/src/components/atoms/PasswordField.js
@@ -2,7 +2,7 @@ import React, { forwardRef, useState } from 'react';
 import { IconButton, InputAdornment, TextField } from '@mui/material';
 import { VisibilityOffOutlined, VisibilityOutlined } from '@mui/icons-material';
 
-const PasswordField = forwardRef(({ ...otherProps }, ref) => {
+const PasswordField = forwardRef(({ InputProps, size, ...otherProps }, ref) => {
   // forwardRef needed to be able to hold a reference, in this way it can be a child for some Mui components, like Tooltip
   // https://mui.com/material-ui/guides/composition/#caveat-with-refs
   const [showPassword, setShowPassword] = useState(false);
@@ -13,10 +13,12 @@ const PasswordField = forwardRef(({ ...otherProps }, ref) => {
       {...otherProps}
       ref={ref}
       type={showPassword ? 'text' : 'password'}
+      size={size}
       InputProps={{
+        ...InputProps,
         endAdornment: (
           <InputAdornment position='end'>
-            <IconButton onClick={handleClickShowPassword}>
+            <IconButton size={size} onClick={handleClickShowPassword}>
               {showPassword ? <VisibilityOutlined /> : <VisibilityOffOutlined />}
             </IconButton>
           </InputAdornment>
@@ -25,5 +27,9 @@ const PasswordField = forwardRef(({ ...otherProps }, ref) => {
     />
   );
 });
+
+PasswordField.defaultProps = {
+  size: 'small'
+};
 
 export default PasswordField;

--- a/packages/react-ui/src/theme/sections/components/forms.js
+++ b/packages/react-ui/src/theme/sections/components/forms.js
@@ -244,6 +244,11 @@ export const formsOverrides = {
           '&.Mui-error::after': {
             opacity: 1,
             border: `2px solid ${theme.palette.error.light}`
+          },
+          '&.Mui-readOnly': {
+            '&.Mui-focused': {
+              backgroundColor: theme.palette.background.default
+            }
           }
         },
 
@@ -258,6 +263,13 @@ export const formsOverrides = {
           },
           '&.Mui-disabled': {
             backgroundColor: theme.palette.default.background
+          },
+          '&.Mui-readOnly': {
+            backgroundColor: theme.palette.background.default,
+
+            '&.Mui-focused': {
+              backgroundColor: theme.palette.background.default
+            }
           },
           '& .MuiOutlinedInput-notchedOutline': {
             top: 0,

--- a/packages/react-ui/storybook/stories/atoms/Text-area.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/Text-area.stories.js
@@ -310,6 +310,34 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
 
       <Grid item container spacing={2}>
         <Grid item xs={2}>
+          <Typography>Read Only</Typography>
+        </Grid>
+        <Grid item>
+          <TextField
+            {...rest}
+            multiline
+            variant='filled'
+            label={label}
+            placeholder={placeholder}
+            defaultValue={defaultValue}
+            InputProps={{ readOnly: true }}
+          />
+        </Grid>
+        <Grid item>
+          <TextField
+            {...rest}
+            multiline
+            variant='outlined'
+            label={label}
+            placeholder={placeholder}
+            defaultValue={defaultValue}
+            InputProps={{ readOnly: true }}
+          />
+        </Grid>
+      </Grid>
+
+      <Grid item container spacing={2}>
+        <Grid item xs={2}>
           <Typography>Error</Typography>
         </Grid>
         <Grid item>

--- a/packages/react-ui/storybook/stories/atoms/Text-area.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/Text-area.stories.js
@@ -37,6 +37,12 @@ const options = {
         type: 'boolean'
       }
     },
+    readOnly: {
+      defaultValue: false,
+      control: {
+        type: 'boolean'
+      }
+    },
     label: {
       control: {
         type: 'text'
@@ -60,9 +66,11 @@ const options = {
 };
 export default options;
 
-const PlaygroundTemplate = (args) => <TextField {...args} multiline></TextField>;
+const PlaygroundTemplate = ({ readOnly, ...args }) => (
+  <TextField {...args} multiline InputProps={{ readOnly: readOnly }}></TextField>
+);
 
-const VariantsTemplate = ({ label, placeholder, ...rest }) => {
+const VariantsTemplate = ({ label, placeholder, readOnly, ...rest }) => {
   return (
     <Grid container direction='column' spacing={6}>
       <Grid item>
@@ -73,6 +81,7 @@ const VariantsTemplate = ({ label, placeholder, ...rest }) => {
             multiline
             label={label}
             variant='filled'
+            InputProps={{ readOnly: readOnly }}
             placeholder={placeholder}
           />
         </Container>
@@ -85,6 +94,7 @@ const VariantsTemplate = ({ label, placeholder, ...rest }) => {
             multiline
             label={label}
             variant='outlined'
+            InputProps={{ readOnly: readOnly }}
             placeholder={placeholder}
           />
         </Container>
@@ -93,7 +103,13 @@ const VariantsTemplate = ({ label, placeholder, ...rest }) => {
   );
 };
 
-const LabelAndHelperTextTemplate = ({ label, placeholder, helperText, ...rest }) => {
+const LabelAndHelperTextTemplate = ({
+  label,
+  placeholder,
+  helperText,
+  readOnly,
+  ...rest
+}) => {
   return (
     <Grid container direction='column' spacing={6}>
       <Grid item>
@@ -104,6 +120,7 @@ const LabelAndHelperTextTemplate = ({ label, placeholder, helperText, ...rest })
             multiline
             label={label}
             placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
             helperText={helperText}
           />
         </Container>
@@ -111,13 +128,25 @@ const LabelAndHelperTextTemplate = ({ label, placeholder, helperText, ...rest })
       <Grid item>
         <Container>
           <Label variant='body2'>{'Without label + helper text'}</Label>
-          <TextField {...rest} multiline placeholder={placeholder} />
+          InputProps={{ readOnly: readOnly }}
+          <TextField
+            {...rest}
+            multiline
+            placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
+          />
         </Container>
       </Grid>
       <Grid item>
         <Container>
           <Label variant='body2'>{'Only label'}</Label>
-          <TextField {...rest} multiline label={label} placeholder={placeholder} />
+          <TextField
+            {...rest}
+            multiline
+            label={label}
+            placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
+          />
         </Container>
       </Grid>
       <Grid item>
@@ -128,6 +157,7 @@ const LabelAndHelperTextTemplate = ({ label, placeholder, helperText, ...rest })
             multiline
             placeholder={placeholder}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
           />
         </Container>
       </Grid>
@@ -135,7 +165,14 @@ const LabelAndHelperTextTemplate = ({ label, placeholder, helperText, ...rest })
   );
 };
 
-const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest }) => {
+const SizeTemplate = ({
+  label,
+  placeholder,
+  defaultValue,
+  helperText,
+  readOnly,
+  ...rest
+}) => {
   return (
     <Grid container spacing={6}>
       <Grid item container spacing={2}>
@@ -149,6 +186,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             variant='filled'
             label={label}
             placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
           />
         </Grid>
         <Grid item>
@@ -158,6 +196,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             variant='outlined'
             label={label}
             placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
           />
         </Grid>
       </Grid>
@@ -167,10 +206,22 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
           <Typography>Empty</Typography>
         </Grid>
         <Grid item>
-          <TextField {...rest} multiline variant='filled' label={label} />
+          <TextField
+            {...rest}
+            multiline
+            variant='filled'
+            label={label}
+            InputProps={{ readOnly: readOnly }}
+          />
         </Grid>
         <Grid item>
-          <TextField {...rest} multiline variant='outlined' label={label} />
+          <TextField
+            {...rest}
+            multiline
+            variant='outlined'
+            label={label}
+            InputProps={{ readOnly: readOnly }}
+          />
         </Grid>
       </Grid>
 
@@ -186,6 +237,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             defaultValue={defaultValue}
+            InputProps={{ readOnly: readOnly }}
           />
         </Grid>
         <Grid item>
@@ -196,6 +248,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             defaultValue={defaultValue}
+            InputProps={{ readOnly: readOnly }}
           />
         </Grid>
       </Grid>
@@ -211,6 +264,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             variant='filled'
             label={label}
             placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
             focused
           />
         </Grid>
@@ -221,6 +275,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             variant='outlined'
             label={label}
             placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
             focused
           />
         </Grid>
@@ -238,6 +293,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             defaultValue={defaultValue}
+            InputProps={{ readOnly: readOnly }}
             focused
           />
         </Grid>
@@ -249,6 +305,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             defaultValue={defaultValue}
+            InputProps={{ readOnly: readOnly }}
             focused
           />
         </Grid>
@@ -348,6 +405,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
             error
           />
         </Grid>
@@ -359,6 +417,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
             error
           />
         </Grid>
@@ -377,6 +436,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             placeholder={placeholder}
             defaultValue={defaultValue}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
             error
           />
         </Grid>
@@ -389,6 +449,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             placeholder={placeholder}
             defaultValue={defaultValue}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
             error
           />
         </Grid>
@@ -397,7 +458,14 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
   );
 };
 
-const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...rest }) => {
+const BehaviorTemplate = ({
+  label,
+  placeholder,
+  defaultValue,
+  helperText,
+  readOnly,
+  ...rest
+}) => {
   return (
     <Grid container direction='column' spacing={2}>
       <Grid item>
@@ -412,6 +480,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
             placeholder={placeholder}
             defaultValue={defaultValue}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
           />
         </Container>
       </Grid>
@@ -428,6 +497,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
             placeholder={placeholder}
             defaultValue={defaultValue}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
           />
         </Container>
       </Grid>
@@ -443,6 +513,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
             placeholder={placeholder}
             defaultValue={defaultValue}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
           />
         </Container>
         <Container>
@@ -455,6 +526,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
             defaultValue={defaultValue}
             helperText={helperText}
             fullWidth={false}
+            InputProps={{ readOnly: readOnly }}
           />
         </Container>
       </Grid>

--- a/packages/react-ui/storybook/stories/atoms/Text-field.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/Text-field.stories.js
@@ -39,6 +39,12 @@ const options = {
         type: 'boolean'
       }
     },
+    readOnly: {
+      defaultValue: false,
+      control: {
+        type: 'boolean'
+      }
+    },
     label: {
       control: {
         type: 'text'
@@ -75,15 +81,23 @@ const endAdornmentIcon = (
   </InputAdornment>
 );
 
-const PlaygroundTemplate = (args) => <TextField {...args}></TextField>;
+const PlaygroundTemplate = ({ readOnly, ...args }) => (
+  <TextField {...args} InputProps={{ readOnly: readOnly }}></TextField>
+);
 
-const VariantsTemplate = ({ label, placeholder, ...rest }) => {
+const VariantsTemplate = ({ label, placeholder, readOnly, ...rest }) => {
   return (
     <Grid container direction='column' spacing={6}>
       <Grid item>
         <Container>
           <Label variant='body2'>{'Filled'}</Label>
-          <TextField {...rest} label={label} variant='filled' placeholder={placeholder} />
+          <TextField
+            {...rest}
+            label={label}
+            variant='filled'
+            placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
+          />
         </Container>
       </Grid>
       <Grid item>
@@ -94,6 +108,7 @@ const VariantsTemplate = ({ label, placeholder, ...rest }) => {
             label={label}
             variant='outlined'
             placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
           />
         </Container>
       </Grid>
@@ -105,6 +120,7 @@ const VariantsTemplate = ({ label, placeholder, ...rest }) => {
             label={label}
             variant='standard'
             placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
           />
         </Container>
       </Grid>
@@ -112,7 +128,13 @@ const VariantsTemplate = ({ label, placeholder, ...rest }) => {
   );
 };
 
-const LabelAndHelperTextTemplate = ({ label, placeholder, helperText, ...rest }) => {
+const LabelAndHelperTextTemplate = ({
+  label,
+  placeholder,
+  helperText,
+  readOnly,
+  ...rest
+}) => {
   return (
     <Grid container direction='column' spacing={6}>
       <Grid item>
@@ -123,25 +145,40 @@ const LabelAndHelperTextTemplate = ({ label, placeholder, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
           />
         </Container>
       </Grid>
       <Grid item>
         <Container>
           <Label variant='body2'>{'Without label + helper text'}</Label>
-          <TextField {...rest} placeholder={placeholder} />
+          <TextField
+            {...rest}
+            placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
+          />
         </Container>
       </Grid>
       <Grid item>
         <Container>
           <Label variant='body2'>{'Only label'}</Label>
-          <TextField {...rest} label={label} placeholder={placeholder} />
+          <TextField
+            {...rest}
+            label={label}
+            placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
+          />
         </Container>
       </Grid>
       <Grid item>
         <Container>
           <Label variant='body2'>{'Only helper text'}</Label>
-          <TextField {...rest} placeholder={placeholder} helperText={helperText} />
+          <TextField
+            {...rest}
+            placeholder={placeholder}
+            helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
+          />
         </Container>
       </Grid>
     </Grid>
@@ -153,6 +190,7 @@ const PrefixAndSuffixTemplate = ({
   placeholder,
   startAdornment,
   endAdornment,
+  readOnly,
   ...rest
 }) => {
   return (
@@ -166,7 +204,8 @@ const PrefixAndSuffixTemplate = ({
             placeholder={placeholder}
             InputProps={{
               startAdornment: startAdornmentText,
-              endAdornment: endAdornmentText
+              endAdornment: endAdornmentText,
+              readOnly: readOnly
             }}
           />
         </Container>
@@ -180,7 +219,8 @@ const PrefixAndSuffixTemplate = ({
             placeholder={placeholder}
             InputProps={{
               startAdornment: startAdornmentIcon,
-              endAdornment: endAdornmentIcon
+              endAdornment: endAdornmentIcon,
+              readOnly: readOnly
             }}
           />
         </Container>
@@ -194,7 +234,8 @@ const PrefixAndSuffixTemplate = ({
             placeholder={placeholder}
             InputProps={{
               startAdornment: startAdornmentText,
-              endAdornment: endAdornmentIcon
+              endAdornment: endAdornmentIcon,
+              readOnly: readOnly
             }}
           />
         </Container>
@@ -207,7 +248,8 @@ const PrefixAndSuffixTemplate = ({
             label={label}
             placeholder={placeholder}
             InputProps={{
-              startAdornment: startAdornmentText
+              startAdornment: startAdornmentText,
+              readOnly: readOnly
             }}
           />
         </Container>
@@ -220,7 +262,8 @@ const PrefixAndSuffixTemplate = ({
             label={label}
             placeholder={placeholder}
             InputProps={{
-              endAdornment: endAdornmentText
+              endAdornment: endAdornmentText,
+              readOnly: readOnly
             }}
           />
         </Container>
@@ -228,14 +271,26 @@ const PrefixAndSuffixTemplate = ({
       <Grid item>
         <Container>
           <Label variant='body2'>{'None'}</Label>
-          <TextField {...rest} label={label} placeholder={placeholder} />
+          <TextField
+            {...rest}
+            label={label}
+            placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
+          />
         </Container>
       </Grid>
     </Grid>
   );
 };
 
-const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest }) => {
+const SizeTemplate = ({
+  label,
+  placeholder,
+  defaultValue,
+  helperText,
+  readOnly,
+  ...rest
+}) => {
   return (
     <Grid container spacing={6}>
       <Grid item container spacing={2}>
@@ -243,7 +298,13 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
           <Typography>Placeholder</Typography>
         </Grid>
         <Grid item>
-          <TextField {...rest} variant='filled' label={label} placeholder={placeholder} />
+          <TextField
+            {...rest}
+            variant='filled'
+            label={label}
+            placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
+          />
         </Grid>
         <Grid item>
           <TextField
@@ -251,6 +312,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             variant='outlined'
             label={label}
             placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
           />
         </Grid>
         <Grid item>
@@ -259,6 +321,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             variant='standard'
             label={label}
             placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
           />
         </Grid>
       </Grid>
@@ -268,13 +331,28 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
           <Typography>Empty</Typography>
         </Grid>
         <Grid item>
-          <TextField {...rest} variant='filled' label={label} />
+          <TextField
+            {...rest}
+            variant='filled'
+            label={label}
+            InputProps={{ readOnly: readOnly }}
+          />
         </Grid>
         <Grid item>
-          <TextField {...rest} variant='outlined' label={label} />
+          <TextField
+            {...rest}
+            variant='outlined'
+            label={label}
+            InputProps={{ readOnly: readOnly }}
+          />
         </Grid>
         <Grid item>
-          <TextField {...rest} variant='standard' label={label} />
+          <TextField
+            {...rest}
+            variant='standard'
+            label={label}
+            InputProps={{ readOnly: readOnly }}
+          />
         </Grid>
       </Grid>
 
@@ -289,6 +367,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             defaultValue={defaultValue}
+            InputProps={{ readOnly: readOnly }}
           />
         </Grid>
         <Grid item>
@@ -298,6 +377,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             defaultValue={defaultValue}
+            InputProps={{ readOnly: readOnly }}
           />
         </Grid>
         <Grid item>
@@ -307,6 +387,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             defaultValue={defaultValue}
+            InputProps={{ readOnly: readOnly }}
           />
         </Grid>
       </Grid>
@@ -321,6 +402,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             variant='filled'
             label={label}
             placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
             focused
           />
         </Grid>
@@ -330,6 +412,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             variant='outlined'
             label={label}
             placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
             focused
           />
         </Grid>
@@ -339,6 +422,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             variant='standard'
             label={label}
             placeholder={placeholder}
+            InputProps={{ readOnly: readOnly }}
             focused
           />
         </Grid>
@@ -355,6 +439,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             defaultValue={defaultValue}
+            InputProps={{ readOnly: readOnly }}
             focused
           />
         </Grid>
@@ -365,6 +450,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             defaultValue={defaultValue}
+            InputProps={{ readOnly: readOnly }}
             focused
           />
         </Grid>
@@ -375,6 +461,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             defaultValue={defaultValue}
+            InputProps={{ readOnly: readOnly }}
             focused
           />
         </Grid>
@@ -496,6 +583,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
             error
           />
         </Grid>
@@ -506,6 +594,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
             error
           />
         </Grid>
@@ -516,6 +605,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             label={label}
             placeholder={placeholder}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
             error
           />
         </Grid>
@@ -533,6 +623,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             placeholder={placeholder}
             defaultValue={defaultValue}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
             error
           />
         </Grid>
@@ -544,6 +635,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             placeholder={placeholder}
             defaultValue={defaultValue}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
             error
           />
         </Grid>
@@ -555,6 +647,7 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
             placeholder={placeholder}
             defaultValue={defaultValue}
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
             error
           />
         </Grid>
@@ -568,6 +661,7 @@ const PasswordFieldTemplate = ({
   placeholder,
   defaultValue,
   helperText,
+  readOnly,
   ...rest
 }) => {
   return (
@@ -592,6 +686,7 @@ const PasswordFieldTemplate = ({
             placeholder={placeholder}
             defaultValue='1234'
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
             type='password'
           />
         </Container>
@@ -605,6 +700,7 @@ const PasswordFieldTemplate = ({
             placeholder={placeholder}
             defaultValue='1234'
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
           />
         </Container>
       </Grid>
@@ -612,7 +708,14 @@ const PasswordFieldTemplate = ({
   );
 };
 
-const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...rest }) => {
+const BehaviorTemplate = ({
+  label,
+  placeholder,
+  defaultValue,
+  helperText,
+  readOnly,
+  ...rest
+}) => {
   return (
     <Grid container direction='column' spacing={6}>
       <Grid item>
@@ -624,6 +727,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
             label={label}
             placeholder={placeholder}
             defaultValue='felipegutierrezsoriano@cartodb.com'
+            InputProps={{ readOnly: readOnly }}
           />
         </Container>
       </Grid>
@@ -635,11 +739,21 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
 
           <Grid container spacing={2}>
             <Grid item>
-              <TextField {...rest} label={label} placeholder={placeholder} />
+              <TextField
+                {...rest}
+                label={label}
+                placeholder={placeholder}
+                InputProps={{ readOnly: readOnly }}
+              />
             </Grid>
 
             <Grid item>
-              <TextField {...rest} label={label} placeholder={placeholder} />
+              <TextField
+                {...rest}
+                label={label}
+                placeholder={placeholder}
+                InputProps={{ readOnly: readOnly }}
+              />
             </Grid>
           </Grid>
         </Container>
@@ -654,6 +768,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
             label={label}
             placeholder={placeholder}
             defaultValue='felipegutierrezsoriano@cartodb.com'
+            InputProps={{ readOnly: readOnly }}
           />
         </Container>
         <Container>
@@ -664,6 +779,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
             placeholder={placeholder}
             defaultValue='felipegutierrezsoriano@cartodb.com'
             fullWidth={false}
+            InputProps={{ readOnly: readOnly }}
           />
         </Container>
       </Grid>
@@ -679,6 +795,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
             placeholder={placeholder}
             defaultValue='Felipe'
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
           />
           <TextField
             {...rest}
@@ -691,7 +808,8 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
                 <InputAdornment position='start'>
                   <EuroOutlined />
                 </InputAdornment>
-              )
+              ),
+              readOnly: readOnly
             }}
             helperText={helperText}
           />
@@ -701,6 +819,7 @@ const BehaviorTemplate = ({ label, placeholder, defaultValue, helperText, ...res
             placeholder={placeholder}
             defaultValue='1234'
             helperText={helperText}
+            InputProps={{ readOnly: readOnly }}
           />
         </Container>
       </Grid>

--- a/packages/react-ui/storybook/stories/atoms/Text-field.stories.js
+++ b/packages/react-ui/storybook/stories/atoms/Text-field.stories.js
@@ -451,6 +451,42 @@ const SizeTemplate = ({ label, placeholder, defaultValue, helperText, ...rest })
 
       <Grid item container spacing={2}>
         <Grid item xs={2}>
+          <Typography>Read Only</Typography>
+        </Grid>
+        <Grid item>
+          <TextField
+            {...rest}
+            variant='filled'
+            label={label}
+            placeholder={placeholder}
+            defaultValue={defaultValue}
+            InputProps={{ readOnly: true }}
+          />
+        </Grid>
+        <Grid item>
+          <TextField
+            {...rest}
+            variant='outlined'
+            label={label}
+            placeholder={placeholder}
+            defaultValue={defaultValue}
+            InputProps={{ readOnly: true }}
+          />
+        </Grid>
+        <Grid item>
+          <TextField
+            {...rest}
+            variant='standard'
+            label={label}
+            placeholder={placeholder}
+            defaultValue={defaultValue}
+            InputProps={{ readOnly: true }}
+          />
+        </Grid>
+      </Grid>
+
+      <Grid item container spacing={2}>
+        <Grid item xs={2}>
           <Typography>Error</Typography>
         </Grid>
         <Grid item>


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/357036/textfield-add-read-only-styles
[sc-357036]

In some parts of the application, we need to use read-only inputs instead of disabled ones because disabled inputs would not be sent when the form is submitted.

We need to modify our design system (C4R) to have the option to give proper styles for read-only inputs.