### PR TITLE
Fix HistogramWidget with one non-zero bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- Fix HistogramWidget with one non-zero bucket [#901](https://github.com/CartoDB/carto-react/pull/901)
 - Spatial Index Sources use remote widgets calculation [#898](https://github.com/CartoDB/carto-react/pull/898)
 - Support for `hiddenColumnFields` parameter and `onRowClick` handler for Table Widget [#900](https://github.com/CartoDB/carto-react/pull/900)
 

--- a/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
@@ -195,7 +195,8 @@ function HistogramWidgetUI({
   // Series
   const seriesOptions = useMemo(() => {
     // We check if we have just one different value
-    const isUniqueDataRow = formattedData.filter((row) => row[2] !== 0).length === 1;
+    const isUniqueDataRow =
+      min === max && formattedData.filter((row) => row[2] !== 0).length === 1;
 
     const data = isUniqueDataRow
       ? [formattedData[0], formattedData[formattedData.length - 1]]

--- a/packages/react-ui/storybook/stories/widgetsUI/HistogramWidgetUI.stories.js
+++ b/packages/react-ui/storybook/stories/widgetsUI/HistogramWidgetUI.stories.js
@@ -93,3 +93,22 @@ const LoadingProps = {
   isLoading: true
 };
 Loading.args = LoadingProps;
+
+export const OneNonZeroBinMid = LoadingTemplate.bind({});
+OneNonZeroBinMid.args = {
+  ...defaultProps,
+  data: [0, 300, 0, 0, 0, 0, 0]
+};
+
+export const OneNonZeroBinStart = LoadingTemplate.bind({});
+OneNonZeroBinStart.args = {
+  ...defaultProps,
+  data: [100, 0, 0, 0, 0, 0, 0]
+};
+
+
+export const OneNonZeroBinEnd = LoadingTemplate.bind({});
+OneNonZeroBinEnd.args = {
+  ...defaultProps,
+  data: [0, 0, 0, 0, 0, 0, 100]
+};


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/439218

Fix HistogramWidgetUI component to support case, where there is _only_ one non-zero bucket but ticks and range is proper (min != max).

Fixes regression introduced in https://github.com/CartoDB/carto-react/pull/653, where support for uniform values case was too broad:
By uniform values it means:
 * all values same, 
 * so `min === max`, 
 * so `ticks` same and only last value matters) condition was too wide.

Note, original case from #653  where column has uniform value was tested in builder.


Stories for a test.

## Type of change

- Fix

# Acceptance

1. Go to storybook for HistogramWidgetUI.
2. Change all but one `data` entries to 0
3. Widget should render properly with one bar.

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
