### PR TITLE
Fix LegendWidget update logic for multiple legends case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- fix LegendWidget update logic for multiple legends case [#889](https://github.com/CartoDB/carto-react/pull/889)
 - onStateChange callback for all widgets [#886](https://github.com/CartoDB/carto-react/pull/886)
 
 ## 3.0.0

--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -81,14 +81,15 @@ export const createCartoSlice = (initialState) => {
         const layer = state.layers[action.payload.id];
         if (layer) {
           const newLayer = { ...layer, ...action.payload.layerAttributes };
+          const hasLegendUpdate = layer.legend && newLayer.legend;
+          // Merge legend object if it's not an array (for the case of multiple legend objects per layer)
+          if (hasLegendUpdate && !Array.isArray(newLayer.legend)) {
+            newLayer.legend = { ...layer.legend, ...newLayer.legend };
+          }
 
           // TODO: Study if we should use a deepmerge fn
           state.layers[action.payload.id] = {
-            ...newLayer,
-            ...(layer.legend &&
-              newLayer.legend && {
-                legend: { ...layer.legend, ...newLayer.legend }
-              })
+            ...newLayer
           };
         }
       },

--- a/packages/react-widgets/src/widgets/LegendWidget.js
+++ b/packages/react-widgets/src/widgets/LegendWidget.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { updateLayer } from '@carto/react-redux/';
 import { LegendWidgetUI } from '@carto/react-ui';
 import { useDispatch, useSelector } from 'react-redux';
@@ -17,12 +17,13 @@ import { useMediaQuery } from '@mui/material';
  */
 function LegendWidget({ customLegendTypes, initialCollapsed, layerOrder = [], title }) {
   const dispatch = useDispatch();
-  const layers = useSelector((state) =>
+  const reduxLayers = useSelector((state) => state.carto.layers);
+  const layers = useMemo(() => {
     sortLayers(
-      Object.values(state.carto.layers).filter((layer) => !!layer.legend),
+      Object.values(reduxLayers).filter((layer) => !!layer.legend),
       layerOrder
-    ).filter((l) => !!l.legend)
-  );
+    ).filter((l) => !!l.legend);
+  }, [reduxLayers, layerOrder]);
 
   const [collapsed, setCollapsed] = useState(initialCollapsed);
   const isMobile = useMediaQuery((theme) => theme.breakpoints.down('sm'));


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/geographica/story/425245

Fix react-redux action `updateLayer` to account for the case of multiple legend objects per layer, keeping array object reference.

## Type of change

- Fix

# Acceptance

Please describe how to validate the feature or fix

1. Render a <LegendWidget /> in which one layer has multiple legends
2. Collapse or hide one of those legends
3. Uncollapse or show the same legend
4. It should be back to its original state

This feature is not used in cloud-native but it is used in various PS projects such as Groupauto, DHL, and more

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
