### PR TITLE
TimeSeriesWidget: support removing series in mounted widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- TimeSeriesWidget: support removing series in mounted widget [#863](https://github.com/CartoDB/carto-react/pull/863)
+
 ## 3.0.0
 
 ### 3.0.0-alpha.7 (2024-04-16)

--- a/packages/react-ui/src/widgets/TimeSeriesWidgetUI/components/TimeSeriesChart.js
+++ b/packages/react-ui/src/widgets/TimeSeriesWidgetUI/components/TimeSeriesChart.js
@@ -293,6 +293,7 @@ export default function TimeSeriesChart({
   return (
     <ReactEcharts
       option={options}
+      notMerge
       onEvents={onEvents}
       onChartReady={onChartReady}
       style={{ height }}


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/404044/monom-solutions-sl-time-series-widget-not-updating-when-parameters-change

TimeseriesWidget: Pass `notMerge` to `ReactEcharts` so it doens't attempt to merge _current_ options with old ones. This effectively allows removing series from widget instance.

Background:
Eacharts/react-echarts by default merge objects passed in `setOptions` so it's not possible to remove old series with default props update mechanism. For fully state-less, reactive behavior "setOption" strategy must changed to `notMerge` so no previous state lingers in echarts component instance.

Ref: 
 * echarts.setOption (look for not merge): https://echarts.apache.org/en/api.html#echartsInstance.setOption
 * others noticing this as bug:  https://github.com/apache/echarts/issues/16742

## Type of change

- Fix

# Acceptance

Create setup where series may disappear automatically. For example through data-source filtering and configure splitByCategory on same column as filtering.

* remove series one by one.
* series should disappear from a chart as they are dissapearing from legend

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
