### PR TITLE
fix(react-ui): Fix LegendProportion radius scale

### DIFF
--- a/packages/react-ui/__tests__/widgets/legend/LegendProportion.test.js
+++ b/packages/react-ui/__tests__/widgets/legend/LegendProportion.test.js
@@ -4,7 +4,7 @@ import LegendProportion from '../../../src/widgets/legend/legend-types/LegendPro
 import { IntlProvider } from 'react-intl';
 
 const DEFAULT_LEGEND = {
-  labels: ['0', '200']
+  labels: ['0', '150']
 };
 
 describe('LegendProportion', () => {
@@ -14,8 +14,8 @@ describe('LegendProportion', () => {
         <LegendProportion legend={DEFAULT_LEGEND} />
       </IntlProvider>
     );
-    expect(screen.queryByText('Max: 200')).toBeInTheDocument();
-    expect(screen.queryByText('150')).toBeInTheDocument();
+    expect(screen.queryByText('Max: 150')).toBeInTheDocument();
+    expect(screen.queryByText('100')).toBeInTheDocument();
     expect(screen.queryByText('50')).toBeInTheDocument();
     expect(screen.queryByText('Min: 0')).toBeInTheDocument();
   });
@@ -27,8 +27,8 @@ describe('LegendProportion', () => {
     );
     expect(screen.queryByText('Max')).not.toBeInTheDocument();
     expect(screen.queryByText('Min')).not.toBeInTheDocument();
-    expect(screen.queryByText('200')).toBeInTheDocument();
     expect(screen.queryByText('150')).toBeInTheDocument();
+    expect(screen.queryByText('100')).toBeInTheDocument();
     expect(screen.queryByText('50')).toBeInTheDocument();
     expect(screen.queryByText('0')).toBeInTheDocument();
   });

--- a/packages/react-ui/src/widgets/legend/LegendWidgetUI.styles.js
+++ b/packages/react-ui/src/widgets/legend/LegendWidgetUI.styles.js
@@ -50,7 +50,7 @@ export const OpacityTextField = styled(TextField)(({ theme }) => ({
   flexShrink: 0,
   'input[type=number]::-webkit-inner-spin-button, input[type=number]::-webkit-outer-spin-button':
     {
-      '-webkit-appearance': 'none',
+      WebkitAppearance: 'none',
       margin: 0
     }
 }));

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendProportion.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendProportion.js
@@ -149,10 +149,11 @@ function calculateRange(legend) {
   return { min, max, error };
 }
 
+/**
+ * Calculates two evenly-spaced steps, linearly interpolated between a given
+ * min and max. For example, `calculateSteps(3, 12)` gives `[6, 9]`.
+ */
 function calculateSteps(min, max) {
-  const gap = (max + min) / 4;
-  const step1 = min + gap;
-  const step2 = max - gap;
-
-  return [step1, step2];
+  const step = (max - min) / 3;
+  return [min + step, max - step];
 }

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendProportion.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendProportion.js
@@ -5,6 +5,8 @@ import Typography from '../../../components/atoms/Typography';
 import { useIntl } from 'react-intl';
 import useImperativeIntl from '../../../hooks/useImperativeIntl';
 
+const MAX_DIGITS = 6;
+
 const sizes = {
   0: 12,
   1: 9,
@@ -86,20 +88,18 @@ function LegendProportion({ legend }) {
         ) : (
           <>
             <Typography variant='overline' color='textSecondary'>
-              {showMinMax
-                ? `${intlConfig.formatMessage({ id: 'c4r.widgets.legend.max' })}: ${max}`
-                : max}
+              {showMinMax && intlConfig.formatMessage({ id: 'c4r.widgets.legend.max' })}:
+              {intl.formatNumber(max, { maximumFractionDigits: MAX_DIGITS })}
             </Typography>
             <Typography variant='overline' color='textSecondary'>
-              {intl.formatNumber(step2, { maximumFractionDigits: 6 })}
+              {intl.formatNumber(step2, { maximumFractionDigits: MAX_DIGITS })}
             </Typography>
             <Typography variant='overline' color='textSecondary'>
-              {intl.formatNumber(step1, { maximumFractionDigits: 6 })}
+              {intl.formatNumber(step1, { maximumFractionDigits: MAX_DIGITS })}
             </Typography>
             <Typography variant='overline' color='textSecondary'>
-              {showMinMax
-                ? `${intlConfig.formatMessage({ id: 'c4r.widgets.legend.min' })}: ${min}`
-                : min}
+              {showMinMax && intlConfig.formatMessage({ id: 'c4r.widgets.legend.min' })}:
+              {intl.formatNumber(min, { maximumFractionDigits: MAX_DIGITS })}
             </Typography>
           </>
         )}

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendProportion.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendProportion.js
@@ -91,10 +91,10 @@ function LegendProportion({ legend }) {
                 : max}
             </Typography>
             <Typography variant='overline' color='textSecondary'>
-              {step2}
+              {intl.formatNumber(step2, { maximumFractionDigits: 6 })}
             </Typography>
             <Typography variant='overline' color='textSecondary'>
