### PR TITLE
Remote widget calculation for  spatial indexed sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Spatial Index Sources use remote widgets calculation [#898](https://github.com/CartoDB/carto-react/pull/898)
+
 ## 3.0.0
 
 ### 3.0.0-alpha.17 (2024-07-29)

--- a/packages/react-api/__tests__/api/model.test.js
+++ b/packages/react-api/__tests__/api/model.test.js
@@ -123,7 +123,7 @@ describe('model', () => {
       expect(mockedMakeCall).toHaveBeenCalledWith({
         credentials: TABLE_SOURCE.credentials,
         opts: { method: 'GET' },
-        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=query&client=c4react&source=SELECT+*+FROM+%60cartobq.public_account.seattle_collisions%60+WHERE+time_column+%3E+%40start+AND+time_column+%3C+%40end&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&queryParameters=%7B%22start%22%3A%222019-01-01%22%2C%22end%22%3A%222019-01-02%22%7D&filters=%7B%7D&filtersLogicalOperator=AND&spatialFilters=%7B%22geom%22%3A%7B%22type%22%3A%22Polygon%22%2C%22coordinates%22%3A%5B%5B%5B-84.40640911186557%2C31.358634554371573%5D%2C%5B-84.40640911186557%2C23.809680634191537%5D%2C%5B-78.72111096471372%2C23.809680634191537%5D%2C%5B-78.72111096471372%2C31.358634554371573%5D%2C%5B-84.40640911186557%2C31.358634554371573%5D%5D%5D%7D%7D'
+        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=query&client=c4react&source=SELECT+*+FROM+%60cartobq.public_account.seattle_collisions%60+WHERE+time_column+%3E+%40start+AND+time_column+%3C+%40end&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&queryParameters=%7B%22start%22%3A%222019-01-01%22%2C%22end%22%3A%222019-01-02%22%7D&filters=%7B%7D&filtersLogicalOperator=AND&spatialFilters=%7B%22geom%22%3A%7B%22type%22%3A%22Polygon%22%2C%22coordinates%22%3A%5B%5B%5B-84.40640911186557%2C31.358634554371573%5D%2C%5B-84.40640911186557%2C23.809680634191537%5D%2C%5B-78.72111096471372%2C23.809680634191537%5D%2C%5B-78.72111096471372%2C31.358634554371573%5D%2C%5B-84.40640911186557%2C31.358634554371573%5D%5D%5D%7D%7D&spatialDataType=geo'
       });
     });
 
@@ -138,7 +138,7 @@ describe('model', () => {
       expect(mockedMakeCall).toHaveBeenCalledWith({
         credentials: TABLE_SOURCE.credentials,
         opts: { method: 'GET' },
-        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=query&client=c4react&source=SELECT+*+FROM+%60cartobq.public_account.seattle_collisions%60+WHERE+time_column+%3E+%40start+AND+time_column+%3C+%40end&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&queryParameters=%7B%22start%22%3A%222019-01-01%22%2C%22end%22%3A%222019-01-02%22%7D&filters=%7B%7D&filtersLogicalOperator=AND&spatialFilters=%7B%22abc%22%3A%7B%22type%22%3A%22Polygon%22%2C%22coordinates%22%3A%5B%5B%5B-84.40640911186557%2C31.358634554371573%5D%2C%5B-84.40640911186557%2C23.809680634191537%5D%2C%5B-78.72111096471372%2C23.809680634191537%5D%2C%5B-78.72111096471372%2C31.358634554371573%5D%2C%5B-84.40640911186557%2C31.358634554371573%5D%5D%5D%7D%7D'
+        url: 'https://gcp-us-east1.api.carto.com/v3/sql/carto-ps-bq-developers/model/formula?type=query&client=c4react&source=SELECT+*+FROM+%60cartobq.public_account.seattle_collisions%60+WHERE+time_column+%3E+%40start+AND+time_column+%3C+%40end&params=%7B%22column%22%3A%22__test__%22%2C%22operation%22%3A%22avg%22%7D&queryParameters=%7B%22start%22%3A%222019-01-01%22%2C%22end%22%3A%222019-01-02%22%7D&filters=%7B%7D&filtersLogicalOperator=AND&spatialFilters=%7B%22abc%22%3A%7B%22type%22%3A%22Polygon%22%2C%22coordinates%22%3A%5B%5B%5B-84.40640911186557%2C31.358634554371573%5D%2C%5B-84.40640911186557%2C23.809680634191537%5D%2C%5B-78.72111096471372%2C23.809680634191537%5D%2C%5B-78.72111096471372%2C31.358634554371573%5D%2C%5B-84.40640911186557%2C31.358634554371573%5D%5D%5D%7D%7D&spatialDataType=geo'
       });
     });
   });

