### PR TITLE
[react-widgets] Add initialSearchText prop to useGeocoderWidgetController hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Initial value for Geocoder widget [#831](https://github.com/CartoDB/carto-react/pull/831)
+
 ## 2.3
 
 ### 2.3.8 (2024-01-25)

--- a/packages/react-widgets/src/hooks/useGeocoderWidgetController.js
+++ b/packages/react-widgets/src/hooks/useGeocoderWidgetController.js
@@ -19,11 +19,12 @@ export const setGeocoderResult = (payload) => ({
  * @param  {object} props
  * @param  {Function=} [props.onError] - Function to handle error messages from the widget.
  * @param  {boolean} [props.allowSearchByCoords]
+ * @param  {string} [props.initialSearchText]
  */
 export default function useGeocoderWidgetController(props = {}) {
   const credentials = useSelector((state) => state.carto.credentials);
   // Component local state and events handling
-  const [searchText, setSearchText] = useState('');
+  const [searchText, setSearchText] = useState(props.initialSearchText || '');
   const [loading, setIsLoading] = useState(false);
 
   const { allowSearchByCoords } = props;
@@ -93,7 +94,6 @@ export default function useGeocoderWidgetController(props = {}) {
   return {
     loading,
     searchText,
-    setSearchText,
     handleChange,
     handleInput,
     handleKeyPress,

--- a/packages/react-widgets/src/hooks/useGeocoderWidgetController.js
+++ b/packages/react-widgets/src/hooks/useGeocoderWidgetController.js
@@ -92,8 +92,8 @@ export default function useGeocoderWidgetController(props = {}) {
   };
 
   return {
-    loading,
     searchText,
+    loading,
     handleChange,
     handleInput,
     handleKeyPress,

--- a/packages/react-widgets/src/hooks/useGeocoderWidgetController.js
+++ b/packages/react-widgets/src/hooks/useGeocoderWidgetController.js
@@ -8,7 +8,7 @@ import {
 
 const DEFAULT_COUNTRY = ''; // 'SPAIN', 'USA'
 
-const setGeocoderResult = (payload) => ({
+export const setGeocoderResult = (payload) => ({
   type: 'carto/setGeocoderResult',
   payload
 });
@@ -91,8 +91,9 @@ export default function useGeocoderWidgetController(props = {}) {
   };
 
   return {
-    searchText,
     loading,
+    searchText,
+    setSearchText,
     handleChange,
     handleInput,
     handleKeyPress,


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/378094/search-location
[sc-378094]

Adds an 'initialSearchText' property to the 'useGeocoderWidgetController' so that Builder can initialize the text field from the ?search=<text> URL parameter. Tested against Builder locally.

Also exports setGeocoderResult for use in Builder. 

## Type of change

- Feature

# Acceptance

n/a


