### PR TITLE
getSqlEscapedSource: support for databricksRest provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 
+- getSqlEscapedSource: support for databricksRest provider [#913](https://github.com/CartoDB/carto-react/pull/913)
 - cache Intl instances to improve performance [#894](https://github.com/CartoDB/carto-react/pull/894)
 - Support for `onRowMouseEnter` and `onRowMouseLeave` handlers for Table Widget [#907](https://github.com/CartoDB/carto-react/pull/907)
 

--- a/packages/react-core/src/operations/constants/Provider.js
+++ b/packages/react-core/src/operations/constants/Provider.js
@@ -8,5 +8,6 @@ export const Provider = Object.freeze({
   Redshift: 'redshift',
   Postgres: 'postgres',
   Snowflake: 'snowflake',
-  Databricks: 'databricks'
+  Databricks: 'databricks',
+  DatabricksRest: 'databricksRest'
 });

--- a/packages/react-core/src/operations/constants/Provider.ts
+++ b/packages/react-core/src/operations/constants/Provider.ts
@@ -3,5 +3,6 @@ export enum Provider {
   Redshift = 'redshift',
   Postgres = 'postgres',
   Snowflake = 'snowflake',
-  Databricks = 'databricks'
+  Databricks = 'databricks',
+  DatabricksRest = 'databricksRest'
 }

--- a/packages/react-widgets/__tests__/models/fqn.test.js
+++ b/packages/react-widgets/__tests__/models/fqn.test.js
@@ -1225,7 +1225,7 @@ describe('FQN', () => {
     });
   });
 
-  describe('for Databricks', () => {
+  describe.each([Provider.Databricks, Provider.DatabricksRest])('for %s', (provider) => {
     test.each([
       [
         'database.schema.table',
@@ -1289,6 +1289,14 @@ describe('FQN', () => {
           quoted: [null, '`schema`', '`ta``bl``e`']
         },
         'database.`schema`.`ta``bl``e`'
+      ],
+      [
+        '`carto-dev-data`.support_team.airports_rls_prepared',
+        {
+          unquoted: ['carto-dev-data', 'support_team', 'airports_rls_prepared'],
+          quoted: ['`carto-dev-data`', 'support_team', 'airports_rls_prepared']
+        },
+        '`carto-dev-data`.support_team.airports_rls_prepared'
       ]
     ])(
       'should parse %p correctly',
@@ -1300,7 +1308,7 @@ describe('FQN', () => {
         },
         expectedFqn
       ) => {
-        const fqnObj = new FullyQualifiedName(fqn, Provider.Databricks);
+        const fqnObj = new FullyQualifiedName(fqn, provider);
 
         expect(fqnObj.getObjectName()).toEqual(objectName);
         expect(fqnObj.getObjectName({ quoted: true })).toEqual(
@@ -1338,11 +1346,7 @@ describe('FQN', () => {
     ])(
       'should parse %p correctly in left to right parsing mode',
       (fqn, databaseName, schemaName, objectName, expectedFqn) => {
-        const fqnObj = new FullyQualifiedName(
-          fqn,
-          Provider.Databricks,
-          ParsingMode.LeftToRight
-        );
+        const fqnObj = new FullyQualifiedName(fqn, provider, ParsingMode.LeftToRight);
         expect(fqnObj.getDatabaseName()).toEqual(databaseName);
         if (schemaName) {
           expect(fqnObj.getSchemaName()).toEqual(schemaName);
@@ -1365,7 +1369,7 @@ describe('FQN', () => {
     });
 
     test('should set database / schema name correctly for an incomplete FQN', () => {
-      const fqnObj = new FullyQualifiedName('schema.table', Provider.Databricks);
+      const fqnObj = new FullyQualifiedName('schema.table', provider);
       fqnObj.setDatabaseName('DAT_A-base');
       fqnObj.setSchemaName('my_schema');
       expect(fqnObj.getDatabaseName()).toEqual('DAT_A-base');
@@ -1382,7 +1386,7 @@ describe('FQN', () => {
     ])(
       'should get object name correctly from %p with suffix %p',
       (fqn, suffix, quotedName, unquotedName) => {
-        const fqnObj = new FullyQualifiedName(fqn, Provider.Databricks);
+        const fqnObj = new FullyQualifiedName(fqn, provider);
         expect(fqnObj.getObjectName({ quoted: true, suffix: suffix })).toEqual(
           quotedName
         );
@@ -1395,7 +1399,7 @@ describe('FQN', () => {
     test('should set object name correctly when it should be escaped', () => {
       const fqnObj = new FullyQualifiedName(
         'database.schema',
-        Provider.Databricks,
+        provider,
         ParsingMode.LeftToRight
       );
       fqnObj.setObjectName('ta ".ble name');
@@ -1422,25 +1426,25 @@ describe('FQN', () => {
         ['`a`..`b`']
       ])('should never accept %p', (fqn) => {
         expect(
-          FullyQualifiedName.isValid(fqn, Provider.Databricks, {
+          FullyQualifiedName.isValid(fqn, provider, {
             parsingMode: ParsingMode.RightToLeft,
             quoted: false
           })
         ).toEqual(false);
         expect(
-          FullyQualifiedName.isValid(fqn, Provider.Databricks, {
+          FullyQualifiedName.isValid(fqn, provider, {
             parsingMode: ParsingMode.RightToLeft,
             quoted: true
           })
         ).toEqual(false);
         expect(
-          FullyQualifiedName.isValid(fqn, Provider.Databricks, {
+          FullyQualifiedName.isValid(fqn, provider, {
             parsingMode: ParsingMode.LeftToRight,
             quoted: false
           })
         ).toEqual(false);
         expect(
-          FullyQualifiedName.isValid(fqn, Provider.Databricks, {
+          FullyQualifiedName.isValid(fqn, provider, {
             parsingMode: ParsingMode.LeftToRight,
             quoted: true
           })
@@ -1458,25 +1462,25 @@ describe('FQN', () => {
         ['my table']
       ])('should should only accept quoted %p', (fqn) => {
         expect(
-          FullyQualifiedName.isValid(fqn, Provider.Databricks, {
+          FullyQualifiedName.isValid(fqn, provider, {
             parsingMode: ParsingMode.RightToLeft,
             quoted: false
           })
         ).toEqual(false);
         expect(
-          FullyQualifiedName.isValid(fqn, Provider.Databricks, {
+          FullyQualifiedName.isValid(fqn, provider, {
             parsingMode: ParsingMode.RightToLeft,
             quoted: true
           })
         ).toEqual(true);
         expect(
-          FullyQualifiedName.isValid(fqn, Provider.Databricks, {
+          FullyQualifiedName.isValid(fqn, provider, {
             parsingMode: ParsingMode.LeftToRight,
             quoted: false
           })
         ).toEqual(false);
         expect(
-          FullyQualifiedName.isValid(fqn, Provider.Databricks, {
+          FullyQualifiedName.isValid(fqn, provider, {
             parsingMode: ParsingMode.LeftToRight,
             quoted: true
           })
@@ -1492,25 +1496,25 @@ describe('FQN', () => {
         ['`a table`']
       ])('should always accept %p', (fqn) => {
         expect(
-          FullyQualifiedName.isValid(fqn, Provider.Databricks, {
+          FullyQualifiedName.isValid(fqn, provider, {
             parsingMode: ParsingMode.RightToLeft,
             quoted: false
           })
         ).toEqual(true);
         expect(
-          FullyQualifiedName.isValid(fqn, Provider.Databricks, {
+          FullyQualifiedName.isValid(fqn, provider, {
             parsingMode: ParsingMode.RightToLeft,
             quoted: true
           })
         ).toEqual(true);
         expect(
-          FullyQualifiedName.isValid(fqn, Provider.Databricks, {
+          FullyQualifiedName.isValid(fqn, provider, {
             parsingMode: ParsingMode.LeftToRight,
             quoted: false
           })
         ).toEqual(true);
         expect(
-          FullyQualifiedName.isValid(fqn, Provider.Databricks, {
+          FullyQualifiedName.isValid(fqn, provider, {
             parsingMode: ParsingMode.LeftToRight,
             quoted: true
           })

--- a/packages/react-widgets/src/models/fqn.js
+++ b/packages/react-widgets/src/models/fqn.js
@@ -9,6 +9,9 @@ const bqProjectId = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
 const bqIdentifierRegex = '((?:[^`.]*?)|`(?:(?:[^`.])*?)`)';
 const identifierRegex = '((?:[^".]*?)|"(?:(?:[^"]|"")*?)")';
 const databricksIdentifierRegex = '((?:[^`.]*?)|`(?:(?:[^`]|``)*?)`)';
+const databricksFqnParseRegex = new RegExp(
+  `^${databricksIdentifierRegex}(?:\\.${databricksIdentifierRegex})?(?:\\.${databricksIdentifierRegex})?$`
+);
 const fqnParseRegex = {
   [Provider.BigQuery]: new RegExp(
     `^\`?${bqIdentifierRegex}(?:\\.${bqIdentifierRegex})?(?:\\.${bqIdentifierRegex})?\`?$`
@@ -22,11 +25,9 @@ const fqnParseRegex = {
   [Provider.Redshift]: new RegExp(
     `^${identifierRegex}(?:\\.${identifierRegex})?(?:\\.${identifierRegex})?$`
   ),
-  [Provider.Databricks]: new RegExp(
-    `^${databricksIdentifierRegex}(?:\\.${databricksIdentifierRegex})?(?:\\.${databricksIdentifierRegex})?$`
-  )
+  [Provider.Databricks]: databricksFqnParseRegex,
+  [Provider.DatabricksRest]: databricksFqnParseRegex
 };
-fqnParseRegex[Provider.DatabricksRest] = fqnParseRegex[Provider.Databricks];
 
 const escapeCharacter = {
   [Provider.BigQuery]: '`',
@@ -42,11 +43,9 @@ const nameNeedsQuotesChecker = {
   [Provider.Postgres]: /^[^a-z_]|[^a-z_\d$]/i,
   [Provider.Snowflake]: /^[^a-z_]|[^a-z_\d$]/i,
   [Provider.Redshift]: /^[^a-z_]|[^a-z_\d$]/i,
-  [Provider.Databricks]: /[^a-z_\d]/i
+  [Provider.Databricks]: /[^a-z_\d]/i,
+  [Provider.DatabricksRest]: /[^a-z_\d]/i
 };
-nameNeedsQuotesChecker[Provider.DatabricksRest] =
-  nameNeedsQuotesChecker[Provider.Databricks];
-
 const caseSensitivenessChecker = {
   [Provider.BigQuery]: null,
   [Provider.Postgres]: /[A-Z]/,

--- a/packages/react-widgets/src/models/fqn.js
+++ b/packages/react-widgets/src/models/fqn.js
@@ -26,13 +26,15 @@ const fqnParseRegex = {
     `^${databricksIdentifierRegex}(?:\\.${databricksIdentifierRegex})?(?:\\.${databricksIdentifierRegex})?$`
   )
 };
+fqnParseRegex[Provider.DatabricksRest] = fqnParseRegex[Provider.Databricks];
 
 const escapeCharacter = {
   [Provider.BigQuery]: '`',
   [Provider.Postgres]: '"',
   [Provider.Snowflake]: '"',
   [Provider.Redshift]: '"',
-  [Provider.Databricks]: '`'
+  [Provider.Databricks]: '`',
+  [Provider.DatabricksRest]: '`'
 };
 
 const nameNeedsQuotesChecker = {
@@ -42,13 +44,16 @@ const nameNeedsQuotesChecker = {
   [Provider.Redshift]: /^[^a-z_]|[^a-z_\d$]/i,
   [Provider.Databricks]: /[^a-z_\d]/i
 };
+nameNeedsQuotesChecker[Provider.DatabricksRest] =
+  nameNeedsQuotesChecker[Provider.Databricks];
 
 const caseSensitivenessChecker = {
   [Provider.BigQuery]: null,
   [Provider.Postgres]: /[A-Z]/,
   [Provider.Snowflake]: /[a-z]/,
   [Provider.Redshift]: null,
-  [Provider.Databricks]: null
+  [Provider.Databricks]: null,
+  [Provider.DatabricksRest]: null
 };
 
 export class FullyQualifiedName {
@@ -384,6 +389,7 @@ export class FullyQualifiedName {
     switch (this.provider) {
       case Provider.BigQuery:
       case Provider.Databricks:
+      case Provider.DatabricksRest:
         return unquotedName;
       case Provider.Postgres:
         return needsQuotes ? unquotedName : unquotedName.toLowerCase();


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/442095

`getSqlEscapedSource` & `FullyQualifiedName` to support `databricksRest` provider type - which is same as `databricks` from SQL pov
## Type of change

(choose one and remove the others)

- Fix

# Acceptance

Already covered with UT

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
