### PR TITLE
Calculate "Others", based on the aggregationType

### DIFF
--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -115,6 +115,7 @@ function CategoryWidget(props) {
         {(!!data.length || isLoading) && (
           <CategoryWidgetUI
             data={data}
+            aggregationType={operation}
             formatter={formatter}
             labels={labels}
             selectedCategories={selectedCategories}


### PR DESCRIPTION
# Description

[Shortcut](https://app.shortcut.com/cartoteam/story/448703/internal-others-category-in-widget-show-the-sum-of-them-instead-of-the-avg)

https://github.com/user-attachments/assets/9a1d1734-a16f-4400-ba31-6f0d1a0f2303

## Type of change

- Fix