### PR TITLE
Check invalid geometries for spatial filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Check invalid geometries for spatial filter [#847](https://github.com/CartoDB/carto-react/pull/847)
+
 ## 2.3
 
 ### 2.3.13 (2024-03-06)

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@turf/intersect": "^6.3.0",
     "@turf/invariant": "^6.3.0",
     "@turf/union": "^6.3.0",
+    "@turf/kinks": "^6.3.0",
     "dequal": "^2.0.2",
     "echarts": "^5.4.2",
     "echarts-for-react": "^3.0.2",

--- a/packages/react-api/src/hooks/useCartoLayerProps.js
+++ b/packages/react-api/src/hooks/useCartoLayerProps.js
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { selectSpatialFilter, selectViewport } from '@carto/react-redux';
+import { selectValidSpatialFilter, selectViewport } from '@carto/react-redux';
 import useGeojsonFeatures from './useGeojsonFeatures';
 import useTileFeatures from './useTileFeatures';
 import { getDataFilterExtensionProps } from './dataFilterExtensionUtil';
@@ -18,7 +18,9 @@ export default function useCartoLayerProps({
   viewporFeaturesDebounceTimeout = 250
 }) {
   const viewport = useSelector(selectViewport);
-  const spatialFilter = useSelector((state) => selectSpatialFilter(state, source?.id));
+  const spatialFilter = useSelector((state) =>
+    selectValidSpatialFilter(state, source?.id)
+  );
 
   const [onDataLoadForGeojson] = useGeojsonFeatures({
     source,

--- a/packages/react-redux/src/slices/cartoSlice.d.ts
+++ b/packages/react-redux/src/slices/cartoSlice.d.ts
@@ -169,4 +169,9 @@ export function selectSpatialFilter(
   sourceId?: string
 ): Feature<Polygon | MultiPolygon> | null;
 
+export function selectValidSpatialFilter(
+  state: any,
+  sourceId?: string
+): Feature<Polygon | MultiPolygon> | null;
+
 export function selectFeatureSelectionMode(state: any): string | null;

--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -382,6 +382,15 @@ export const selectSpatialFilter = (state, sourceId) => {
 };
 
 /**
+ * Redux selector to select the spatial filter of a given sourceId or the root one.
+ * This selector returns null if the spatial filter is invalid (if it intersetcs itself)
+ */
+export const selectValidSpatialFilter = (state, sourceId) => {
+  const spatialFilter = selectSpatialFilter(state, sourceId);
+  return spatialFilter?.properties?.isInvalid ? null : spatialFilter;
+};
+
+/**
  * Redux selector to select the feature selection mode based on if it's enabled
  */
 export const selectFeatureSelectionMode = (state) =>

--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -387,7 +387,7 @@ export const selectSpatialFilter = (state, sourceId) => {
  */
 export const selectValidSpatialFilter = (state, sourceId) => {
   const spatialFilter = selectSpatialFilter(state, sourceId);
-  return spatialFilter?.properties?.isInvalid ? null : spatialFilter;
+  return spatialFilter?.properties?.invalid ? null : spatialFilter;
 };
 
 /**

--- a/packages/react-ui/__tests__/widgets/FeatureSelectionWidgetUI.test.js
+++ b/packages/react-ui/__tests__/widgets/FeatureSelectionWidgetUI.test.js
@@ -142,7 +142,7 @@ describe('FeatureSelectionWidgetUI', () => {
 
   test('invalid geometry is rendered correctly', () => {
     const rendered = render(<CommonFeatureSelectionWidgetUI geometry={INVALID_GEOM} />);
-    expect(rendered.getByText('Invalid geometry')).toBeDefined();
+    expect(rendered.getByAltText('Invalid geometry')).toBeDefined();
   });
 
   test('geometry select event is raised correctly', () => {

--- a/packages/react-ui/__tests__/widgets/FeatureSelectionWidgetUI.test.js
+++ b/packages/react-ui/__tests__/widgets/FeatureSelectionWidgetUI.test.js
@@ -123,9 +123,26 @@ describe('FeatureSelectionWidgetUI', () => {
       name: 'Mask'
     }
   };
+  const INVALID_GEOM = {
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [125.6, 10.1]
+    },
+    properties: {
+      name: 'Mask',
+      invalid: true
+    }
+  };
+
   test('geometry is rendered correctly', () => {
     const rendered = render(<CommonFeatureSelectionWidgetUI geometry={GEOMETRY} />);
     expect(rendered.getByText('Mask')).toBeDefined();
+  });
+
+  test('invalid geometry is rendered correctly', () => {
+    const rendered = render(<CommonFeatureSelectionWidgetUI geometry={INVALID_GEOM} />);
+    expect(rendered.getByText('Invalid geometry')).toBeDefined();
   });
 
   test('geometry select event is raised correctly', () => {

--- a/packages/react-ui/__tests__/widgets/FeatureSelectionWidgetUI.test.js
+++ b/packages/react-ui/__tests__/widgets/FeatureSelectionWidgetUI.test.js
@@ -142,7 +142,7 @@ describe('FeatureSelectionWidgetUI', () => {
 
   test('invalid geometry is rendered correctly', () => {
     const rendered = render(<CommonFeatureSelectionWidgetUI geometry={INVALID_GEOM} />);
-    expect(rendered.getByAltText('Invalid geometry')).toBeDefined();
+    expect(rendered.getByRole('button', { name: 'Invalid geometry' })).toBeDefined();
   });
 
   test('geometry select event is raised correctly', () => {

--- a/packages/react-ui/src/localization/en.js
+++ b/packages/react-ui/src/localization/en.js
@@ -73,7 +73,8 @@ const locales = {
         remove: 'Remove',
         polygon: 'Polygon',
         point: 'Point',
-        lineString: 'Line'
+        lineString: 'Line',
+        invalid: 'Invalid geometry'
       },
       pie: {
         clear: 'Clear',

--- a/packages/react-ui/src/localization/en.js
+++ b/packages/react-ui/src/localization/en.js
@@ -74,7 +74,7 @@ const locales = {
         polygon: 'Polygon',
         point: 'Point',
         lineString: 'Line',
-        invalid: 'Invalid geometry'
+        invalid: 'Invalid shape'
       },
       pie: {
         clear: 'Clear',

--- a/packages/react-ui/src/localization/en.js
+++ b/packages/react-ui/src/localization/en.js
@@ -74,7 +74,7 @@ const locales = {
         polygon: 'Polygon',
         point: 'Point',
         lineString: 'Line',
-        invalid: 'Invalid shape'
+        invalid: 'Invalid geometry'
       },
       pie: {
         clear: 'Clear',

--- a/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionUIGeometryChips.js
+++ b/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionUIGeometryChips.js
@@ -1,4 +1,4 @@
-import { Cancel } from '@mui/icons-material';
+import { Cancel, ErrorOutline } from '@mui/icons-material';
 import { Box, Chip, List, ListItem, Tooltip, styled } from '@mui/material';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
@@ -80,13 +80,30 @@ function FeatureSelectionUIGeometryChips({
       <ChipList sx={{ gap: size === 'small' ? 0.5 : 1 }}>
         {features.map((geometry, index) => {
           const isDisabled = geometry.properties?.disabled;
-          const tooltipText = isDisabled
-            ? disabledChipTooltip || chipTooltip
-            : showDeleteTooltip
-            ? intlConfig.formatMessage({
-                id: `c4r.widgets.featureSelection.remove`
-              })
-            : chipTooltip;
+          const isInvalid = geometry.properties?.invalid;
+
+          let tooltipText = chipTooltip;
+          if (isDisabled) {
+            tooltipText = disabledChipTooltip || chipTooltip;
+          }
+          if (isInvalid) {
+            tooltipText = intlConfig.formatMessage({
+              id: `c4r.widgets.featureSelection.invalid`
+            });
+          }
+          if (showDeleteTooltip) {
+            tooltipText = intlConfig.formatMessage({
+              id: `c4r.widgets.featureSelection.remove`
+            });
+          }
+
+          let color = 'secondary';
+          if (isDisabled) {
+            color = 'default';
+          }
+          if (isInvalid) {
+            color = 'error';
+          }
 
           return (
             <ListItem disablePadding key={index}>
@@ -98,11 +115,12 @@ function FeatureSelectionUIGeometryChips({
                 <Chip
                   size={size}
                   label={getFeatureChipLabel(geometry, index)}
-                  color={isDisabled ? 'default' : 'secondary'}
+                  color={color}
                   onClick={() => onSelectGeometry(geometry)}
                   onDelete={
                     onDeleteGeometry ? () => onDeleteGeometry(geometry) : undefined
                   }
+                  icon={isInvalid ? <ErrorOutline color='error' /> : undefined}
                   deleteIcon={
                     <Cancel
                       onMouseEnter={() => setShowDeleteTooltip(true)}

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -81,6 +81,7 @@
     "@mui/material": "^5.11.16",
     "@nebula.gl/edit-modes": "^1.0.4",
     "@nebula.gl/layers": "^1.0.4",
+    "@turf/kinks": "^6.3.0",
     "dequal": "^2.0.2",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x",

--- a/packages/react-widgets/src/hooks/useWidgetFetch.js
+++ b/packages/react-widgets/src/hooks/useWidgetFetch.js
@@ -6,7 +6,7 @@ import {
 } from '@carto/react-core';
 import {
   selectAreFeaturesReadyForSource,
-  selectSpatialFilter,
+  selectValidSpatialFilter,
   selectViewport
 } from '@carto/react-redux';
 import { dequal } from 'dequal';
@@ -85,7 +85,9 @@ export default function useWidgetFetch(
   );
 
   const viewport = useSelector(selectViewport);
-  const spatialFilter = useSelector((state) => selectSpatialFilter(state, dataSource));
+  const spatialFilter = useSelector((state) =>
+    selectValidSpatialFilter(state, dataSource)
+  );
   const geometryToIntersect = useMemo(
     () => selectGeometryToIntersect(global, viewport, spatialFilter),
     [global, viewport, spatialFilter]

--- a/packages/react-widgets/src/layers/FeatureSelectionLayer.js
+++ b/packages/react-widgets/src/layers/FeatureSelectionLayer.js
@@ -65,7 +65,7 @@ export default function FeatureSelectionLayer(
   if (hasGeometry && !isSelected) {
     mainColor = secondaryAsRgba;
   }
-  if (spatialFilterGeometry?.properties?.isInvalid) {
+  if (spatialFilterGeometry?.properties?.invalid) {
     mainColor = errorAsRgba;
   }
 
@@ -101,7 +101,7 @@ export default function FeatureSelectionLayer(
           if (updatedData.features.length !== 0 && !editType.includes('Tentative')) {
             const [lastFeature] = updatedData.features.slice(-1);
             const intersectionPoints = kinks(lastFeature).features.length;
-            lastFeature.properties.isInvalid = intersectionPoints > 0;
+            lastFeature.properties.invalid = intersectionPoints > 0;
 
             if (lastFeature) {
               dispatch(

--- a/packages/react-widgets/src/layers/FeatureSelectionLayer.js
+++ b/packages/react-widgets/src/layers/FeatureSelectionLayer.js
@@ -12,6 +12,7 @@ import { hexToRgb, useTheme } from '@mui/material';
 import EditableCartoGeoJsonLayer from './EditableCartoGeoJsonLayer';
 import useEventManager from './useEventManager';
 import MaskLayer from './MaskLayer';
+import kinks from '@turf/kinks';
 
 const { ViewMode, TranslateMode, ModifyMode, CompositeMode } = nebulaModes;
 
@@ -58,8 +59,15 @@ export default function FeatureSelectionLayer(
 
   const primaryAsRgba = formatRGBA(hexToRgb(theme.palette.primary.main));
   const secondaryAsRgba = formatRGBA(hexToRgb(theme.palette.secondary.main));
+  const errorAsRgba = formatRGBA(hexToRgb(theme.palette.error.main));
 
-  const mainColor = hasGeometry && !isSelected ? secondaryAsRgba : primaryAsRgba;
+  let mainColor = primaryAsRgba;
+  if (hasGeometry && !isSelected) {
+    mainColor = secondaryAsRgba;
+  }
+  if (spatialFilterGeometry?.properties?.isInvalid) {
+    mainColor = errorAsRgba;
+  }
 
   return [
     mask && MaskLayer(),
@@ -92,6 +100,9 @@ export default function FeatureSelectionLayer(
           //     2. editType includes tentative, that means it's being drawn
           if (updatedData.features.length !== 0 && !editType.includes('Tentative')) {
             const [lastFeature] = updatedData.features.slice(-1);
+            const intersectionPoints = kinks(lastFeature).features.length;
+            lastFeature.properties.isInvalid = intersectionPoints > 0;
+
             if (lastFeature) {
               dispatch(
                 addSpatialFilter({

--- a/packages/react-widgets/src/layers/MaskLayer.js
+++ b/packages/react-widgets/src/layers/MaskLayer.js
@@ -1,10 +1,10 @@
 import { useSelector } from 'react-redux';
 import { SolidPolygonLayer } from '@deck.gl/layers/typed';
 import { MASK_ID } from '@carto/react-core/';
-import { selectSpatialFilter } from '@carto/react-redux/';
+import { selectValidSpatialFilter } from '@carto/react-redux/';
 
 export default function MaskLayer() {
-  const spatialFilterGeometry = useSelector((state) => selectSpatialFilter(state));
+  const spatialFilterGeometry = useSelector(selectValidSpatialFilter);
   const maskData = !!spatialFilterGeometry
     ? [{ polygon: spatialFilterGeometry?.geometry?.coordinates }]
     : [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4307,6 +4307,13 @@
   dependencies:
     "@turf/helpers" "^6.5.0"
 
+"@turf/kinks@^6.3.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/kinks/-/kinks-6.5.0.tgz#80e7456367535365012f658cf1a988b39a2c920b"
+  integrity sha512-ViCngdPt1eEL7hYUHR2eHR662GvCgTc35ZJFaNR6kRtr6D8plLaDju0FILeFFWSc+o8e3fwxZEJKmFj9IzPiIQ==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+
 "@turf/line-intersect@>=4.0.0", "@turf/line-intersect@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/line-intersect/-/line-intersect-6.5.0.tgz#dea48348b30c093715d2195d2dd7524aee4cf020"


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/391523/show-error

This PR adds capabilities for detecting invalid geometries drawn with the Feature Selection tool. It adds a new dependency `@turf/kinks` that checks for self-intersection inside polygons. With this, a polygon is considered invalid if it intersects with itself 1 time or more.

The purpose of this PR is disabling spatial filtering when invalid polygons are detected. A new property `invalid` is added to the GeoJSON `properties` of the feature so this data can be consumed from outside. Also a new `selectValidSpatialFilter` selector is created so obtaining this data can be easier.

![Captura de pantalla 2024-03-05 a las 17 42 41](https://github.com/CartoDB/carto-react/assets/6652814/4fdc3992-4bf3-4b30-8011-cfa8495cd698)

If this PR requires a companion in carto-react-template, please also link them both.

## Type of change

- Feature

# Acceptance

Please describe how to validate the feature or fix

1. log in to carto workspace
2. open a map or create a new one
3. using the feature selection tool, draw a invalid polygon like the one in the picture above
4. this polygon should not be applied as a mask or a filter anywhere in the app and error messages should pop up

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
