### PR TITLE
Mui v5 fix styles to upgrade to the latest stable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Mui v5 fix styles to upgrade to the latest stable version [#892](https://github.com/CartoDB/carto-react/pull/892)
 - onStateChange callback for range widget [#890](https://github.com/CartoDB/carto-react/pull/890)
 - fix LegendWidget update logic for multiple legends case [#889](https://github.com/CartoDB/carto-react/pull/889)
 - onStateChange callback for all widgets [#886](https://github.com/CartoDB/carto-react/pull/886)

--- a/packages/react-ui/src/theme/sections/components/forms.js
+++ b/packages/react-ui/src/theme/sections/components/forms.js
@@ -511,7 +511,7 @@ export const formsOverrides = {
           right: theme.spacing(2),
           color: theme.palette.text.secondary
         },
-        '&.Mui-disabled .MuiSelect-icon': {
+        '&.Mui-disabled .MuiSelect-icon, &.Mui-readOnly .MuiSelect-icon': {
           color: theme.palette.text.disabled
         },
         '& .MuiSelect-iconStandard': {
@@ -661,6 +661,7 @@ export const formsOverrides = {
       }),
 
       endAdornment: ({ theme }) => ({
+        transform: 'none',
         top: theme.spacing(2),
         display: 'flex',
         alignItems: 'center',

--- a/packages/react-ui/src/theme/sections/components/navigation.js
+++ b/packages/react-ui/src/theme/sections/components/navigation.js
@@ -129,7 +129,7 @@ export const navigationOverrides = {
       root: ({ theme }) => ({
         paddingTop: 0,
 
-        '.MuiPopover-root &, .MuiPopper-root &, .base-Popper-root &': {
+        '.MuiPopover-root &, .MuiPopper-root &, .MuiPaper-root &': {
           minWidth: theme.spacing(8), // 64px, defined by design
           maxHeight: theme.spacing(39), // 312px, defined by design
           overflowY: 'auto',

--- a/packages/react-ui/src/theme/sections/components/navigation.js
+++ b/packages/react-ui/src/theme/sections/components/navigation.js
@@ -129,7 +129,7 @@ export const navigationOverrides = {
       root: ({ theme }) => ({
         paddingTop: 0,
 
-        '.MuiPopover-root &, .MuiPopper-root &': {
+        '.MuiPopover-root &, .MuiPopper-root &, .base-Popper-root &': {
           minWidth: theme.spacing(8), // 64px, defined by design
           maxHeight: theme.spacing(39), // 312px, defined by design
           overflowY: 'auto',


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/414478/bump-mui-v5-version-and-adapt-unit-tests-e2e-tests
[sc-414478]

