### PR TITLE
Fix issue with GET/POST searchFilter

### DIFF
--- a/packages/react-api/src/api/model.js
+++ b/packages/react-api/src/api/model.js
@@ -124,7 +124,7 @@ export function executeModel(props) {
   } else {
     // undo the JSON.stringify, @todo find a better pattern
     queryParams.params = params;
-    queryParams.filters = filters;
+    queryParams.filters = { ...filters, ...props.searchFilter };
     queryParams.queryParameters = source.queryParameters;
     if (spatialFilters) {
       queryParams.spatialFilters = spatialFilters;


### PR DESCRIPTION
# Description

Shortcut: [(link?)](https://app.shortcut.com/cartoteam/story/449248/team-builder-table-widget-search-not-functioning-with-a-specific-sql-source)

https://github.com/user-attachments/assets/cc914046-8ba6-4be8-9382-c8f298313850

## Type of change

- Fix