-              {step1}
+              {intl.formatNumber(step1, { maximumFractionDigits: 6 })}
             </Typography>
             <Typography variant='overline' color='textSecondary'>
               {showMinMax

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendProportion.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendProportion.js
@@ -5,7 +5,7 @@ import Typography from '../../../components/atoms/Typography';
 import { useIntl } from 'react-intl';
 import useImperativeIntl from '../../../hooks/useImperativeIntl';
 
-const MAX_DIGITS = 6;
+const MAX_SIGNIFICANT_DIGITS = 6;
 
 const sizes = {
   0: 12,
@@ -89,17 +89,25 @@ function LegendProportion({ legend }) {
           <>
             <Typography variant='overline' color='textSecondary'>
               {showMinMax && intlConfig.formatMessage({ id: 'c4r.widgets.legend.max' })}:
-              {intl.formatNumber(max, { maximumFractionDigits: MAX_DIGITS })}
+              {intl.formatNumber(max, {
+                maximumSignificantDigits: MAX_SIGNIFICANT_DIGITS
+              })}
             </Typography>
             <Typography variant='overline' color='textSecondary'>
-              {intl.formatNumber(step2, { maximumFractionDigits: MAX_DIGITS })}
+              {intl.formatNumber(step2, {
+                maximumSignificantDigits: MAX_SIGNIFICANT_DIGITS
+              })}
             </Typography>
             <Typography variant='overline' color='textSecondary'>
-              {intl.formatNumber(step1, { maximumFractionDigits: MAX_DIGITS })}
+              {intl.formatNumber(step1, {
+                maximumSignificantDigits: MAX_SIGNIFICANT_DIGITS
+              })}
             </Typography>
             <Typography variant='overline' color='textSecondary'>
               {showMinMax && intlConfig.formatMessage({ id: 'c4r.widgets.legend.min' })}:
-              {intl.formatNumber(min, { maximumFractionDigits: MAX_DIGITS })}
+              {intl.formatNumber(min, {
+                maximumSignificantDigits: MAX_SIGNIFICANT_DIGITS
+              })}
             </Typography>
           </>
         )}

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendProportion.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendProportion.js
@@ -5,7 +5,7 @@ import Typography from '../../../components/atoms/Typography';
 import { useIntl } from 'react-intl';
 import useImperativeIntl from '../../../hooks/useImperativeIntl';
 
-const MAX_SIGNIFICANT_DIGITS = 6;
+const MAX_SIG_DIGITS = 6;
 
 const sizes = {
   0: 12,
@@ -88,26 +88,20 @@ function LegendProportion({ legend }) {
         ) : (
           <>
             <Typography variant='overline' color='textSecondary'>
-              {showMinMax && intlConfig.formatMessage({ id: 'c4r.widgets.legend.max' })}:
-              {intl.formatNumber(max, {
-                maximumSignificantDigits: MAX_SIGNIFICANT_DIGITS
-              })}
+              {showMinMax &&
+                intlConfig.formatMessage({ id: 'c4r.widgets.legend.max' }) + ': '}
+              {intl.formatNumber(max, { maximumSignificantDigits: MAX_SIG_DIGITS })}
             </Typography>
             <Typography variant='overline' color='textSecondary'>
-              {intl.formatNumber(step2, {
-                maximumSignificantDigits: MAX_SIGNIFICANT_DIGITS
-              })}
+              {intl.formatNumber(step2, { maximumSignificantDigits: MAX_SIG_DIGITS })}
             </Typography>
             <Typography variant='overline' color='textSecondary'>
-              {intl.formatNumber(step1, {
-                maximumSignificantDigits: MAX_SIGNIFICANT_DIGITS
-              })}
+              {intl.formatNumber(step1, { maximumSignificantDigits: MAX_SIG_DIGITS })}
             </Typography>
             <Typography variant='overline' color='textSecondary'>
-              {showMinMax && intlConfig.formatMessage({ id: 'c4r.widgets.legend.min' })}:
-              {intl.formatNumber(min, {
-                maximumSignificantDigits: MAX_SIGNIFICANT_DIGITS
-              })}
+              {showMinMax &&
+                intlConfig.formatMessage({ id: 'c4r.widgets.legend.min' }) + ': '}
+              {intl.formatNumber(min, { maximumSignificantDigits: MAX_SIG_DIGITS })}
             </Typography>
           </>
         )}


### PR DESCRIPTION
# Description

Shortcut: Story 415171, URL redacted.

LegendProportion displays the legend for point scaling, and sometimes calculates the scale incorrectly. In the image below, note that the 'max' is smaller than the second number, and the 'min' is larger than the third.

The cause is a typo, we should be using `max - min` instead of `max + min` to calculate the interval over which the two middle steps are interpolated. With this bug, the steps were calculated correctly only when `min` was zero.

Additionally, the visual sizes of the circles in the legend panel are hard-coded to `[3, 6, 9, 12]`, representing two evenly-spaced steps between the min and max. However, our implementation would have generated different steps given `min=3, max=12` as input, because it divided the interval by 4, not 3.

| before | after |
|---|---|
| <img width="209" alt="legend_range_bug" src="https://github.com/CartoDB/carto-react/assets/1848368/bee143ed-f729-4c91-b563-f7df74270e9d"> | <img width="234" alt="Screenshot 2024-06-11 at 12 39 00 PM" src="https://github.com/CartoDB/carto-react/assets/1848368/759094bf-e0d9-4f6d-840a-97e540d35ad3"> |

## Type of change

- [x] Fix

# Acceptance

Please describe how to validate the feature or fix

1. Link C4R into Builder
2. Create a new map
3. Add SQL query

    ```sql
    SELECT * FROM `carto-demo-data.demo_tables.cell_towers_worldwide` AS table
    WHERE (table.lat - 36.744874) < 5 AND (table.lon - 3.195371) < 5;
    ```

4. Set point layer to style radius by `lat` column
5. Open legend, observe steps are correctly spaced

