### PR TITLE
isRemoteCalculationSupported: remove backwards compatbility check for spatial indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- isRemoteCalculationSupported: dynamic aggregation of points to grid/h3 should be remote [#917](https://github.com/CartoDB/carto-react/pull/917)
+
 ## 3.0.0
 
 ### 3.0.0-alpha.22 (2024-09-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- isRemoteCalculationSupported: dynamic aggregation of points to grid/h3 should be remote [#917](https://github.com/CartoDB/carto-react/pull/917)
+- isRemoteCalculationSupported: remove backwards compatbility check for spatial indices [#917](https://github.com/CartoDB/carto-react/pull/917)
 
 ## 3.0.0
 

--- a/packages/react-widgets/__tests__/models/utils.test.js
+++ b/packages/react-widgets/__tests__/models/utils.test.js
@@ -49,7 +49,7 @@ describe('utils', () => {
       ['v3', { ...V3_SOURCE, type: 'tileset' }, false],
       ['v3/databricks', { ...V3_SOURCE, provider: 'databricks' }, false],
       ['v3/databricksRest', { ...V3_SOURCE, provider: 'databricksRest' }, true],
-      ['v3/h3/no dataResolution', { ...V3_SOURCE, geoColumn: 'h3' }, false],
+
       [
         'v3/h3/with dataResolution',
         { ...V3_SOURCE, geoColumn: 'h3', dataResolution: 5 },

--- a/packages/react-widgets/__tests__/models/utils.test.js
+++ b/packages/react-widgets/__tests__/models/utils.test.js
@@ -56,6 +56,16 @@ describe('utils', () => {
         true
       ],
       [
+        'v3/h3-frompoint/without dataResolution',
+        { ...V3_SOURCE, geoColumn: 'h3:geom', spatialDataType: 'geo' },
+        true
+      ],
+      [
+        'v3/quadbin-frompoint/without dataResolution',
+        { ...V3_SOURCE, geoColumn: 'quadbin:geom', spatialDataType: 'geo' },
+        true
+      ],
+      [
         'v3/quadbin/with dataResolution',
         { ...V3_SOURCE, geoColumn: 'quadbin:abc', spatialFiltersResolution: 5 },
         true

--- a/packages/react-widgets/src/models/utils.js
+++ b/packages/react-widgets/src/models/utils.js
@@ -21,6 +21,8 @@ export function isRemoteCalculationSupported(props) {
     return false;
   }
 
+  // If user specifies a spatialDataType, we assume it is _binding_
+  // otherwise, try to deduce it from the geoColumn
   const isDynamicSpatialIndex = source.spatialDataType
     ? source.spatialDataType !== 'geo'
     : source.geoColumn && getSpatialIndexFromGeoColumn(source.geoColumn);

--- a/packages/react-widgets/src/models/utils.js
+++ b/packages/react-widgets/src/models/utils.js
@@ -1,6 +1,5 @@
 import {
   AggregationTypes,
-  getSpatialIndexFromGeoColumn,
   _filtersToSQL,
   Provider
 } from '@carto/react-core';
@@ -21,19 +20,6 @@ export function isRemoteCalculationSupported(props) {
     return false;
   }
 
-  // If user specifies a spatialDataType, we assume it is _binding_
-  // otherwise, try to deduce it from the geoColumn
-  const isDynamicSpatialIndex = source.spatialDataType
-    ? source.spatialDataType !== 'geo'
-    : source.geoColumn && getSpatialIndexFromGeoColumn(source.geoColumn);
-
-  if (
-    isDynamicSpatialIndex &&
-    !source.dataResolution &&
-    !source.spatialFiltersResolution
-  ) {
-    return false;
-  }
   return true;
 }
 

--- a/packages/react-widgets/src/models/utils.js
+++ b/packages/react-widgets/src/models/utils.js
@@ -21,8 +21,10 @@ export function isRemoteCalculationSupported(props) {
     return false;
   }
 
-  const isDynamicSpatialIndex =
-    source.geoColumn && getSpatialIndexFromGeoColumn(source.geoColumn);
+  const isDynamicSpatialIndex = source.spatialDataType
+    ? source.spatialDataType !== 'geo'
+    : source.geoColumn && getSpatialIndexFromGeoColumn(source.geoColumn);
+
   if (
     isDynamicSpatialIndex &&
     !source.dataResolution &&


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/443888/katopody-llc-h3-widgets-not-filtering-properly

isRemoteCalculationSupported: remove backwards compatbility check for spatial indices


## Type of change

- Fix

# Acceptance

Covered by unit-test

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
