### PR TITLE
Adapt CategoryWidgetUI Height based on blocked/expanded parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 3.1.0
 
+### 3.1.0-alpha.7 (2024-02-17)
+
+- Calculate VirtualizedList height dynamically in CategoryWidgetUI, when there are blocked categories [#927](https://github.com/CartoDB/carto-react/pull/927)
+
 ### 3.1.0-alpha.6 (2024-02-06)
 
 - Calculate VirtualizedList height dynamically in CategoryWidgetUI [#924](https://github.com/CartoDB/carto-react/pull/924)

--- a/packages/react-ui/src/widgets/CategoryWidgetUI/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI/CategoryWidgetUI.js
@@ -448,6 +448,18 @@ function CategoryWidgetUI(props) {
 
   if (data?.length === 0 || showSkeleton) return <CategorySkeleton />;
 
+  const getFixedSizeListHeight = () => {
+    if (showAll) {
+      return 320;
+    }
+
+    if (blockedCategories.length > 0) {
+      return blockedCategories.length * 38;
+    }
+
+    return (maxItems + 1) * 38;
+  };
+
   return (
     <CategoriesRoot>
       {filterable && sortedData.length > 0 && (
@@ -534,7 +546,7 @@ function CategoryWidgetUI(props) {
       <CategoriesWrapper container item>
         {animValues.length ? (
           <FixedSizeList
-            height={!showAll ? (maxItems + 1) * 38 : 320}
+            height={getFixedSizeListHeight()}
             width='100%'
             itemCount={animValues.length}
             itemSize={36}


### PR DESCRIPTION
# Description

https://app.shortcut.com/cartoteam/story/469563/widgets-are-not-accommodating-to-the-right-extent-after-the-list-of-categories-changes

https://github.com/user-attachments/assets/7021cf27-beb9-4e04-ba70-edcfe757b625

## Type of change

- Fix