### PR TITLE
Cache Intl instances to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- cache Intl instances to improve performance [#894](https://github.com/CartoDB/carto-react/pull/894)
 - Support for `onRowMouseEnter` and `onRowMouseLeave` handlers for Table Widget [#907](https://github.com/CartoDB/carto-react/pull/907)
 
 ## 3.0.0

--- a/packages/react-ui/src/hooks/useImperativeIntl.js
+++ b/packages/react-ui/src/hooks/useImperativeIntl.js
@@ -8,22 +8,40 @@ import {
 } from '../localization/localeUtils';
 
 const cache = createIntlCache();
+const intlInstanceCache = new WeakMap();
+
+const createIntlInstance = (intlConfig) => {
+  const locale = intlConfig?.locale || DEFAULT_LOCALE;
+  const messagesLocale = findMatchingMessagesLocale(locale, messages);
+  const intMessages = {
+    ...(messages[messagesLocale] || {}),
+    ...(intlConfig?.messages || {})
+  };
+
+  const combinedMessages = flattenMessages(intMessages);
+  return createIntl(
+    {
+      locale,
+      messages: combinedMessages
+    },
+    cache
+  );
+};
+
+const getGloballyCachedIntl = (intlConfig) => {
+  // This is very simple cache exploits fact that Intl instance is actually same for most of time
+  // so we can reuse those maps across several instances of same components
+  // note, useMemo can't cache accross many that globally and flattenMessages over _app_ and c4r messages is quite costly
+  // and would be paid for every c4r component mounted.
+  let cachedInstance = intlInstanceCache.get(intlConfig);
+  if (cachedInstance) {
+    return cachedInstance;
+  }
+  const newInstance = createIntlInstance(intlConfig);
+  intlInstanceCache.set(intlConfig, newInstance);
+  return newInstance;
+};
 
 export default function useImperativeIntl(intlConfig) {
-  return useMemo(() => {
-    const locale = intlConfig?.locale || DEFAULT_LOCALE;
-    const messagesLocale = findMatchingMessagesLocale(locale, messages);
-    const intMessages = {
-      ...(messages[messagesLocale] || {}),
-      ...(intlConfig?.messages || {})
-    };
-
-    return createIntl(
-      {
-        locale,
-        messages: flattenMessages(intMessages)
-      },
-      cache
-    );
-  }, [intlConfig]);
+  return getGloballyCachedIntl(intlConfig);
 }


### PR DESCRIPTION
# Description


Cache intl instances globally.

`flattenMessages` over _c4r_ and app could take up to 2-4 milliseconds (on fast machine). And with current, `useMemo` approach it was executed for each component mounted .. and lost when unmounted.


Real app can mount even 10+ c4r+intl-based components a time, causing some mounts to miss sane deadlines and cause warnings like:

> [Violation] 'click' handler took 106ms

(it's not that this call is only one slow in big components, but this can be easily avoided as `intlConfig` instance is generally stable)

We also don't want to waste memory to keep next 10+ copies of all messages (3.5k keys)

## Type of change

(choose one and remove the others)

- Fix
- Refactor

# Acceptance

N/A performance issue

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
