### PR TITLE
fix legend widget return bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## Not released
 
-- onStateChange callback for range widget [#890](https://github.com/CartoDB/carto-react/pull/890)
-- fix LegendWidget update logic for multiple legends case [#889](https://github.com/CartoDB/carto-react/pull/889)
-- onStateChange callback for all widgets [#886](https://github.com/CartoDB/carto-react/pull/886)
+- fix legend widget return bug [#893](https://github.com/CartoDB/carto-react/pull/893)
 
 ## 3.0.0
 

--- a/packages/react-widgets/src/widgets/LegendWidget.js
+++ b/packages/react-widgets/src/widgets/LegendWidget.js
@@ -19,7 +19,7 @@ function LegendWidget({ customLegendTypes, initialCollapsed, layerOrder = [], ti
   const dispatch = useDispatch();
   const reduxLayers = useSelector((state) => state.carto.layers);
   const layers = useMemo(() => {
-    sortLayers(
+    return sortLayers(
       Object.values(reduxLayers).filter((layer) => !!layer.legend),
       layerOrder
     ).filter((l) => !!l.legend);


### PR DESCRIPTION
# Description

Fix for a silly bug introduced in PR #889

## Type of change

(choose one and remove the others)

- Fix

# Acceptance

Please describe how to validate the feature or fix

1. download version alpha 15 of @carto/react-widgets
2. install it in your project
3. rendering <LegendWidget /> should work correctly

(this code is not used in carto cloud native)

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
