### PR TITLE
fix: keep always two digits at PieWidgetUI default percentFormatter

### DIFF
--- a/packages/react-ui/src/widgets/PieWidgetUI/PieWidgetUI.js
+++ b/packages/react-ui/src/widgets/PieWidgetUI/PieWidgetUI.js
@@ -71,7 +71,11 @@ function PieWidgetUI({
   const _percentFormatter = useMemo(
     () =>
       percentFormatter ||
-      ((v) => `${intl.formatNumber(v, { maximumFractionDigits: 2 })}%`),
+      ((v) =>
+        `${intl.formatNumber(v, {
+          maximumFractionDigits: 2,
+          minimumFractionDigits: 2
+        })}%`),
     [intl, percentFormatter]
   );
   // Tooltip


### PR DESCRIPTION
# Description
Related by: https://github.com/CartoDB/carto-react/pull/844

Keep two decimals always in default percent formatters in PieWidgetUI

## Type of change
- Fix

# Acceptance

Please describe how to validate the feature or fix

1. go to PieWidgetUI
2. Check percents format should have two decimals always, if you didn't defined a different percentFormatter

