### PR TITLE
configurable histogram y axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+-  configurable histogram y axis [#860](https://github.com/CartoDB/carto-react/pull/860)
+
 ## 2.5
 
 ### 2.5.1 (2024-04-03)

--- a/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
@@ -36,6 +36,7 @@ function HistogramWidgetUI({
   max,
   xAxisFormatter,
   yAxisFormatter,
+  yAxisType,
   selectedBars,
   onSelectedBarsChange,
   tooltip,
@@ -135,8 +136,31 @@ function HistogramWidgetUI({
   );
 
   // yAxis
-  const yAxisOptions = useMemo(
-    () => ({
+  const yAxisOptions = useMemo(() => {
+    const denseAxisConfig = {
+      margin: 0,
+      verticalAlign: 'bottom',
+      padding: [0, 0, theme.spacingValue * 1.25, 0],
+      inside: true,
+      color: (value) => {
+        const maxValue = Math.max(...data.map((d) => d ?? Number.MIN_SAFE_INTEGER)) || 1;
+        let col = 'transparent';
+        if (value >= maxValue) {
+          col = theme.palette.black[60];
+        }
+
+        return col;
+      },
+      ...theme.typography.overlineDelicate,
+      formatter: (v) => processFormatterRes(yAxisFormatter(v))
+    };
+    const fullAxisConfig = {
+      verticalAlign: 'middle',
+      padding: [0, 0, 0, theme.spacingValue * 0.25],
+      color: theme.palette.black[60]
+    };
+    const axisLabelConfig = yAxisType === 'dense' ? denseAxisConfig : fullAxisConfig;
+    return {
       type: 'value',
       axisLine: {
         show: false
@@ -151,35 +175,22 @@ function HistogramWidgetUI({
         show: false
       },
       axisLabel: {
-        margin: 0,
-        verticalAlign: 'bottom',
-        padding: [0, 0, theme.spacingValue * 1.25, 0],
         show: true,
         showMaxLabel: true,
         showMinLabel: false,
-        inside: true,
-        color: (value) => {
-          const maxValue =
-            Math.max(...data.map((d) => d ?? Number.MIN_SAFE_INTEGER)) || 1;
-          let col = 'transparent';
-          if (value >= maxValue) {
-            col = theme.palette.black[60];
-          }
-
-          return col;
-        },
+        ...axisLabelConfig,
         ...theme.typography.overlineDelicate,
         formatter: (v) => processFormatterRes(yAxisFormatter(v))
       }
-    }),
-    [
-      theme.palette.black,
-      theme.spacingValue,
-      theme.typography.overlineDelicate,
-      data,
-      yAxisFormatter
-    ]
-  );
+    };
+  }, [
+    theme.palette.black,
+    theme.spacingValue,
+    theme.typography.overlineDelicate,
+    data,
+    yAxisFormatter,
+    yAxisType
+  ]);
 
   // Series
   const seriesOptions = useMemo(() => {
@@ -318,6 +329,7 @@ HistogramWidgetUI.defaultProps = {
   tooltipFormatter: defaultTooltipFormatter,
   xAxisFormatter: (v) => v,
   yAxisFormatter: (v) => v,
+  yAxisType: 'dense',
   selectedBars: [],
   animation: true,
   filterable: true,
@@ -333,6 +345,7 @@ HistogramWidgetUI.propTypes = {
   tooltipFormatter: PropTypes.func,
   xAxisFormatter: PropTypes.func,
   yAxisFormatter: PropTypes.func,
+  yAxisType: PropTypes.oneOf(['dense', 'full']),
   selectedBars: PropTypes.arrayOf(PropTypes.number),
   onSelectedBarsChange: PropTypes.func,
   animation: PropTypes.bool,

--- a/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
@@ -156,7 +156,7 @@ function HistogramWidgetUI({
     };
     const fullAxisConfig = {
       verticalAlign: 'middle',
-      padding: [0, 0, 0, theme.spacingValue * 0.25],
+      padding: [0, 0, 0, theme.spacingValue * 0.5],
       color: theme.palette.black[60]
     };
     const axisLabelConfig = yAxisType === 'dense' ? denseAxisConfig : fullAxisConfig;

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -31,6 +31,7 @@ const EMPTY_ARRAY = [];
  * @param  {number} [props.bins] - Number of bins to calculate the ticks.
  * @param  {Function} [props.xAxisFormatter] - Function to format X axis values.
  * @param  {Function} [props.formatter] - Function to format Y axis values.
+ * @param  {'dense' | 'full'} [props.yAxisType='dense'] - Type of Y axis. A dense axis will show only the top value and a full axis will show them all.
  * @param  {boolean} [props.tooltip=true] - Whether to show a tooltip or not.
  * @param  {Function} [props.tooltipFormatter] - Function to return the HTML of the tooltip.
  * @param  {boolean} [props.animation] - Enable/disable widget animations on data updates. Enabled by default.
@@ -54,6 +55,7 @@ function HistogramWidget({
   xAxisFormatter,
   bins,
   formatter,
+  yAxisType,
   tooltip,
   tooltipFormatter,
   animation,
@@ -198,6 +200,7 @@ function HistogramWidget({
             tooltipFormatter={tooltipFormatter}
             xAxisFormatter={xAxisFormatter}
             yAxisFormatter={formatter}
+            yAxisType={yAxisType}
             animation={animation}
             filterable={filterable}
             isLoading={isLoading}
@@ -220,6 +223,7 @@ HistogramWidget.propTypes = {
   operation: PropTypes.oneOf(Object.values(AggregationTypes)),
   xAxisFormatter: PropTypes.func,
   formatter: PropTypes.func,
+  yAxisType: PropTypes.oneOf(['dense', 'full']),
   tooltip: PropTypes.bool,
   tooltipFormatter: PropTypes.func,
   animation: PropTypes.bool,
@@ -237,6 +241,7 @@ HistogramWidget.defaultProps = {
   min: Number.MIN_SAFE_INTEGER,
   max: Number.MAX_SAFE_INTEGER,
   operation: AggregationTypes.COUNT,
+  yAxisType: 'dense',
   tooltip: true,
   animation: true,
   filterable: true,


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/400198/ui-pdf-report-in-the-pdf-preview-mode-the-histogram-chart-widget-is-interactive-and-shouldn-t-be

This is a PR with a feature required in the design QA phase of the PDF Report in Builder initiative 

## Type of change

- Feature

# Acceptance

Please describe how to validate the feature or fix

1. Open C4R Storybook
2. Go to story for HistogramWidgetUI
3. Select `yAxisType` as `full`
4. it should look like this

![Captura de pantalla 2024-04-03 a las 17 12 30](https://github.com/CartoDB/carto-react/assets/6652814/7e5123bb-e943-4667-88c8-715ac6d488ee)

If feature deals with theme / UI or internal elements used also in CARTO 3, please also add a note on how to do acceptance on that part.

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
