### PR TITLE
[react-redux, react-widgets] Add 'GeocoderResult' types, add .passive property

### DIFF
--- a/packages/react-redux/src/types.d.ts
+++ b/packages/react-redux/src/types.d.ts
@@ -53,9 +53,16 @@ type InitialCarto3State = {
 
 export type InitialCartoState = InitialCarto2State | InitialCarto3State;
 
+export type GeocoderResult = {
+  latitude: number,
+  longitude: number,
+  /** Passive results are loaded without moving the map viewport. */
+  passive?: boolean
+}
+
 export type CartoState = {
   viewport: Viewport | undefined,
-  geocoderResult: Record<string,any> | null,
+  geocoderResult: GeocoderResult | null,
   error: null, // TODO: remove from state?
   layers: { [key: string]: string },
   dataSources: { [key: string]: Source },

--- a/packages/react-widgets/src/widgets/GeocoderWidget.js
+++ b/packages/react-widgets/src/widgets/GeocoderWidget.js
@@ -56,7 +56,7 @@ function GeocoderWidget(props = {}) {
   }, [dispatch]);
 
   useEffect(() => {
-    if (geocoderResult) {
+    if (geocoderResult && !geocoderResult.passive) {
       dispatch(
         setViewState({
           longitude: geocoderResult.longitude,


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/378094/search-location
[sc-378094]

We need the option of setting the geocoder result state without moving the map viewport. This PR creates type definitions for the `GeocoderResult` interface, and adds a new `.passive` property used to indicate when a result must not change the viewport.

## Type of change

- [x] Feature
