### PR TITLE
[react-ui][react-widgets] Add 'data-testid' attribute to widgets

### DIFF
--- a/packages/react-ui/src/widgets/WrapperWidgetUI.d.ts
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.d.ts
@@ -26,6 +26,7 @@ export type WrapperWidgetOption = {
 
 export type WrapperWidgetUIProps = {
   title: string;
+  id?: string;
 
   expandable?: boolean;
   expanded?: boolean;

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.js
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.js
@@ -189,7 +189,12 @@ function WrapperWidgetUI(props) {
   }
 
   return (
-    <Root margin={props.margin} component='section' aria-label={props.title}>
+    <Root
+      margin={props.margin}
+      component='section'
+      aria-label={props.title}
+      data-testid={props.id}
+    >
       {props.isLoading ? <LoadingBar /> : null}
       <Header container expanded={props.expanded}>
         <HeaderButton

--- a/packages/react-widgets/src/widgets/BarWidget.js
+++ b/packages/react-widgets/src/widgets/BarWidget.js
@@ -141,7 +141,7 @@ function BarWidget({
   );
 
   return (
-    <WrapperWidgetUI title={title} isLoading={isLoading} {...wrapperProps}>
+    <WrapperWidgetUI id={id} title={title} isLoading={isLoading} {...wrapperProps}>
       <WidgetWithAlert
         dataSource={dataSource}
         warning={warning}

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -110,7 +110,7 @@ function CategoryWidget(props) {
   );
 
   return (
-    <WrapperWidgetUI title={title} isLoading={isLoading} {...wrapperProps}>
+    <WrapperWidgetUI id={id} title={title} isLoading={isLoading} {...wrapperProps}>
       <WidgetWithAlert
         dataSource={dataSource}
         warning={warning}

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -64,7 +64,7 @@ function FormulaWidget({
   const value = Number.isFinite(data?.value) ? data.value : undefined;
 
   return (
-    <WrapperWidgetUI title={title} isLoading={isLoading} {...wrapperProps}>
+    <WrapperWidgetUI id={id} title={title} isLoading={isLoading} {...wrapperProps}>
       <WidgetWithAlert
         dataSource={dataSource}
         warning={warning}

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -177,7 +177,7 @@ function HistogramWidget({
   );
 
   return (
-    <WrapperWidgetUI title={title} {...wrapperProps} isLoading={isLoading}>
+    <WrapperWidgetUI id={id} title={title} {...wrapperProps} isLoading={isLoading}>
       <WidgetWithAlert
         dataSource={dataSource}
         warning={warning}

--- a/packages/react-widgets/src/widgets/PieWidget.js
+++ b/packages/react-widgets/src/widgets/PieWidget.js
@@ -112,7 +112,7 @@ function PieWidget({
   );
 
   return (
-    <WrapperWidgetUI title={title} isLoading={isLoading} {...wrapperProps}>
+    <WrapperWidgetUI id={id} title={title} isLoading={isLoading} {...wrapperProps}>
       <WidgetWithAlert
         dataSource={dataSource}
         warning={warning}

--- a/packages/react-widgets/src/widgets/RangeWidget.js
+++ b/packages/react-widgets/src/widgets/RangeWidget.js
@@ -131,7 +131,7 @@ function RangeWidget({
   }, [column, dataSource, dispatch, hasMinMax, id, max, min, selectedValues]);
 
   return (
-    <WrapperWidgetUI title={title} isLoading={isLoading} {...wrapperProps}>
+    <WrapperWidgetUI id={id} title={title} isLoading={isLoading} {...wrapperProps}>
       <WidgetWithAlert
         dataSource={dataSource}
         warning={warning}

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -64,7 +64,7 @@ function ScatterPlotWidget({
   });
 
   return (
-    <WrapperWidgetUI title={title} isLoading={isLoading} {...wrapperProps}>
+    <WrapperWidgetUI id={id} title={title} isLoading={isLoading} {...wrapperProps}>
       <WidgetWithAlert
         dataSource={dataSource}
         warning={warning}

--- a/packages/react-widgets/src/widgets/TableWidget.js
+++ b/packages/react-widgets/src/widgets/TableWidget.js
@@ -100,7 +100,7 @@ function TableWidget({
   };
 
   return (
-    <WrapperWidgetUI title={title} {...wrapperProps} isLoading={isLoading}>
+    <WrapperWidgetUI id={id} title={title} {...wrapperProps} isLoading={isLoading}>
       <WidgetWithAlert
         dataSource={dataSource}
         warning={warning}

--- a/packages/react-widgets/src/widgets/TimeSeriesWidget.js
+++ b/packages/react-widgets/src/widgets/TimeSeriesWidget.js
@@ -409,6 +409,7 @@ function TimeSeriesWidget({
   return (
     <>
       <WrapperWidgetUI
+        id={id}
         title={title}
         isLoading={isLoading}
         {...wrapperProps}


### PR DESCRIPTION
# Description

- Shortcut: https://app.shortcut.com/cartoteam/story/383469/add-an-html-attribute-containing-the-widget-uuid
- Story ID: [sc-383469]

Adds a widget's ID to an HTML attribute, `data-testid`, for use in test environments.

## Type of change

- Feature
