### PR TITLE
isRemoteCalculationSupported: revert remote calculation for dynamic spatial index sources 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- isRemoteCalculationSupported: revert remote calculation for dynamic spatial index sources  [#905](https://github.com/CartoDB/carto-react/pull/905)
 - Fix HistogramWidget with one non-zero bucket [#901](https://github.com/CartoDB/carto-react/pull/901)
 - Spatial Index Sources use remote widgets calculation [#898](https://github.com/CartoDB/carto-react/pull/898)
 - Support for `hiddenColumnFields` parameter and `onRowClick` handler for Table Widget [#900](https://github.com/CartoDB/carto-react/pull/900)

--- a/packages/react-widgets/src/models/utils.js
+++ b/packages/react-widgets/src/models/utils.js
@@ -1,4 +1,9 @@
-import { AggregationTypes, _filtersToSQL, Provider } from '@carto/react-core';
+import {
+  AggregationTypes,
+  getSpatialIndexFromGeoColumn,
+  _filtersToSQL,
+  Provider
+} from '@carto/react-core';
 import { FullyQualifiedName } from './fqn';
 import { MAP_TYPES, API_VERSIONS } from '@carto/react-api';
 
@@ -9,6 +14,7 @@ export function isRemoteCalculationSupported(props) {
     source &&
     source.type !== MAP_TYPES.TILESET &&
     source.credentials.apiVersion !== API_VERSIONS.V2 &&
+    !(source.geoColumn && getSpatialIndexFromGeoColumn(source.geoColumn)) &&
     source.provider !== 'databricks'
   );
 }


### PR DESCRIPTION
# Description

Temporarily revert changes in isRemoteCalculationSupported from https://github.com/CartoDB/carto-react/pull/898 so we can publish changes.

Leaving rest of original PR, that is backwards compatible (only new params).

## Type of change

(choose one and remove the others)

- Fix
- Feature

# Acceptance

n/a

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
