### PR TITLE
Release 3.0.0 alpha.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Not released
 
+## 3.0.0
+
+### 3.0.0-alpha.16 (2024-07-26)
+
 - Mui v5 fix styles to upgrade to the latest stable version [#892](https://github.com/CartoDB/carto-react/pull/892)
 - fix legend widget return bug [#893](https://github.com/CartoDB/carto-react/pull/893)
-
-## 3.0.0
 
 ### 3.0.0-alpha.15 (2024-07-22)
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.0.0-alpha.15"
+  "version": "3.0.0-alpha.16"
 }

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-api",
-  "version": "3.0.0-alpha.15",
+  "version": "3.0.0-alpha.16",
   "description": "CARTO for React - Api",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -68,9 +68,9 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^3.0.0-alpha.15",
-    "@carto/react-redux": "^3.0.0-alpha.15",
-    "@carto/react-workers": "^3.0.0-alpha.15",
+    "@carto/react-core": "^3.0.0-alpha.16",
+    "@carto/react-redux": "^3.0.0-alpha.16",
+    "@carto/react-workers": "^3.0.0-alpha.16",
     "@deck.gl/carto": "^9.0.1",
     "@deck.gl/core": "^9.0.1",
     "@deck.gl/extensions": "^9.0.1",

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -68,7 +68,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^3.0.0-alpha.15",
+    "@carto/react-core": "^3.0.0-alpha.16",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x"
   }

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-auth",
-  "version": "3.0.0-alpha.15",
+  "version": "3.0.0-alpha.16",
   "description": "CARTO for React - Auth",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-basemaps/package.json
+++ b/packages/react-basemaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-basemaps",
-  "version": "3.0.0-alpha.15",
+  "version": "3.0.0-alpha.16",
   "description": "CARTO for React - Basemaps",
   "keywords": [
     "carto",

--- a/packages/react-basemaps/package.json
+++ b/packages/react-basemaps/package.json
@@ -68,7 +68,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^3.0.0-alpha.15",
+    "@carto/react-core": "^3.0.0-alpha.16",
     "@deck.gl/google-maps": "^9.0.1",
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x"

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-core",
-  "version": "3.0.0-alpha.15",
+  "version": "3.0.0-alpha.16",
   "description": "CARTO for React - Core",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -67,8 +67,8 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^3.0.0-alpha.15",
-    "@carto/react-workers": "^3.0.0-alpha.15",
+    "@carto/react-core": "^3.0.0-alpha.16",
+    "@carto/react-workers": "^3.0.0-alpha.16",
     "@deck.gl/carto": "^9.0.1",
     "@deck.gl/core": "^9.0.1",
     "@reduxjs/toolkit": "^1.5.0"

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-redux",
-  "version": "3.0.0-alpha.15",
+  "version": "3.0.0-alpha.16",
   "description": "CARTO for React - Redux",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-ui",
-  "version": "3.0.0-alpha.15",
+  "version": "3.0.0-alpha.16",
   "description": "CARTO for React - UI",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -82,7 +82,7 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-core": "^3.0.0-alpha.15",
+    "@carto/react-core": "^3.0.0-alpha.16",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@formatjs/intl-localematcher": "^0.4.0",

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-widgets",
-  "version": "3.0.0-alpha.15",
+  "version": "3.0.0-alpha.16",
   "description": "CARTO for React - Widgets",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -69,11 +69,11 @@
     "@babel/runtime": "^7.13.9"
   },
   "peerDependencies": {
-    "@carto/react-api": "^3.0.0-alpha.15",
-    "@carto/react-core": "^3.0.0-alpha.15",
-    "@carto/react-redux": "^3.0.0-alpha.15",
-    "@carto/react-ui": "^3.0.0-alpha.15",
-    "@carto/react-workers": "^3.0.0-alpha.15",
+    "@carto/react-api": "^3.0.0-alpha.16",
+    "@carto/react-core": "^3.0.0-alpha.16",
+    "@carto/react-redux": "^3.0.0-alpha.16",
+    "@carto/react-ui": "^3.0.0-alpha.16",
+    "@carto/react-workers": "^3.0.0-alpha.16",
     "@deck.gl-community/editable-layers": "^9.0.0-alpha.1",
     "@deck.gl/core": "^9.0.1",
     "@deck.gl/layers": "^9.0.1",

--- a/packages/react-workers/package.json
+++ b/packages/react-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-workers",
-  "version": "3.0.0-alpha.15",
+  "version": "3.0.0-alpha.16",
   "description": "CARTO for React - Workers",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.9",
-    "@carto/react-core": "^3.0.0-alpha.15",
+    "@carto/react-core": "^3.0.0-alpha.16",
     "@turf/bbox-polygon": "^6.3.0",
     "@turf/boolean-intersects": "^6.3.0",
     "@turf/boolean-within": "^6.3.0",


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/414478/bump-mui-v5-version-and-adapt-unit-tests-e2e-tests
[sc-414478]
