### PR TITLE
Fix MuiList outside Popper elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix MuiList outside Popper elements [#896](https://github.com/CartoDB/carto-react/pull/896)
+
 ## 3.0.0
 
 ### 3.0.0-alpha.16 (2024-07-26)

--- a/packages/react-ui/src/theme/sections/components/navigation.js
+++ b/packages/react-ui/src/theme/sections/components/navigation.js
@@ -129,7 +129,7 @@ export const navigationOverrides = {
       root: ({ theme }) => ({
         paddingTop: 0,
 
-        '.MuiPopover-root &, .MuiPopper-root &, .MuiPaper-root &': {
+        '.MuiPopover-root &, .MuiPopper-root &, .base-Popper-root &': {
           minWidth: theme.spacing(8), // 64px, defined by design
           maxHeight: theme.spacing(39), // 312px, defined by design
           overflowY: 'auto',


### PR DESCRIPTION
# Description

- Story: https://app.shortcut.com/cartoteam/story/430177/menu-ui-issues
- Autolink: [sc-430177]
