### PR TITLE
Category widget UI: increase keyboard accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Category widget UI: increase keyboard accessibility [#856](https://github.com/CartoDB/carto-react/pull/856)
+
 ## 2.4
 
 ### 2.4.1 (2024-03-13)

--- a/packages/react-ui/src/widgets/CategoryWidgetUI/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI/CategoryWidgetUI.js
@@ -7,7 +7,8 @@ import {
   InputAdornment,
   Divider,
   TextField,
-  Tooltip
+  Tooltip,
+  Box
 } from '@mui/material';
 
 import { useIntl } from 'react-intl';
@@ -477,17 +478,17 @@ function CategoryWidgetUI(props) {
             />
           ))
         ) : (
-          <>
+          <Box>
             <Typography variant='body2'>
               {intlConfig.formatMessage({ id: 'c4r.widgets.category.noResults' })}
             </Typography>
-            <Typography variant='caption'>
+            <Typography component='p' variant='caption' mb={2}>
               {intlConfig.formatMessage(
                 { id: 'c4r.widgets.category.noResultsMessage' },
                 { searchValue }
               )}
             </Typography>
-          </>
+          </Box>
         )}
       </CategoriesWrapper>
       {data.length > maxItems && searchable ? (

--- a/packages/react-ui/src/widgets/CategoryWidgetUI/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI/CategoryWidgetUI.js
@@ -323,7 +323,7 @@ function CategoryWidgetUI(props) {
       };
     }, []);
 
-    const handleCategoryPress = (e) => {
+    const onCategoryPress = (e) => {
       if (e.key === 'Enter') {
         onCategoryClick();
       }
@@ -339,11 +339,11 @@ function CategoryWidgetUI(props) {
         direction='row'
         spacing={1}
         onClick={filterable ? onCategoryClick : () => {}}
-        onKeyDown={handleCategoryPress}
+        onKeyDown={filterable ? onCategoryPress : () => {}}
         selectable={filterable}
         unselected={unselected}
         name={data.name === REST_CATEGORY ? REST_CATEGORY : ''}
-        tabIndex={filterable && showAll ? 0 : -1}
+        tabIndex={filterable ? 0 : -1}
       >
         {filterable && showAll && (
           <Grid item>

--- a/packages/react-ui/src/widgets/CategoryWidgetUI/CategoryWidgetUI.styled.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI/CategoryWidgetUI.styled.js
@@ -5,7 +5,6 @@ const REST_CATEGORY = '__rest__';
 
 export const CategoriesWrapper = styled(Grid)(({ theme: { spacing } }) => ({
   maxHeight: spacing(40),
-  overflow: 'auto',
   padding: spacing(0, 1, 1, 0)
 }));
 
@@ -28,10 +27,6 @@ export const CategoryItemGroup = styled(Grid, {
 
         '&:hover .progressbar div': {
           backgroundColor: theme.palette.secondary.dark
-        },
-        '&:focus-visible': {
-          outline: `none !important`,
-          boxShadow: `inset 0 0 0 2px ${theme.palette.primary.main} !important`
         }
       }),
     ...(name === REST_CATEGORY && {


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/395961/builder-widget-w-o-search-not-accessible-via-keyboard
[sc-395961]

Make Category widget w/o search accessible via keyboard