### PR TITLE
[react-widgets][react-redux] Export missing types from v2.3.9

### DIFF
--- a/packages/react-redux/src/index.d.ts
+++ b/packages/react-redux/src/index.d.ts
@@ -1,13 +1,3 @@
 export * from './slices/cartoSlice';
 export * from './slices/oauthSlice';
-
-export {
-  InitialCartoState,
-  CartoState,
-  InitialOauthState,
-  OauthState,
-  ViewState,
-  InitialCarto3State,
-  Source,
-  SourceFilters
-} from './types';
+export * from './types';

--- a/packages/react-widgets/src/index.d.ts
+++ b/packages/react-widgets/src/index.d.ts
@@ -25,6 +25,6 @@ export { default as BarWidget } from './widgets/BarWidget';
 export { default as useSourceFilters } from './hooks/useSourceFilters';
 export { default as FeatureSelectionWidget } from './widgets/FeatureSelectionWidget';
 export { default as FeatureSelectionLayer } from './layers/FeatureSelectionLayer';
-export { default as useGeocoderWidgetController } from './hooks/useGeocoderWidgetController';
+export { default as useGeocoderWidgetController, setGeocoderResult } from './hooks/useGeocoderWidgetController';
 export { WidgetState, WidgetStateType } from './types';
 export { isRemoteCalculationSupported as _isRemoteCalculationSupported, sourceAndFiltersToSQL as _sourceAndFiltersToSQL } from './models/utils';

--- a/packages/react-widgets/src/index.js
+++ b/packages/react-widgets/src/index.js
@@ -21,7 +21,10 @@ export {
 } from './models';
 export { default as useSourceFilters } from './hooks/useSourceFilters';
 export { default as FeatureSelectionLayer } from './layers/FeatureSelectionLayer';
-export { default as useGeocoderWidgetController } from './hooks/useGeocoderWidgetController';
+export {
+  default as useGeocoderWidgetController,
+  setGeocoderResult
+} from './hooks/useGeocoderWidgetController';
 export { WidgetStateType } from './hooks/useWidgetFetch';
 export {
   isRemoteCalculationSupported as _isRemoteCalculationSupported,


### PR DESCRIPTION
# Description

Followup to:

- https://github.com/CartoDB/carto-react/pull/830
- https://github.com/CartoDB/carto-react/pull/831

These type definitions were exported from their declarations, but not re-exported from the indexes above them. This change *does not* block any functionality in the current Builder iteration, but just cleans up some duplicate type information So there is no rush to cut a v2.3.10 release.

## Type of change

Fix (type definitions)

# Acceptance

n/a, tested against feature branch locally.
