### PR TITLE
Prevent duplicated columns in TableModel

### DIFF
--- a/packages/react-widgets/__tests__/models/TableModel.test.js
+++ b/packages/react-widgets/__tests__/models/TableModel.test.js
@@ -31,6 +31,10 @@ jest.mock('@carto/react-workers', () => ({
   }
 }));
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 describe('getTable', () => {
   const tableParams = {
     source: {
@@ -93,6 +97,16 @@ describe('getTable', () => {
         totalCount: RESULT.metadata.total,
         hasData: true
       });
+    });
+
+    test('prevents column duplicates', async () => {
+      const data = await getTable({
+        ...tableParams,
+        columns: ['any-column', 'any-column'],
+        remoteCalculation: true
+      });
+
+      expect(mockedExecuteModel.mock.calls[0][0].params.column).toEqual(['any-column']);
     });
   });
 });

--- a/packages/react-widgets/src/models/TableModel.js
+++ b/packages/react-widgets/src/models/TableModel.js
@@ -61,7 +61,7 @@ function fromRemote(props) {
     spatialFilter,
     ...(searchFilter && { searchFilter }),
     params: {
-      column: columns,
+      column: [...new Set(columns)],
       sortBy,
       sortDirection,
       limit: rowsPerPage,


### PR DESCRIPTION
# Description

Shortcut: (443603)

### Works ✅

```
curl 'https://gcp-us-east1.api.carto.com/v3/sql/carto_dw/model/table?type=query&client=builder&source=SELECT+*+FROM+%60carto-demo-data.demo_tables.newyork_ooh_sample_audience_h3%60&params=%7B%22column%22%3A%5B%22h3%22%2C%22geom%22%2C%22female_20_f727dc_sum%22%5D%2C%22sortDirection%22%3A%22asc%22%2C%22limit%22%3A5%2C%22offset%22%3A0%7D&queryParameters=%5B%5D&filters=%7B%7D&filtersLogicalOperator=and&spatialFiltersMode=intersects' \
  -H 'accept: */*' \
  -H 'authorization: Bearer <place-here-your-token>' \
  -H 'cache-control: no-cache'
```

### Fails 💔

```
curl 'https://gcp-us-east1.api.carto.com/v3/sql/carto_dw/model/table?type=query&client=builder&source=SELECT+*+FROM+%60carto-demo-data.demo_tables.newyork_ooh_sample_audience_h3%60&params=%7B%22column%22%3A%5B%22h3%22%2C%22geom%22%2C%22female_20_f727dc_sum%22%2C%22h3%22%5D%2C%22sortDirection%22%3A%22asc%22%2C%22limit%22%3A5%2C%22offset%22%3A0%7D&queryParameters=%5B%5D&filters=%7B%7D&filtersLogicalOperator=and&spatialFiltersMode=intersects' \
  -H 'accept: */*' \
  -H 'authorization: Bearer <place-here-your-token>' \
  -H 'cache-control: no-cache'
```

## Type of change

- Fix