### PR TITLE
Fix Geometry Edit in Feature Selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix geometry edit in Feature Selection [#854](https://github.com/CartoDB/carto-react/pull/854)
+
 ## 2.4
 
 ### 2.4.0 (2024-03-08)

--- a/packages/react-widgets/src/layers/FeatureSelectionLayer.js
+++ b/packages/react-widgets/src/layers/FeatureSelectionLayer.js
@@ -101,12 +101,17 @@ export default function FeatureSelectionLayer(
           if (updatedData.features.length !== 0 && !editType.includes('Tentative')) {
             const [lastFeature] = updatedData.features.slice(-1);
             const intersectionPoints = kinks(lastFeature).features.length;
-            lastFeature.properties.invalid = intersectionPoints > 0;
 
             if (lastFeature) {
               dispatch(
                 addSpatialFilter({
-                  geometry: lastFeature
+                  geometry: {
+                    ...lastFeature,
+                    properties: {
+                      ...lastFeature.properties,
+                      invalid: intersectionPoints > 0
+                    }
+                  }
                 })
               );
             }


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/394555/feature-selection-edition-doesn-t-work

This PR fixes a bug with edition of geometries introduced in PR #847 
Turns out nebula.gl features are immutable objects (enforced with the Object constructor) and cannot be edited in-place

## Type of change

- Fix

# Acceptance

Please describe how to validate the feature or fix

1. open carto workspace
2. open or create a map
3. add some data if none is present
4. add a feature selection mask
5. try to edit the mask or switch to a different edit mode
6. feature selection tool should stay responsive and respond to edits

If feature deals with theme / UI or internal elements used also in CARTO 3, please also add a note on how to do acceptance on that part.

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
