### PR TITLE
Fix legend deformed dot when the title is too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix legend deformed dot when the title is too long [#871](https://github.com/CartoDB/carto-react/pull/871)
+
 ## 3.0.0
 
 ### 3.0.0-alpha.8 (2024-04-23)

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendCategories.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendCategories.js
@@ -132,7 +132,7 @@ const Marker = styled(Box, {
   display: 'block',
   width: theme.spacing(1.5),
   height: theme.spacing(1.5),
-  flex: '0, 0, auto',
+  flexShrink: '0',
   borderRadius: '50%',
   position: 'relative',
   border: '2px solid transparent',

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendCategories.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendCategories.js
@@ -132,6 +132,7 @@ const Marker = styled(Box, {
   display: 'block',
   width: theme.spacing(1.5),
   height: theme.spacing(1.5),
+  flex: '0, 0, auto',
   borderRadius: '50%',
   position: 'relative',
   border: '2px solid transparent',


### PR DESCRIPTION
# Description

Fixing this situation:

<img width="240" alt="Captura de pantalla 2024-05-29 a las 9 35 21" src="https://github.com/CartoDB/carto-react/assets/7164554/75b10e94-16ab-455b-b874-6c3fa4202470">

Reported here 
https://app.shortcut.com/cartoteam/story/413527/cambium-earth-color-dots-not-displayed-properly-in-legend

## Type of change

- Fix