### PR TITLE
fix(widgets): Allow repeated whitespace in GeocoderWidget lat/lng detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- GeocoderWidget: Fix detection of lat,lng coordinates with whitespace
+
 ## 3.1.0
 
 ### 3.1.0-alpha.1 (2024-10-02)

--- a/packages/react-widgets/__tests__/widgets/utils/validateCoordinates.test.js
+++ b/packages/react-widgets/__tests__/widgets/utils/validateCoordinates.test.js
@@ -44,6 +44,10 @@ test('isCoordinate should return true for valid coordinates', () => {
   expect(isCoordinate('0.1234 -45.6789')).toBe(true);
   expect(isCoordinate('12.3456789 0')).toBe(true);
   expect(isCoordinate('12.3456789123456789 123.4567891234567891')).toBe(true);
+  expect(isCoordinate('90  120')).toBe(true);
+  expect(isCoordinate('90  ,120')).toBe(true);
+  expect(isCoordinate('90  ,  120')).toBe(true);
+  expect(isCoordinate('90, \t  120')).toBe(true);
 });
 
 test('isCoordinate should return false for invalid coordinates', () => {

--- a/packages/react-widgets/src/widgets/utils/validateCoordinates.js
+++ b/packages/react-widgets/src/widgets/utils/validateCoordinates.js
@@ -8,7 +8,7 @@ export const isLongitude = (lng) => {
 
 export const isCoordinate = (str) => {
   const coordinateRegexp =
-    /^-?([1-8]?\d(\.\d{1,16})?|90(\.0{1,16})?)(,?\s?)-?((1?[0-7]|\d)?\d(\.\d{1,16})?|180(\.0{1,16})?)$/;
+    /^-?([1-8]?\d(\.\d{1,16})?|90(\.0{1,16})?)(\s*,?\s*)-?((1?[0-7]|\d)?\d(\.\d{1,16})?|180(\.0{1,16})?)$/;
   return coordinateRegexp.test(str);
 };
 


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/465209/cna-location-search-going-to-incorrect-location-when-spaces-used

Unsure when/if this should be merged, because of the ongoing work in Builder, but this PR fixes an issue with GeocoderWidget's detection of lat/lng input, so that these are all treated the same way:

```
<lat>,<lng>
<lat>, <lng>
<lat>,  <lng>
<lat> ,  <lng>
<lat>  ,  <lng>
```

## Type of change

- [x] Fix

# Acceptance

n/a

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
