### PR TITLE
[react-redux] Export 'Filter' types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Export `Filter` type definitions from react-redux [#829](https://github.com/CartoDB/carto-react/pull/829)
+
 ## 2.3
 
 ### 2.3.8 (2024-01-25)

--- a/packages/react-redux/src/slices/cartoSlice.d.ts
+++ b/packages/react-redux/src/slices/cartoSlice.d.ts
@@ -32,7 +32,7 @@ type SpatialFilter = {
   geometry: object;
 };
 
-type Filter = FilterBasic & FilterCommonProps;
+export type Filter = FilterBasic & FilterCommonProps;
 
 
 type FeaturesData = {


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/377718/widgets-values-for-filtering
[sc-377718]

Exports `Filter` types, to be used in Builder.

## Type of change

- Feature

# Acceptance

n/a

# Basic checklist

- [x] Good PR name
- [x] Shortcut link
- [x] Changelog entry
- [x] Just one issue per PR
- [x] GitHub labels
- [x] Proper status & reviewers
- [ ] ~~Tests~~
- [ ] ~~Documentation~~