--- a/packages/react-api/src/api/model.js
+++ b/packages/react-api/src/api/model.js
@@ -101,7 +101,6 @@ export function executeModel(props) {
     queryParams.spatialFilters = JSON.stringify(spatialFilters);
     queryParams.spatialDataType = spatialDataType;
     if (spatialDataType !== 'geo') {
-      // TODO: any sane default (?)
       if (source.spatialFiltersResolution !== undefined) {
         queryParams.spatialFiltersResolution = source.spatialFiltersResolution;
       }

--- a/packages/react-api/src/api/model.js
+++ b/packages/react-api/src/api/model.js
@@ -73,7 +73,7 @@ export function executeModel(props) {
 
     if (!spatialDataType || !spatialDataColumn) {
       if (source.geoColumn) {
-        const parsedGeoColumn = source.geoColumn ? source.geoColumn.split(':') : [];
+        const parsedGeoColumn = source.geoColumn.split(':');
         if (parsedGeoColumn.length === 2) {
           spatialDataType = parsedGeoColumn[0];
           spatialDataColumn = parsedGeoColumn[1];
@@ -82,7 +82,7 @@ export function executeModel(props) {
           spatialDataType = 'geo';
         }
         if (spatialDataType === 'geom') {
-          // fallback if for some reason someone provided old `geom:whatever`
+          // fallback if for some reason someone provided old `geom:$column`
           spatialDataType = 'geo';
         }
       } else {

--- a/packages/react-api/src/api/model.js
+++ b/packages/react-api/src/api/model.js
@@ -66,15 +66,43 @@ export function executeModel(props) {
     filtersLogicalOperator
   };
 
-  // API supports multiple filters, we apply it only to geoColumn
-  const spatialFilters = spatialFilter
-    ? {
-        [source.geoColumn ? source.geoColumn : DEFAULT_GEO_COLUMN]: spatialFilter
-      }
-    : undefined;
+  let spatialFilters;
+  if (spatialFilter) {
+    let spatialDataType = source.spatialDataType;
+    let spatialDataColumn = source.spatialDataColumn;
 
-  if (spatialFilters) {
+    if ((!spatialDataType || !spatialDataColumn) && source.geoColumn) {
+      const parsedGeoColumn = source.geoColumn ? source.geoColumn.split('.') : [];
+      if (parsedGeoColumn.length === 2) {
+        spatialDataType = parsedGeoColumn[0];
+        spatialDataColumn = parsedGeoColumn[1];
+      } else if (parsedGeoColumn.length === 1) {
+        spatialDataColumn = parsedGeoColumn[0] || DEFAULT_GEO_COLUMN;
+        spatialDataType = 'geo';
+      }
+      if (spatialDataType === 'geom') {
+        // fallback if for some reason someone provided old `geom:whatever`
+        spatialDataType = 'geo';
+      }
+    } else {
+      spatialDataType = 'geo';
+      spatialDataColumn = DEFAULT_GEO_COLUMN;
+    }
+
+    // API supports multiple filters, we apply it only to geometry column or spatialDataColumn
+    spatialFilters = spatialFilter
+      ? {
+          [spatialDataColumn]: spatialFilter
+        }
+      : undefined;
+
     queryParams.spatialFilters = JSON.stringify(spatialFilters);
+    queryParams.spatialDataType = spatialDataType;
+    queryParams.spatialFiltersMode = source.spatialFiltersMode;
+    if (spatialDataType !== 'geo') {
+      // TODO: any sane default (?)
+      queryParams.spatialFiltersResolution = source.spatialFiltersResolution || 10;
+    }
   }
 
   const urlWithSearchParams = url + '?' + new URLSearchParams(queryParams).toString();

--- a/packages/react-api/src/types.d.ts
+++ b/packages/react-api/src/types.d.ts
@@ -43,7 +43,7 @@ export type SourceProps = {
   type: MapTypesType['QUERY'] | MapTypesType['TABLE'] | MapTypesType['TILESET'];
   connection: string;
   geoColumn?: string;
-  dataResoultion?: number;
+  dataResolution?: number;
   spatialDataType?: string;
   spatialDataColumn?: string;
   spatialFiltersResolution?: number;
@@ -77,4 +77,3 @@ export type UseCartoLayerFilterProps = {
 };
 
 export type ExecuteSQLResponse<Response = FeatureCollection | {}[]> = Promise<Response>;
-

--- a/packages/react-api/src/types.d.ts
+++ b/packages/react-api/src/types.d.ts
@@ -43,6 +43,7 @@ export type SourceProps = {
   type: MapTypesType['QUERY'] | MapTypesType['TABLE'] | MapTypesType['TILESET'];
   connection: string;
   geoColumn?: string;
+  dataResoultion?: number;
   spatialDataType?: string;
   spatialDataColumn?: string;
   spatialFiltersResolution?: number;

--- a/packages/react-api/src/types.d.ts
+++ b/packages/react-api/src/types.d.ts
@@ -43,6 +43,9 @@ export type SourceProps = {
   type: MapTypesType['QUERY'] | MapTypesType['TABLE'] | MapTypesType['TILESET'];
   connection: string;
   geoColumn?: string;
+  spatialDataType?: string;
+  spatialDataColumn?: string;
+  spatialFiltersResolution?: number;
   aggregationExp?: string;
   credentials?: Credentials;
   queryParameters?: QueryParameters;

--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -204,6 +204,8 @@ export const createCartoSlice = (initialState) => {
  * @param {FiltersLogicalOperators=} data.filtersLogicalOperator - logical operator that defines how filters for different columns are joined together.
  * @param {import('@deck.gl/carto').QueryParameters} data.queryParameters - SQL query parameters.
  * @param {string=} data.geoColumn - (optional) name of column containing geometries or spatial index data.
+ * @param {number=} data.dataResolution - data resolution for spatial index data.
+ * @param {number=} data.spatialFiltersResolution - spatial filters resolution for spatial index data.
  * @param {string=} data.aggregationExp - (optional) for spatial index data.
  * @param {string=} data.provider - (optional) type of the data warehouse.
  */
@@ -219,6 +221,7 @@ export const addSource = ({
   geoColumn,
   spatialDataType,
   spatialDataColumn,
+  dataResolution,
   spatialFiltersResolution,
   aggregationExp,
   provider
@@ -234,6 +237,7 @@ export const addSource = ({
     filtersLogicalOperator,
     queryParameters,
     geoColumn,
+    dataResolution,
     spatialDataType,
     spatialDataColumn,
     spatialFiltersResolution,

--- a/packages/react-redux/src/slices/cartoSlice.js
+++ b/packages/react-redux/src/slices/cartoSlice.js
@@ -217,6 +217,9 @@ export const addSource = ({
   filtersLogicalOperator = FiltersLogicalOperators.AND,
   queryParameters = [],
   geoColumn,
+  spatialDataType,
+  spatialDataColumn,
+  spatialFiltersResolution,
   aggregationExp,
   provider
 }) => ({
@@ -231,6 +234,9 @@ export const addSource = ({
     filtersLogicalOperator,
     queryParameters,
     geoColumn,
+    spatialDataType,
+    spatialDataColumn,
+    spatialFiltersResolution,
     aggregationExp,
     provider
   }

--- a/packages/react-widgets/src/hooks/useWidgetFetch.js
+++ b/packages/react-widgets/src/hooks/useWidgetFetch.js
@@ -109,6 +109,7 @@ export default function useWidgetFetch(
 
   const source2 = useMemo(() => {
     if (
+      !source ||
       !geometryToIntersect ||
       !source.dataResolution ||
       source.spatialDataType === 'geo'

--- a/packages/react-widgets/src/hooks/useWidgetFetch.js
+++ b/packages/react-widgets/src/hooks/useWidgetFetch.js
@@ -107,12 +107,13 @@ export default function useWidgetFetch(
     [global, viewport, spatialFilter]
   );
 
-  const source2 = useMemo(() => {
+  const enrichedSource = useMemo(() => {
     if (
       !source ||
       !geometryToIntersect ||
-      !source.dataResolution ||
-      source.spatialDataType === 'geo'
+      source.spatialDataType === 'geo' ||
+      source.spatialFiltersResolution !== undefined ||
+      !source.dataResolution
     ) {
       return source;
     }
@@ -128,7 +129,7 @@ export default function useWidgetFetch(
       };
     }
     if (source.spatialDataType === 'quadbin') {
-      const quadsResolution = viewState.zoom;
+      const quadsResolution = Math.floor(viewState.zoom);
       return {
         ...source,
         spatialFiltersResolution: Math.min(source.dataResolution, quadsResolution)
@@ -150,7 +151,7 @@ export default function useWidgetFetch(
       onStateChange?.({ state: WidgetStateType.Loading });
 
       modelFn({
-        source: source2,
+        source: enrichedSource,
         ...params,
         global,
         remoteCalculation,
@@ -185,7 +186,7 @@ export default function useWidgetFetch(
     },
     [
       params,
-      source2,
+      enrichedSource,
       onError,
       isSourceReady,
       global,

--- a/packages/react-widgets/src/models/utils.js
+++ b/packages/react-widgets/src/models/utils.js
@@ -1,9 +1,4 @@
-import {
-  AggregationTypes,
-  getSpatialIndexFromGeoColumn,
-  _filtersToSQL,
-  Provider
-} from '@carto/react-core';
+import { AggregationTypes, _filtersToSQL, Provider } from '@carto/react-core';
 import { FullyQualifiedName } from './fqn';
 import { MAP_TYPES, API_VERSIONS } from '@carto/react-api';
 
@@ -14,7 +9,6 @@ export function isRemoteCalculationSupported(props) {
     source &&
     source.type !== MAP_TYPES.TILESET &&
     source.credentials.apiVersion !== API_VERSIONS.V2 &&
-    !(source.geoColumn && getSpatialIndexFromGeoColumn(source.geoColumn)) &&
     source.provider !== 'databricks'
   );
 }


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/425306

1. Spatial index sources use remote widgets calculation.
2. addSource: Support for `spatialDataType`, `spatialIndexColumn` instead of old `geoColumn`, at least for remote widgets
3. remote widgets: support for new parameters `spatialDataType`, `spatialIndexColumn`, `spatialFiltersResolution` and `spatialFiltersMode`

## Type of change

- Feature

# Acceptance

...

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
