### PR TITLE
Update MultipleSelectField placeholder text color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Not released
 - Fix Snowflake spatial index detection [#845](https://github.com/CartoDB/carto-react/pull/845)
 - Fix TimeSeriesWidgetUI check undefined echart.getInstance().getDom() [#842](https://github.com/CartoDB/carto-react/pull/842)
-  
+- Update MultipleSelectField placeholder text color [#846](https://github.com/CartoDB/carto-react/pull/846)
+
 ## 2.3
 
 ### 2.3.12 (2024-02-19)

--- a/packages/react-ui/src/components/molecules/MultipleSelectField/MultipleSelectField.js
+++ b/packages/react-ui/src/components/molecules/MultipleSelectField/MultipleSelectField.js
@@ -92,7 +92,7 @@ const MultipleSelectField = forwardRef(
         <Typography
           component='span'
           variant={isSmall ? 'body2' : 'body1'}
-          color='textSecondary'
+          color='text.hint'
           ml={paddingSize}
         >
           {placeholder || intlConfig.formatMessage({ id: 'c4r.form.noneSelected' })}

--- a/packages/react-ui/src/theme/sections/components/forms.js
+++ b/packages/react-ui/src/theme/sections/components/forms.js
@@ -572,7 +572,6 @@ export const formsOverrides = {
           //Needed to overide Mui default styles
           '.MuiInputBase-root': {
             gap: theme.spacing(0.5),
-            height: 'auto',
             minHeight: theme.spacing(6),
             padding: theme.spacing(1, 2),
             paddingRight: theme.spacing(5),

--- a/packages/react-ui/src/theme/sections/components/forms.js
+++ b/packages/react-ui/src/theme/sections/components/forms.js
@@ -572,6 +572,7 @@ export const formsOverrides = {
           //Needed to overide Mui default styles
           '.MuiInputBase-root': {
             gap: theme.spacing(0.5),
+            height: 'auto',
             minHeight: theme.spacing(6),
             padding: theme.spacing(1, 2),
             paddingRight: theme.spacing(5),


### PR DESCRIPTION
# Description

Update the color of MultipleSelectField text placeholder to match the design

## Type of change

- Fix

# Acceptance

- Before
![Screenshot from 2024-03-05 15-32-46](https://github.com/CartoDB/carto-react/assets/6042873/ca701e70-2d2e-48f4-9dd3-e14b56375426)

- After
![Screenshot from 2024-03-05 15-32-19](https://github.com/CartoDB/carto-react/assets/6042873/3064e1b4-8f27-4b21-9599-7194979cdf74)
