### PR TITLE
TimeSeriesWidget: fix echarts props update, to keep state of control when clicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- TimeSeriesWidget: fix echarts props update, to keep state of control when clicking [#865](https://github.com/CartoDB/carto-react/pull/865)
 - TimeSeriesWidget: support removing series in mounted widget [#863](https://github.com/CartoDB/carto-react/pull/863)
 
 ## 3.0.0
@@ -11,6 +12,10 @@
 -  Update Deck GL v9 and removed dropping features functionality [#838](https://github.com/CartoDB/carto-react/pull/838)
 
 ## 2.5
+
+### 2.5.3 (2024-04-18)
+
+- TimeSeriesWidget: support removing series in mounted widget [#863](https://github.com/CartoDB/carto-react/pull/863)
 
 ### 2.5.2 (2024-04-10)
 

--- a/packages/react-ui/src/custom-components/echarts-for-react/index.js
+++ b/packages/react-ui/src/custom-components/echarts-for-react/index.js
@@ -49,6 +49,20 @@ export default class ReactEcharts extends _ReactEcharts {
     }
   }
 
+  updateEChartsOption() {
+    const { option, lazyUpdate, showLoading, loadingOption = null } = this.props;
+    const echartInstance = this.getEchartsInstance();
+
+    echartInstance.setOption(option, { replaceMerge: ['series'], lazyUpdate });
+
+    if (showLoading) {
+      echartInstance.showLoading(loadingOption);
+    } else {
+      echartInstance.hideLoading();
+    }
+    return echartInstance;
+  }
+
   offEvents(instance, events) {
     if (!events) return;
     // loop and off

--- a/packages/react-ui/src/widgets/TimeSeriesWidgetUI/components/TimeSeriesChart.js
+++ b/packages/react-ui/src/widgets/TimeSeriesWidgetUI/components/TimeSeriesChart.js
@@ -197,7 +197,7 @@ export default function TimeSeriesChart({
             : theme.palette.action.disabledBackground;
 
         return {
-          id: name,
+          id: String(i),
           name,
           markLine: i === 0 ? markLine : undefined,
           markArea: i === 0 ? markArea : undefined,

--- a/packages/react-ui/src/widgets/TimeSeriesWidgetUI/components/TimeSeriesChart.js
+++ b/packages/react-ui/src/widgets/TimeSeriesWidgetUI/components/TimeSeriesChart.js
@@ -197,6 +197,7 @@ export default function TimeSeriesChart({
             : theme.palette.action.disabledBackground;
 
         return {
+          id: name,
           name,
           markLine: i === 0 ? markLine : undefined,
           markArea: i === 0 ? markArea : undefined,
@@ -293,7 +294,6 @@ export default function TimeSeriesChart({
   return (
     <ReactEcharts
       option={options}
-      notMerge
       onEvents={onEvents}
       onChartReady={onChartReady}
       style={{ height }}

--- a/packages/react-ui/src/widgets/TimeSeriesWidgetUI/hooks/useTimeSeriesInteractivity.js
+++ b/packages/react-ui/src/widgets/TimeSeriesWidgetUI/hooks/useTimeSeriesInteractivity.js
@@ -25,10 +25,18 @@ export default function useTimeSeriesInteractivity({
 
   const updateCursor = useCallback((cursor) => zr?.setCursorStyle(cursor), [zr]);
 
+  const firstCategory = data?.[0]?.category;
+  const seriesFinder = useMemo(() => {
+    if (firstCategory) {
+      return { seriesId: firstCategory };
+    }
+    return { seriesIndex: 0 };
+  }, [firstCategory]);
+
   const updateTimelineByCoordinate = useCallback(
     (params) => {
       if (echartsInstance) {
-        const [x] = echartsInstance.convertFromPixel({ seriesIndex: 0 }, [
+        const [x] = echartsInstance.convertFromPixel(seriesFinder, [
           params.offsetX,
           params.offsetY
         ]);
@@ -36,7 +44,7 @@ export default function useTimeSeriesInteractivity({
         setTimeWindow(itemIndex !== undefined ? [data[itemIndex].name] : []);
       }
     },
-    [data, echartsInstance, setTimeWindow]
+    [data, echartsInstance, setTimeWindow, seriesFinder]
   );
 
   // Echarts events
@@ -87,7 +95,7 @@ export default function useTimeSeriesInteractivity({
 
       // Move markArea
       if (timeWindow.length === 2) {
-        const [x] = echartsInstance.convertFromPixel({ seriesIndex: 0 }, [
+        const [x] = echartsInstance.convertFromPixel(seriesFinder, [
           params.offsetX,
           params.offsetY
         ]);
@@ -101,7 +109,7 @@ export default function useTimeSeriesInteractivity({
 
       if (echartsInstance) {
         setIsMarkAreaSelected(true);
-        const [x] = echartsInstance.convertFromPixel({ seriesIndex: 0 }, [
+        const [x] = echartsInstance.convertFromPixel(seriesFinder, [
           params.offsetX,
           params.offsetY
         ]);
@@ -111,7 +119,7 @@ export default function useTimeSeriesInteractivity({
     }
 
     return addEventWithCleanUp(zr, 'mousedown', mouseDownEvent);
-  }, [zr, echartsInstance, timeWindow, updateCursor, filterable]);
+  }, [zr, echartsInstance, timeWindow, updateCursor, filterable, seriesFinder]);
 
   useEffect(() => {
     function mouseMoveEvent(params) {
@@ -125,7 +133,7 @@ export default function useTimeSeriesInteractivity({
       }
 
       if (isMarkAreaSelected && echartsInstance) {
-        const [x] = echartsInstance.convertFromPixel({ seriesIndex: 0 }, [
+        const [x] = echartsInstance.convertFromPixel(seriesFinder, [
           params.offsetX,
           params.offsetY
         ]);
@@ -145,7 +153,8 @@ export default function useTimeSeriesInteractivity({
     isMarkLineSelected,
     setTimeWindow,
     updateCursor,
-    updateTimelineByCoordinate
+    updateTimelineByCoordinate,
+    seriesFinder
   ]);
 
   useEffect(() => {
@@ -164,7 +173,7 @@ export default function useTimeSeriesInteractivity({
       }
 
       if (isMarkAreaMoving && echartsInstance) {
-        const [x] = echartsInstance.convertFromPixel({ seriesIndex: 0 }, [
+        const [x] = echartsInstance.convertFromPixel(seriesFinder, [
           params.offsetX,
           params.offsetY
         ]);
@@ -187,7 +196,8 @@ export default function useTimeSeriesInteractivity({
     oldMarkAreaPosition,
     setTimeWindow,
     timeWindow,
-    updateCursor
+    updateCursor,
+    seriesFinder
   ]);
 
   useEffect(() => {

--- a/packages/react-ui/src/widgets/TimeSeriesWidgetUI/hooks/useTimeSeriesInteractivity.js
+++ b/packages/react-ui/src/widgets/TimeSeriesWidgetUI/hooks/useTimeSeriesInteractivity.js
@@ -6,6 +6,9 @@ import { findItemIndexByTime } from '../utils/utilities';
 const events = {};
 let initialTimeWindow = null;
 
+// we identify series by their index and stringify it
+const seriesFinder = { seriesId: '0' };
+
 export default function useTimeSeriesInteractivity({
   echartsInstance,
   data,
@@ -25,14 +28,6 @@ export default function useTimeSeriesInteractivity({
 
   const updateCursor = useCallback((cursor) => zr?.setCursorStyle(cursor), [zr]);
 
-  const firstCategory = data?.[0]?.category;
-  const seriesFinder = useMemo(() => {
-    if (firstCategory) {
-      return { seriesId: firstCategory };
-    }
-    return { seriesIndex: 0 };
-  }, [firstCategory]);
-
   const updateTimelineByCoordinate = useCallback(
     (params) => {
       if (echartsInstance) {
@@ -44,7 +39,7 @@ export default function useTimeSeriesInteractivity({
         setTimeWindow(itemIndex !== undefined ? [data[itemIndex].name] : []);
       }
     },
-    [data, echartsInstance, setTimeWindow, seriesFinder]
+    [data, echartsInstance, setTimeWindow]
   );
 
   // Echarts events
@@ -119,7 +114,7 @@ export default function useTimeSeriesInteractivity({
     }
 
     return addEventWithCleanUp(zr, 'mousedown', mouseDownEvent);
-  }, [zr, echartsInstance, timeWindow, updateCursor, filterable, seriesFinder]);
+  }, [zr, echartsInstance, timeWindow, updateCursor, filterable]);
 
   useEffect(() => {
     function mouseMoveEvent(params) {
@@ -153,8 +148,7 @@ export default function useTimeSeriesInteractivity({
     isMarkLineSelected,
     setTimeWindow,
     updateCursor,
-    updateTimelineByCoordinate,
-    seriesFinder
+    updateTimelineByCoordinate
   ]);
 
   useEffect(() => {
@@ -196,8 +190,7 @@ export default function useTimeSeriesInteractivity({
     oldMarkAreaPosition,
     setTimeWindow,
     timeWindow,
-    updateCursor,
-    seriesFinder
+    updateCursor
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/404593/builder-timeserieswidget-tooltip-disappears-when-clicking-on-series

In `TimeseriesWidget`, fix way we update props in `echarts` instance so 
 * series are effectively removed
 * we don't lose state of control on props update

(note, data update still resets control animation/filter state)

Fixes regression from #863 
## Type of change

- Fix

# Acceptance

Please describe how to validate the feature or fix

1. go to X
2. test Y
3. assert Z

If feature deals with theme / UI or internal elements used also in CARTO 3, please also add a note on how to do acceptance on that part.

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
