### PR TITLE
refactor(ui,widgets): Remove .defaultProps for React 18 compatibility [sc-469139]

### DIFF
--- a/packages/react-ui/src/components/atoms/PasswordField.js
+++ b/packages/react-ui/src/components/atoms/PasswordField.js
@@ -2,7 +2,7 @@ import React, { forwardRef, useState } from 'react';
 import { IconButton, InputAdornment, TextField } from '@mui/material';
 import { VisibilityOffOutlined, VisibilityOutlined } from '@mui/icons-material';
 
-const PasswordField = forwardRef(({ InputProps, size, ...otherProps }, ref) => {
+const PasswordField = forwardRef(({ InputProps, size = 'small', ...otherProps }, ref) => {
   // forwardRef needed to be able to hold a reference, in this way it can be a child for some Mui components, like Tooltip
   // https://mui.com/material-ui/guides/composition/#caveat-with-refs
   const [showPassword, setShowPassword] = useState(false);
@@ -27,9 +27,5 @@ const PasswordField = forwardRef(({ InputProps, size, ...otherProps }, ref) => {
     />
   );
 });
-
-PasswordField.defaultProps = {
-  size: 'small'
-};
 
 export default PasswordField;

--- a/packages/react-ui/src/components/atoms/SelectField.js
+++ b/packages/react-ui/src/components/atoms/SelectField.js
@@ -40,7 +40,7 @@ const SelectField = forwardRef(
     {
       children,
       placeholder,
-      size,
+      size = 'small',
       displayEmpty,
       menuProps,
       inputProps,
@@ -140,9 +140,6 @@ const SelectField = forwardRef(
   }
 );
 
-SelectField.defaultProps = {
-  size: 'small'
-};
 SelectField.propTypes = {
   placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   size: PropTypes.oneOf(['small', 'medium']),

--- a/packages/react-ui/src/components/atoms/ToggleButtonGroup.js
+++ b/packages/react-ui/src/components/atoms/ToggleButtonGroup.js
@@ -83,7 +83,12 @@ const StyledToggleButtonGroup = styled(MuiToggleButtonGroup, {
   })
 }));
 
-const ToggleButtonGroup = ({ children, variant, backgroundColor, ...rest }) => {
+const ToggleButtonGroup = ({
+  children,
+  variant = 'floating',
+  backgroundColor,
+  ...rest
+}) => {
   const isUnbounded = variant === 'unbounded';
   const defaultColor = isUnbounded ? 'transparent' : 'primary';
 
@@ -96,10 +101,6 @@ const ToggleButtonGroup = ({ children, variant, backgroundColor, ...rest }) => {
       {children}
     </StyledToggleButtonGroup>
   );
-};
-
-ToggleButtonGroup.defaultProps = {
-  variant: 'floating'
 };
 
 ToggleButtonGroup.propTypes = {

--- a/packages/react-ui/src/components/molecules/AccordionGroup.js
+++ b/packages/react-ui/src/components/molecules/AccordionGroup.js
@@ -15,7 +15,7 @@ const AccordionContainer = styled('div', {
   })
 }));
 
-const AccordionGroup = ({ variant, items, ...otherProps }) => {
+const AccordionGroup = ({ variant = 'standard', items, ...otherProps }) => {
   return (
     <AccordionContainer {...otherProps} variant={variant}>
       {items.map((item, index) => (
@@ -35,9 +35,6 @@ const AccordionGroup = ({ variant, items, ...otherProps }) => {
   );
 };
 
-AccordionGroup.defaultProps = {
-  variant: 'standard'
-};
 AccordionGroup.propTypes = {
   variant: PropTypes.oneOf(['standard' | 'outlined']),
   items: PropTypes.arrayOf(

--- a/packages/react-ui/src/components/molecules/Alert.js
+++ b/packages/react-ui/src/components/molecules/Alert.js
@@ -95,8 +95,9 @@ const Alert = forwardRef(
   (
     {
       title,
-      severity,
-      content,
+      severity = 'neutral',
+      content = 'inline',
+      variant = 'standard',
       children,
       onClose,
       action,
@@ -129,6 +130,7 @@ const Alert = forwardRef(
           severity={isNeutral ? 'info' : severity}
           isNeutral={isNeutral}
           content={content}
+          variant={variant}
           action={action}
           onClose={handleClose}
           hasCloseButton={Boolean(onClose)}
@@ -148,11 +150,6 @@ const Alert = forwardRef(
   }
 );
 
-Alert.defaultProps = {
-  severity: 'neutral',
-  content: 'inline',
-  variant: 'standard'
-};
 Alert.propTypes = {
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   severity: PropTypes.oneOf(['neutral', 'info', 'success', 'warning', 'error']),

--- a/packages/react-ui/src/components/molecules/Avatar.js
+++ b/packages/react-ui/src/components/molecules/Avatar.js
@@ -36,7 +36,7 @@ const AvatarContainer = styled(MuiAvatar, {
   })
 }));
 
-const Avatar = ({ size, children, ...otherProps }) => {
+const Avatar = ({ size = 'medium', children, ...otherProps }) => {
   return (
     <AvatarContainer {...otherProps} size={size}>
       {children}
@@ -44,9 +44,6 @@ const Avatar = ({ size, children, ...otherProps }) => {
   );
 };
 
-Avatar.defaultProps = {
-  size: 'medium'
-};
 Avatar.propTypes = {
   size: PropTypes.oneOf(Object.keys(sizes))
 };

--- a/packages/react-ui/src/components/molecules/MenuItem.js
+++ b/packages/react-ui/src/components/molecules/MenuItem.js
@@ -131,7 +131,7 @@ const MenuItem = ({
   destructive,
   extended,
   children,
-  iconColor,
+  iconColor = 'primary',
   fixed,
   ...otherProps
 }) => {
@@ -149,9 +149,6 @@ const MenuItem = ({
   );
 };
 
-MenuItem.defaultProps = {
-  iconColor: 'primary'
-};
 MenuItem.propTypes = {
   subtitle: PropTypes.bool,
   destructive: PropTypes.bool,

--- a/packages/react-ui/src/components/molecules/MultipleSelectField/MultipleSelectField.js
+++ b/packages/react-ui/src/components/molecules/MultipleSelectField/MultipleSelectField.js
@@ -48,10 +48,10 @@ const MultipleSelectField = forwardRef(
     {
       options,
       selectedOptions,
-      size,
+      size = 'small',
       placeholder,
       showCounter,
-      showFilters,
+      showFilters = true,
       onChange,
       selectAllDisabled,
       tooltipPlacement,
@@ -204,11 +204,6 @@ const MultipleSelectField = forwardRef(
     );
   }
 );
-
-MultipleSelectField.defaultProps = {
-  size: 'small',
-  showFilters: true
-};
 
 MultipleSelectField.propTypes = {
   options: PropTypes.arrayOf(

--- a/packages/react-ui/src/components/molecules/Table/TablePaginationActions.js
+++ b/packages/react-ui/src/components/molecules/Table/TablePaginationActions.js
@@ -21,7 +21,7 @@ const Button = styled('div')(({ theme }) => ({
 const TablePaginationActions = ({
   count,
   page,
-  rowsPerPage,
+  rowsPerPage = 10,
   onPageChange,
   lastPageTooltip
 }) => {
@@ -67,9 +67,6 @@ const TablePaginationActions = ({
   );
 };
 
-TablePaginationActions.defaultProps = {
-  rowsPerPage: 10
-};
 TablePaginationActions.propTypes = {
   count: PropTypes.number.isRequired,
   onPageChange: PropTypes.func.isRequired,

--- a/packages/react-ui/src/components/molecules/UploadField/UploadField.js
+++ b/packages/react-ui/src/components/molecules/UploadField/UploadField.js
@@ -4,13 +4,17 @@ import PropTypes from 'prop-types';
 import useFileUpload from './useFileUpload';
 import UploadFieldBase from './UploadFieldBase';
 
+const DEFAULT_ACCEPT = ['application/JSON'];
+const DEFAULT_FILES = [];
+const IDENTITY_FN = (x) => x;
+
 function UploadField({
   name,
   buttonText,
-  accept = ['application/JSON'],
-  files = [],
+  accept = DEFAULT_ACCEPT,
+  files = DEFAULT_FILES,
   inProgress,
-  onChange = (files) => files,
+  onChange = IDENTITY_FN,
   multiple,
   placeholder,
   error,

--- a/packages/react-ui/src/components/molecules/UploadField/UploadField.js
+++ b/packages/react-ui/src/components/molecules/UploadField/UploadField.js
@@ -7,10 +7,10 @@ import UploadFieldBase from './UploadFieldBase';
 function UploadField({
   name,
   buttonText,
-  accept,
-  files,
+  accept = ['application/JSON'],
+  files = [],
   inProgress,
-  onChange,
+  onChange = (files) => files,
   multiple,
   placeholder,
   error,
@@ -58,12 +58,6 @@ function UploadField({
     </>
   );
 }
-
-UploadField.defaultProps = {
-  accept: ['application/JSON'],
-  files: [],
-  onChange: (files) => files
-};
 
 UploadField.propTypes = {
   name: PropTypes.string,

--- a/packages/react-ui/src/components/molecules/UploadField/UploadFieldBase.js
+++ b/packages/react-ui/src/components/molecules/UploadField/UploadFieldBase.js
@@ -13,12 +13,12 @@ function UploadFieldBase({
   error,
   placeholder,
   focused,
-  buttonText,
+  buttonText = 'Browse',
   inProgress,
   InputProps,
-  size,
+  size = 'small',
   hasFiles,
-  cursor,
+  cursor = 'pointer',
   ...props
 }) {
   return (
@@ -50,12 +50,6 @@ function UploadFieldBase({
     />
   );
 }
-
-UploadFieldBase.defaultProps = {
-  buttonText: 'Browse',
-  size: 'small',
-  cursor: 'pointer'
-};
 
 UploadFieldBase.propTypes = {
   name: PropTypes.string,

--- a/packages/react-ui/src/components/organisms/AppBar/AppBar.js
+++ b/packages/react-ui/src/components/organisms/AppBar/AppBar.js
@@ -43,7 +43,7 @@ const AppBar = ({
   brandLogo,
   brandText,
   secondaryText,
-  showBurgerMenu,
+  showBurgerMenu = false,
   onClickMenu,
   ...otherProps
 }) => {
@@ -61,10 +61,6 @@ const AppBar = ({
       </Toolbar>
     </Root>
   );
-};
-
-AppBar.defaultProps = {
-  showBurgerMenu: false
 };
 
 AppBar.propTypes = {

--- a/packages/react-ui/src/components/organisms/TooltipData.js
+++ b/packages/react-ui/src/components/organisms/TooltipData.js
@@ -37,14 +37,13 @@ const Category = styled(Typography)(({ theme }) => ({
   marginRight: theme.spacing(1.5)
 }));
 
-const TooltipData = ({
-  items = [
-    {
-      outlinedBullet: false
-    }
-  ],
-  title
-}) => {
+const DEFAULT_ITEMS = [
+  {
+    outlinedBullet: false
+  }
+];
+
+const TooltipData = ({ items = DEFAULT_ITEMS, title }) => {
   return (
     <>
       {title && (

--- a/packages/react-ui/src/components/organisms/TooltipData.js
+++ b/packages/react-ui/src/components/organisms/TooltipData.js
@@ -37,7 +37,14 @@ const Category = styled(Typography)(({ theme }) => ({
   marginRight: theme.spacing(1.5)
 }));
 
-const TooltipData = ({ items, title }) => {
+const TooltipData = ({
+  items = [
+    {
+      outlinedBullet: false
+    }
+  ],
+  title
+}) => {
   return (
     <>
       {title && (
@@ -68,14 +75,6 @@ const TooltipData = ({ items, title }) => {
       </Content>
     </>
   );
-};
-
-TooltipData.defaultProps = {
-  items: [
-    {
-      outlinedBullet: false
-    }
-  ]
 };
 
 TooltipData.propTypes = {

--- a/packages/react-ui/src/custom-components/AnimatedNumber.js
+++ b/packages/react-ui/src/custom-components/AnimatedNumber.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import useAnimatedNumber from '../hooks/useAnimatedNumber';
 
+const EMPTY_OBJECT = {};
+
 /**
  * Renders a <AnimatedNumber /> widget
  * @param {Object} props
@@ -10,7 +12,12 @@ import useAnimatedNumber from '../hooks/useAnimatedNumber';
  * @param {{ duration?: number; animateOnMount?: boolean; initialValue?: number }} [props.options]
  * @param {(n: number) => React.ReactNode} [props.formatter]
  */
-function AnimatedNumber({ enabled = true, value = 0, options = {}, formatter = null }) {
+function AnimatedNumber({
+  enabled = true,
+  value = 0,
+  options = EMPTY_OBJECT,
+  formatter = null
+}) {
   const defaultOptions = {
     animateOnMount: true,
     disabled: enabled === false || value === null || value === undefined

--- a/packages/react-ui/src/custom-components/AnimatedNumber.js
+++ b/packages/react-ui/src/custom-components/AnimatedNumber.js
@@ -10,7 +10,7 @@ import useAnimatedNumber from '../hooks/useAnimatedNumber';
  * @param {{ duration?: number; animateOnMount?: boolean; initialValue?: number }} [props.options]
  * @param {(n: number) => React.ReactNode} [props.formatter]
  */
-function AnimatedNumber({ enabled, value, options, formatter }) {
+function AnimatedNumber({ enabled = true, value = 0, options = {}, formatter = null }) {
   const defaultOptions = {
     animateOnMount: true,
     disabled: enabled === false || value === null || value === undefined
@@ -20,12 +20,6 @@ function AnimatedNumber({ enabled, value, options, formatter }) {
 }
 
 AnimatedNumber.displayName = 'AnimatedNumber';
-AnimatedNumber.defaultProps = {
-  enabled: true,
-  value: 0,
-  options: {},
-  formatter: null
-};
 
 export const animationOptionsPropTypes = PropTypes.shape({
   duration: PropTypes.number,

--- a/packages/react-ui/src/widgets/BarWidgetUI/BarWidgetUI.js
+++ b/packages/react-ui/src/widgets/BarWidgetUI/BarWidgetUI.js
@@ -32,21 +32,21 @@ function BarWidgetUI(props) {
   // With useProcessedProps we convert those multiple shapes in a common one
   // to avoid complex logic in the component.
   const {
-    yAxisData = [],
+    yAxisData,
     xAxisData,
-    series = [],
-    selectedBars = [],
-    onSelectedBarsChange = null,
-    tooltip = true,
-    tooltipFormatter = defaultTooltipFormatter,
-    labels = {},
+    series,
+    selectedBars,
+    onSelectedBarsChange,
+    tooltip,
+    tooltipFormatter,
+    labels,
     colors,
-    xAxisFormatter = (v) => v,
-    yAxisFormatter = (v) => v,
-    stacked = true,
+    xAxisFormatter,
+    yAxisFormatter,
+    stacked,
     height,
-    filterable = true,
-    animation = true,
+    filterable,
+    animation,
     isLoading
   } = useProcessedProps(props);
 
@@ -399,12 +399,22 @@ function defaultTooltipFormatter(params, yAxisFormatter) {
 }
 
 function useProcessedProps({
-  labels,
-  height,
-  selectedBars: _selectedBars,
-  yAxisData: _yAxisData,
+  yAxisData: _yAxisData = [],
+  xAxisData,
+  series: _series = [],
+  selectedBars: _selectedBars = [],
+  onSelectedBarsChange = null,
+  tooltip = true,
+  tooltipFormatter = defaultTooltipFormatter,
+  labels = {},
   colors: _colors,
-  series: _series,
+  xAxisFormatter = (v) => v,
+  yAxisFormatter = (v) => v,
+  stacked = true,
+  height,
+  filterable = true,
+  animation = true,
+  isLoading,
   ...props
 }) {
   const theme = useTheme();
@@ -441,12 +451,22 @@ function useProcessedProps({
 
   return {
     ...props,
-    labels,
-    height: height ?? theme.spacingValue * 22,
-    selectedBars: formatSelectedBars(_selectedBars),
     yAxisData,
+    xAxisData,
+    series,
+    selectedBars: formatSelectedBars(_selectedBars),
+    onSelectedBarsChange,
+    tooltip,
+    tooltipFormatter,
+    labels,
     colors,
-    series
+    xAxisFormatter,
+    yAxisFormatter,
+    stacked,
+    height: height ?? theme.spacingValue * 22,
+    filterable,
+    animation,
+    isLoading
   };
 }
 

--- a/packages/react-ui/src/widgets/BarWidgetUI/BarWidgetUI.js
+++ b/packages/react-ui/src/widgets/BarWidgetUI/BarWidgetUI.js
@@ -32,21 +32,21 @@ function BarWidgetUI(props) {
   // With useProcessedProps we convert those multiple shapes in a common one
   // to avoid complex logic in the component.
   const {
-    yAxisData,
+    yAxisData = [],
     xAxisData,
-    series,
-    selectedBars,
-    onSelectedBarsChange,
-    tooltip,
-    tooltipFormatter,
-    labels,
+    series = [],
+    selectedBars = [],
+    onSelectedBarsChange = null,
+    tooltip = true,
+    tooltipFormatter = defaultTooltipFormatter,
+    labels = {},
     colors,
-    xAxisFormatter,
-    yAxisFormatter,
-    stacked,
+    xAxisFormatter = (v) => v,
+    yAxisFormatter = (v) => v,
+    stacked = true,
     height,
-    filterable,
-    animation,
+    filterable = true,
+    animation = true,
     isLoading
   } = useProcessedProps(props);
 
@@ -339,21 +339,6 @@ function BarWidgetUI(props) {
     </div>
   );
 }
-
-BarWidgetUI.defaultProps = {
-  tooltip: true,
-  tooltipFormatter: defaultTooltipFormatter,
-  yAxisData: [],
-  series: [],
-  xAxisFormatter: (v) => v,
-  yAxisFormatter: (v) => v,
-  selectedBars: [],
-  labels: {},
-  onSelectedBarsChange: null,
-  animation: true,
-  filterable: true,
-  stacked: true
-};
 
 const numberOrString = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
 

--- a/packages/react-ui/src/widgets/BarWidgetUI/BarWidgetUI.js
+++ b/packages/react-ui/src/widgets/BarWidgetUI/BarWidgetUI.js
@@ -398,18 +398,22 @@ function defaultTooltipFormatter(params, yAxisFormatter) {
   return message;
 }
 
+const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
+const IDENTITY_FN = (v) => v;
+
 function useProcessedProps({
-  yAxisData: _yAxisData = [],
+  yAxisData: _yAxisData = EMPTY_ARRAY,
   xAxisData,
-  series: _series = [],
-  selectedBars: _selectedBars = [],
+  series: _series = EMPTY_ARRAY,
+  selectedBars: _selectedBars = EMPTY_ARRAY,
   onSelectedBarsChange = null,
   tooltip = true,
   tooltipFormatter = defaultTooltipFormatter,
-  labels = {},
+  labels = EMPTY_OBJECT,
   colors: _colors,
-  xAxisFormatter = (v) => v,
-  yAxisFormatter = (v) => v,
+  xAxisFormatter = IDENTITY_FN,
+  yAxisFormatter = IDENTITY_FN,
   stacked = true,
   height,
   filterable = true,

--- a/packages/react-ui/src/widgets/CategoryWidgetUI/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI/CategoryWidgetUI.js
@@ -79,12 +79,13 @@ const REST_CATEGORY = '__rest__';
 
 const EMPTY_OBJECT = {};
 const EMPTY_ARRAY = [];
+const IDENTITY_FN = (v) => v;
 
 function CategoryWidgetUI(props) {
   const {
     data = null,
     aggregationType,
-    formatter = (v) => v,
+    formatter = IDENTITY_FN,
     labels = EMPTY_OBJECT,
     maxItems = 5,
     order = ORDER_TYPES.RANKING,

--- a/packages/react-ui/src/widgets/CategoryWidgetUI/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI/CategoryWidgetUI.js
@@ -77,15 +77,18 @@ const aggregateRest = ({ items, aggregationType }) => {
 
 const REST_CATEGORY = '__rest__';
 
+const EMPTY_OBJECT = {};
+const EMPTY_ARRAY = [];
+
 function CategoryWidgetUI(props) {
   const {
     data = null,
     aggregationType,
     formatter = (v) => v,
-    labels = {},
+    labels = EMPTY_OBJECT,
     maxItems = 5,
     order = ORDER_TYPES.RANKING,
-    selectedCategories = [],
+    selectedCategories = EMPTY_ARRAY,
     animation = true,
     filterable = true,
     searchable = true,

--- a/packages/react-ui/src/widgets/CategoryWidgetUI/CategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/CategoryWidgetUI/CategoryWidgetUI.js
@@ -79,16 +79,16 @@ const REST_CATEGORY = '__rest__';
 
 function CategoryWidgetUI(props) {
   const {
-    data,
+    data = null,
     aggregationType,
-    formatter,
-    labels,
-    maxItems,
-    order,
-    selectedCategories,
-    animation,
-    filterable,
-    searchable,
+    formatter = (v) => v,
+    labels = {},
+    maxItems = 5,
+    order = ORDER_TYPES.RANKING,
+    selectedCategories = [],
+    animation = true,
+    filterable = true,
+    searchable = true,
     isLoading
   } = props;
   const [sortedData, setSortedData] = useState([]);
@@ -603,18 +603,6 @@ function CategoryWidgetUI(props) {
     </CategoriesRoot>
   );
 }
-
-CategoryWidgetUI.defaultProps = {
-  data: null,
-  formatter: (v) => v,
-  labels: {},
-  maxItems: 5,
-  order: ORDER_TYPES.RANKING,
-  selectedCategories: [],
-  animation: true,
-  filterable: true,
-  searchable: true
-};
 
 CategoryWidgetUI.propTypes = {
   data: PropTypes.arrayOf(

--- a/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionUIDropdown.js
+++ b/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionUIDropdown.js
@@ -37,6 +37,9 @@ const DisabledMenuItem = styled(MenuItem)(({ theme }) => ({
     opacity: 1
   }
 }));
+
+const NOOP = () => {};
+
 /**
  * Renders a `<FeatureSelectionUIDropdown />` component.
  * This component displays the dropdown layout with all available edit and selection modes
@@ -64,7 +67,7 @@ function FeatureSelectionUIDropdown({
   selectionModes,
   editModes,
   selectedMode,
-  onSelectMode = () => {},
+  onSelectMode = NOOP,
   enabled,
   tooltipPlacement = 'bottom',
   tooltipText = '',

--- a/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionUIDropdown.js
+++ b/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionUIDropdown.js
@@ -64,9 +64,9 @@ function FeatureSelectionUIDropdown({
   selectionModes,
   editModes,
   selectedMode,
-  onSelectMode,
+  onSelectMode = () => {},
   enabled,
-  tooltipPlacement,
+  tooltipPlacement = 'bottom',
   tooltipText = '',
   menuHeaderText = '',
   editDisabled
@@ -165,12 +165,6 @@ FeatureSelectionUIDropdown.propTypes = {
   tooltipText: PropTypes.string,
   menuHeaderText: PropTypes.string,
   editDisabled: PropTypes.bool
-};
-FeatureSelectionUIDropdown.defaultProps = {
-  onSelectMode: () => {},
-  tooltipPlacement: 'bottom',
-  tooltipText: '',
-  menuHeaderText: ''
 };
 
 export default FeatureSelectionUIDropdown;

--- a/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionUIGeometryChips.js
+++ b/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionUIGeometryChips.js
@@ -160,10 +160,5 @@ FeatureSelectionUIGeometryChips.propTypes = {
   ]),
   chipLabel: PropTypes.string
 };
-FeatureSelectionUIGeometryChips.defaultProps = {
-  size: 'medium',
-  tooltipPlacement: 'bottom',
-  onSelectGeometry: NOOP
-};
 
 export default FeatureSelectionUIGeometryChips;

--- a/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionUIToggleButton.js
+++ b/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionUIToggleButton.js
@@ -2,6 +2,8 @@ import { ClickAwayListener, ToggleButton, Tooltip } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
+const NOOP = () => {};
+
 /**
  * Renders the toggle button for feature selection UI
  * handles tooltip logic for click away listener and listens on escape key to disable the button
@@ -20,7 +22,7 @@ function FeatureSelectionUIToggleButton({
   hoverTooltip,
   clickTooltip,
   enabled,
-  onEnabledChange = () => {},
+  onEnabledChange = NOOP,
   tooltipPlacement = 'bottom'
 }) {
   const [tooltipShown, setTooltipShown] = useState(false);

--- a/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionUIToggleButton.js
+++ b/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionUIToggleButton.js
@@ -20,7 +20,7 @@ function FeatureSelectionUIToggleButton({
   hoverTooltip,
   clickTooltip,
   enabled,
-  onEnabledChange,
+  onEnabledChange = () => {},
   tooltipPlacement = 'bottom'
 }) {
   const [tooltipShown, setTooltipShown] = useState(false);
@@ -76,10 +76,6 @@ FeatureSelectionUIToggleButton.propTypes = {
   enabled: PropTypes.bool,
   onEnabledChange: PropTypes.func,
   tooltipPlacement: PropTypes.string
-};
-FeatureSelectionUIToggleButton.defaultProps = {
-  onEnabledChange: () => {},
-  tooltipPlacement: 'bottom'
 };
 
 export default FeatureSelectionUIToggleButton;

--- a/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionWidgetUI.js
+++ b/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionWidgetUI.js
@@ -15,6 +15,8 @@ const StylesWrapper = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(0.5)
 }));
 
+const EMPTY_ARRAY = [];
+
 /**
  * Renders a <FeatureSelectionWidgetUI /> component
  *
@@ -44,7 +46,7 @@ const StylesWrapper = styled(Paper)(({ theme }) => ({
 function FeatureSelectionWidgetUI(props) {
   const {
     selectionModes,
-    editModes = [],
+    editModes = EMPTY_ARRAY,
     selectedMode,
     onSelectMode,
     enabled = false,

--- a/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionWidgetUI.js
+++ b/packages/react-ui/src/widgets/FeatureSelectionWidgetUI/FeatureSelectionWidgetUI.js
@@ -47,7 +47,7 @@ function FeatureSelectionWidgetUI(props) {
     editModes = [],
     selectedMode,
     onSelectMode,
-    enabled,
+    enabled = false,
     onEnabledChange,
     geometry,
     onSelectGeometry,
@@ -158,13 +158,6 @@ function FeatureSelectionWidgetUI(props) {
     </StylesWrapper>
   );
 }
-
-FeatureSelectionWidgetUI.defaultProps = {
-  enabled: false,
-  tooltipPlacement: 'bottom',
-  editModes: [],
-  size: 'medium'
-};
 
 const MODE_SHAPE = PropTypes.shape({
   id: PropTypes.string.isRequired,

--- a/packages/react-ui/src/widgets/FormulaWidgetUI/FormulaWidgetUI.js
+++ b/packages/react-ui/src/widgets/FormulaWidgetUI/FormulaWidgetUI.js
@@ -23,7 +23,7 @@ function usePrevious(value) {
 }
 
 function FormulaWidgetUI(props) {
-  const { data, formatter, animation, isLoading } = props;
+  const { data = '-', formatter = (v) => v, animation = true, isLoading } = props;
   const [value, setValue] = useState('-');
   const requestRef = useRef();
   const prevValue = usePrevious(value);
@@ -89,14 +89,6 @@ function FormulaWidgetUI(props) {
     </Typography>
   );
 }
-
-FormulaWidgetUI.defaultProps = {
-  data: '-',
-  formatter: (v) => v,
-  prefix: '',
-  suffix: '',
-  animation: true
-};
 
 FormulaWidgetUI.propTypes = {
   data: PropTypes.oneOfType([

--- a/packages/react-ui/src/widgets/FormulaWidgetUI/FormulaWidgetUI.js
+++ b/packages/react-ui/src/widgets/FormulaWidgetUI/FormulaWidgetUI.js
@@ -22,8 +22,10 @@ function usePrevious(value) {
   return ref.current;
 }
 
+const IDENTITY_FN = (v) => v;
+
 function FormulaWidgetUI(props) {
-  const { data = '-', formatter = (v) => v, animation = true, isLoading } = props;
+  const { data = '-', formatter = IDENTITY_FN, animation = true, isLoading } = props;
   const [value, setValue] = useState('-');
   const requestRef = useRef();
   const prevValue = usePrevious(value);

--- a/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
@@ -34,16 +34,16 @@ function HistogramWidgetUI({
   ticks,
   min,
   max,
-  xAxisFormatter,
-  yAxisFormatter,
-  yAxisType,
-  selectedBars,
+  xAxisFormatter = (v) => v,
+  yAxisFormatter = (v) => v,
+  yAxisType = 'dense',
+  selectedBars = [],
   onSelectedBarsChange,
-  tooltip,
-  tooltipFormatter,
-  animation,
-  filterable: _filterable,
-  height,
+  tooltip = true,
+  tooltipFormatter = defaultTooltipFormatter,
+  animation = true,
+  filterable: _filterable = true,
+  height = 200,
   isLoading
 }) {
   const theme = useTheme();
@@ -324,18 +324,6 @@ function HistogramWidgetUI({
     </div>
   );
 }
-
-HistogramWidgetUI.defaultProps = {
-  tooltip: true,
-  tooltipFormatter: defaultTooltipFormatter,
-  xAxisFormatter: (v) => v,
-  yAxisFormatter: (v) => v,
-  yAxisType: 'dense',
-  selectedBars: [],
-  animation: true,
-  filterable: true,
-  height: 200
-};
 
 HistogramWidgetUI.propTypes = {
   data: PropTypes.arrayOf(PropTypes.number).isRequired,

--- a/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
+++ b/packages/react-ui/src/widgets/HistogramWidgetUI/HistogramWidgetUI.js
@@ -29,15 +29,18 @@ const ClearButton = styled(Link)(({ theme }) => ({
   cursor: 'pointer'
 }));
 
+const IDENTITY_FN = (v) => v;
+const EMPTY_ARRAY = [];
+
 function HistogramWidgetUI({
   data,
   ticks,
   min,
   max,
-  xAxisFormatter = (v) => v,
-  yAxisFormatter = (v) => v,
+  xAxisFormatter = IDENTITY_FN,
+  yAxisFormatter = IDENTITY_FN,
   yAxisType = 'dense',
-  selectedBars = [],
+  selectedBars = EMPTY_ARRAY,
   onSelectedBarsChange,
   tooltip = true,
   tooltipFormatter = defaultTooltipFormatter,

--- a/packages/react-ui/src/widgets/PieWidgetUI/PieWidgetUI.js
+++ b/packages/react-ui/src/widgets/PieWidgetUI/PieWidgetUI.js
@@ -44,19 +44,23 @@ const Chart = styled(ReactEcharts)(({ theme }) => ({
   bottom: 0
 }));
 
+const IDENTITY_FN = (v) => v;
+const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
+
 function PieWidgetUI({
   name = null,
-  data = [],
-  formatter = (v) => v,
+  data = EMPTY_ARRAY,
+  formatter = IDENTITY_FN,
   tooltipFormatter = _tooltipFormatter,
   percentFormatter,
   height = CHART_SIZE,
   width = CHART_SIZE,
-  labels = {},
-  colors = [],
+  labels = EMPTY_OBJECT,
+  colors = EMPTY_ARRAY,
   animation = true,
   filterable = true,
-  selectedCategories = [],
+  selectedCategories = EMPTY_ARRAY,
   onSelectedCategoriesChange,
   isLoading,
   maxItems = 11,

--- a/packages/react-ui/src/widgets/PieWidgetUI/PieWidgetUI.js
+++ b/packages/react-ui/src/widgets/PieWidgetUI/PieWidgetUI.js
@@ -45,22 +45,22 @@ const Chart = styled(ReactEcharts)(({ theme }) => ({
 }));
 
 function PieWidgetUI({
-  name,
+  name = null,
   data = [],
-  formatter,
-  tooltipFormatter,
+  formatter = (v) => v,
+  tooltipFormatter = _tooltipFormatter,
   percentFormatter,
-  height,
-  width,
-  labels,
-  colors,
-  animation,
-  filterable,
-  selectedCategories,
+  height = CHART_SIZE,
+  width = CHART_SIZE,
+  labels = {},
+  colors = [],
+  animation = true,
+  filterable = true,
+  selectedCategories = [],
   onSelectedCategoriesChange,
   isLoading,
-  maxItems,
-  order
+  maxItems = 11,
+  order = ORDER_TYPES.RANKING
 }) {
   const theme = useTheme();
   const processedData = usePieCategories(data, order, maxItems, colors);
@@ -271,21 +271,6 @@ function PieWidgetUI({
   );
 }
 
-PieWidgetUI.defaultProps = {
-  name: null,
-  formatter: (v) => v,
-  tooltipFormatter,
-  colors: [],
-  labels: {},
-  height: CHART_SIZE,
-  width: CHART_SIZE,
-  animation: true,
-  filterable: true,
-  selectedCategories: [],
-  maxItems: 11,
-  order: ORDER_TYPES.RANKING
-};
-
 PieWidgetUI.propTypes = {
   name: PropTypes.string,
   data: PropTypes.arrayOf(
@@ -313,7 +298,7 @@ PieWidgetUI.propTypes = {
 export default PieWidgetUI;
 
 // Aux
-function tooltipFormatter(params) {
+function _tooltipFormatter(params) {
   const value = processFormatterRes(params.formatter(params.value));
   const percentage = params?.percentFormatter(params.percent) || `${params.percent}%`;
   const markerColor = params.data.color || params.textStyle.color;

--- a/packages/react-ui/src/widgets/ScatterPlotWidgetUI/ScatterPlotWidgetUI.js
+++ b/packages/react-ui/src/widgets/ScatterPlotWidgetUI/ScatterPlotWidgetUI.js
@@ -73,12 +73,12 @@ const EchartsWrapper = React.memo(
 );
 
 function ScatterPlotWidgetUI({
-  name,
+  name = null,
   data = [],
-  animation,
-  xAxisFormatter,
-  yAxisFormatter,
-  tooltipFormatter,
+  animation = true,
+  xAxisFormatter = (v) => v,
+  yAxisFormatter = (v) => v,
+  tooltipFormatter = (v) => `[${v.value[0]}, ${v.value[1]})`,
   isLoading
 }) {
   const theme = useTheme();
@@ -118,14 +118,6 @@ function ScatterPlotWidgetUI({
     />
   );
 }
-
-ScatterPlotWidgetUI.defaultProps = {
-  name: null,
-  animation: true,
-  tooltipFormatter: (v) => `[${v.value[0]}, ${v.value[1]})`,
-  xAxisFormatter: (v) => v,
-  yAxisFormatter: (v) => v
-};
 
 ScatterPlotWidgetUI.propTypes = {
   name: PropTypes.string,

--- a/packages/react-ui/src/widgets/ScatterPlotWidgetUI/ScatterPlotWidgetUI.js
+++ b/packages/react-ui/src/widgets/ScatterPlotWidgetUI/ScatterPlotWidgetUI.js
@@ -72,13 +72,17 @@ const EchartsWrapper = React.memo(
     areChartPropsEqual(optionPrev, optionNext)
 );
 
+const EMPTY_ARRAY = [];
+const IDENTITY_FN = (v) => v;
+const DEFAULT_TOOLTIP_FORMATTER = (v) => `[${v.value[0]}, ${v.value[1]})`;
+
 function ScatterPlotWidgetUI({
   name = null,
-  data = [],
+  data = EMPTY_ARRAY,
   animation = true,
-  xAxisFormatter = (v) => v,
-  yAxisFormatter = (v) => v,
-  tooltipFormatter = (v) => `[${v.value[0]}, ${v.value[1]})`,
+  xAxisFormatter = IDENTITY_FN,
+  yAxisFormatter = IDENTITY_FN,
+  tooltipFormatter = DEFAULT_TOOLTIP_FORMATTER,
   isLoading
 }) {
   const theme = useTheme();

--- a/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
+++ b/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
@@ -52,23 +52,23 @@ const StyledTablePagination = styled(TablePagination)(({ theme }) => ({
 function TableWidgetUI({
   columns,
   rows,
-  sorting,
+  sorting = false,
   sortBy,
-  sortDirection,
+  sortDirection = 'asc',
   onSetSortBy,
   onSetSortDirection,
-  pagination,
+  pagination = false,
   totalCount,
   page,
   onSetPage,
-  rowsPerPage,
-  rowsPerPageOptions,
+  rowsPerPage = 10,
+  rowsPerPageOptions = [5, 10, 25],
   onSetRowsPerPage,
   onRowClick,
   onRowMouseEnter,
   onRowMouseLeave,
   height,
-  dense,
+  dense = false,
   isLoading,
   lastPageTooltip
 }) {
@@ -244,15 +244,6 @@ function TableBodyComponent({
     </TableBody>
   );
 }
-
-TableWidgetUI.defaultProps = {
-  sorting: false,
-  sortDirection: 'asc',
-  pagination: false,
-  rowsPerPage: 10,
-  rowsPerPageOptions: [5, 10, 25],
-  dense: false
-};
 
 TableWidgetUI.propTypes = {
   columns: PropTypes.array.isRequired,

--- a/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
+++ b/packages/react-ui/src/widgets/TableWidgetUI/TableWidgetUI.js
@@ -49,6 +49,8 @@ const StyledTablePagination = styled(TablePagination)(({ theme }) => ({
   overflowY: 'hidden'
 }));
 
+const DEFAULT_ROWS_PER_PAGE_OPTIONS = [5, 10, 25];
+
 function TableWidgetUI({
   columns,
   rows,
@@ -62,7 +64,7 @@ function TableWidgetUI({
   page,
   onSetPage,
   rowsPerPage = 10,
-  rowsPerPageOptions = [5, 10, 25],
+  rowsPerPageOptions = DEFAULT_ROWS_PER_PAGE_OPTIONS,
   onSetRowsPerPage,
   onRowClick,
   onRowMouseEnter,

--- a/packages/react-ui/src/widgets/TimeSeriesWidgetUI/TimeSeriesWidgetUI.js
+++ b/packages/react-ui/src/widgets/TimeSeriesWidgetUI/TimeSeriesWidgetUI.js
@@ -19,8 +19,12 @@ import ChartLegend from '../ChartLegend';
 import { findItemIndexByTime, getDate } from './utils/utilities';
 import useSkeleton from '../useSkeleton';
 
+const EMPTY_ARRAY = [];
+const IDENTITY_FN = (v) => v;
+const DEFAULT_PALETTE = Object.values(commonPalette.qualitative.bold);
+
 function TimeSeriesWidgetUI({
-  data = [],
+  data = EMPTY_ARRAY,
   categories,
   stepSize,
   stepMultiplier = 1,
@@ -28,7 +32,7 @@ function TimeSeriesWidgetUI({
   timeAxisSplitNumber,
   tooltip = true,
   tooltipFormatter = defaultTooltipFormatter,
-  formatter = (value) => value,
+  formatter = IDENTITY_FN,
   height,
   fitHeight,
   showControls = true,
@@ -46,7 +50,7 @@ function TimeSeriesWidgetUI({
   onPause,
   onStop,
   isLoading = false,
-  palette = Object.values(commonPalette.qualitative.bold),
+  palette = DEFAULT_PALETTE,
   showLegend,
   yAxisType = 'dense'
 }) {

--- a/packages/react-ui/src/widgets/TimeSeriesWidgetUI/TimeSeriesWidgetUI.js
+++ b/packages/react-ui/src/widgets/TimeSeriesWidgetUI/TimeSeriesWidgetUI.js
@@ -20,35 +20,35 @@ import { findItemIndexByTime, getDate } from './utils/utilities';
 import useSkeleton from '../useSkeleton';
 
 function TimeSeriesWidgetUI({
-  data,
+  data = [],
   categories,
   stepSize,
   stepMultiplier = 1,
-  chartType,
+  chartType = CHART_TYPES.LINE,
   timeAxisSplitNumber,
-  tooltip,
-  tooltipFormatter,
-  formatter,
+  tooltip = true,
+  tooltipFormatter = defaultTooltipFormatter,
+  formatter = (value) => value,
   height,
   fitHeight,
-  showControls,
-  animation,
-  filterable,
+  showControls = true,
+  animation = true,
+  filterable = true,
   onTimelineUpdate,
   timeWindow,
   timelinePosition,
   onTimeWindowUpdate,
   selectedCategories,
   onSelectedCategoriesChange,
-  isPlaying,
+  isPlaying = false,
   onPlay,
-  isPaused,
+  isPaused = false,
   onPause,
   onStop,
-  isLoading,
-  palette,
+  isLoading = false,
+  palette = Object.values(commonPalette.qualitative.bold),
   showLegend,
-  yAxisType
+  yAxisType = 'dense'
 }) {
   let prevEmittedTimeWindow = useRef();
   const intl = useIntl();
@@ -165,22 +165,6 @@ TimeSeriesWidgetUI.propTypes = {
   showLegend: PropTypes.bool,
   intl: PropTypes.object,
   yAxisType: PropTypes.oneOf(['dense', 'full'])
-};
-
-TimeSeriesWidgetUI.defaultProps = {
-  data: [],
-  chartType: CHART_TYPES.LINE,
-  tooltip: true,
-  tooltipFormatter: defaultTooltipFormatter,
-  formatter: (value) => value,
-  animation: true,
-  filterable: true,
-  isPlaying: false,
-  isPaused: false,
-  showControls: true,
-  isLoading: false,
-  palette: Object.values(commonPalette.qualitative.bold),
-  yAxisType: 'dense'
 };
 
 export default TimeSeriesWidgetUI;

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.js
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.js
@@ -131,6 +131,9 @@ const PaperMenu = styled(Menu)(({ theme }) => ({
   }
 }));
 
+const EMPTY_ARRAY = [];
+const DEFAULT_OPTIONS_ICON = <MoreVert />;
+
 function WrapperWidgetUI({
   title,
   expanded: _expanded = true,
@@ -138,9 +141,9 @@ function WrapperWidgetUI({
   onExpandedChange,
   isLoading = false,
   disabled = false,
-  options = [],
-  actions = [],
-  optionsIcon = <MoreVert />,
+  options = EMPTY_ARRAY,
+  actions = EMPTY_ARRAY,
+  optionsIcon = DEFAULT_OPTIONS_ICON,
   children,
   margin,
   headerItems,

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.js
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.js
@@ -131,32 +131,36 @@ const PaperMenu = styled(Menu)(({ theme }) => ({
   }
 }));
 
-function WrapperWidgetUI(props) {
-  props.expanded ??= true;
-  props.expandable ??= true;
-  props.isLoading ??= false;
-  props.disabled ??= false;
-
+function WrapperWidgetUI({
+  title,
+  expanded: _expanded = true,
+  expandable: _expandable = true,
+  onExpandedChange,
+  isLoading = false,
+  disabled = false,
+  options = [],
+  actions = [],
+  optionsIcon = <MoreVert />,
+  children,
+  margin,
+  headerItems,
+  contentProps,
+  footer
+}) {
   const wrapper = createRef();
 
   const [expandedInt, setExpandedInt] = useState(true);
   const externalExpanded =
-    typeof props.expanded === 'boolean' && typeof props.onExpandedChange === 'function';
+    typeof _expanded === 'boolean' && typeof onExpandedChange === 'function';
   const expanded =
-    props.expandable !== false ? (externalExpanded ? props.expanded : expandedInt) : true;
-  const setExpanded = externalExpanded ? props.onExpandedChange : setExpandedInt;
+    _expandable !== false ? (externalExpanded ? _expanded : expandedInt) : true;
+  const setExpanded = externalExpanded ? onExpandedChange : setExpandedInt;
 
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
-  const {
-    disabled = false,
-    options = [],
-    actions = [],
-    optionsIcon = <MoreVert />
-  } = props;
 
   const handleExpandClick = () => {
-    if (props.expandable) {
+    if (_expandable) {
       setExpanded(!expanded);
     }
   };
@@ -191,30 +195,30 @@ function WrapperWidgetUI(props) {
   };
 
   if (disabled) {
-    return props.children;
+    return children;
   }
 
   return (
-    <Root margin={props.margin} component='section' aria-label={props.title}>
-      {props.isLoading ? <LoadingBar /> : null}
-      <Header container expanded={props.expanded}>
+    <Root margin={margin} component='section' aria-label={title}>
+      {isLoading ? <LoadingBar /> : null}
+      <Header container expanded={_expanded}>
         <HeaderButton
-          expandable={props.expandable}
+          expandable={_expandable}
           startIcon={
-            props.expandable && <Icon>{expanded ? <HideButton /> : <ShowButton />}</Icon>
+            _expandable && <Icon>{expanded ? <HideButton /> : <ShowButton />}</Icon>
           }
           onClick={handleExpandClick}
-          tabIndex={props.expandable ? 0 : -1}
+          tabIndex={_expandable ? 0 : -1}
         >
-          <Tooltip title={props.title}>
-            <Text expanded={props.expanded} align='left' variant='subtitle1'>
-              {props.title}
+          <Tooltip title={title}>
+            <Text expanded={_expanded} align='left' variant='subtitle1'>
+              {title}
             </Text>
           </Tooltip>
         </HeaderButton>
 
         <HeaderItems item>
-          {props.headerItems}
+          {headerItems}
 
           {actions.length > 0 &&
             actions.map((action) => {
@@ -275,9 +279,9 @@ function WrapperWidgetUI(props) {
 
       {/* TODO: check collapse error */}
       <Collapse ref={wrapper} in={expanded} timeout='auto' unmountOnExit>
-        <Box {...props.contentProps}>
-          <Box pt={1}>{props.children}</Box>
-          {props.footer ?? <Box>{props.footer}</Box>}
+        <Box {...contentProps}>
+          <Box pt={1}>{children}</Box>
+          {footer ?? <Box>{footer}</Box>}
         </Box>
       </Collapse>
     </Root>

--- a/packages/react-ui/src/widgets/WrapperWidgetUI.js
+++ b/packages/react-ui/src/widgets/WrapperWidgetUI.js
@@ -132,6 +132,11 @@ const PaperMenu = styled(Menu)(({ theme }) => ({
 }));
 
 function WrapperWidgetUI(props) {
+  props.expanded ??= true;
+  props.expandable ??= true;
+  props.isLoading ??= false;
+  props.disabled ??= false;
+
   const wrapper = createRef();
 
   const [expandedInt, setExpandedInt] = useState(true);
@@ -278,13 +283,6 @@ function WrapperWidgetUI(props) {
     </Root>
   );
 }
-
-WrapperWidgetUI.defaultProps = {
-  expanded: true,
-  expandable: true,
-  isLoading: false,
-  disabled: false
-};
 
 WrapperWidgetUI.propTypes = {
   title: PropTypes.string.isRequired,

--- a/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/CategoryItem.js
+++ b/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/CategoryItem.js
@@ -19,6 +19,7 @@ import {
 
 const IDENTITY_FN = (v) => v;
 const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
 
 function ComparativeCategoryTooltip({
   item,
@@ -83,7 +84,7 @@ ComparativeCategoryTooltip.propTypes = {
 function CategoryItem({
   item,
   animation = true,
-  animationOptions = {},
+  animationOptions = EMPTY_OBJECT,
   maxValue,
   showCheckbox,
   checkboxChecked,

--- a/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/CategoryItem.js
+++ b/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/CategoryItem.js
@@ -20,7 +20,12 @@ import {
 const IDENTITY_FN = (v) => v;
 const EMPTY_ARRAY = [];
 
-function ComparativeCategoryTooltip({ item, index, names, formatter = IDENTITY_FN }) {
+function ComparativeCategoryTooltip({
+  item,
+  index = 0,
+  names = EMPTY_ARRAY,
+  formatter = IDENTITY_FN
+}) {
   const theme = useTheme();
   const reference = item.data[0];
   const data = item.data[index];
@@ -68,11 +73,6 @@ function ComparativeCategoryTooltip({ item, index, names, formatter = IDENTITY_F
 }
 
 ComparativeCategoryTooltip.displayName = 'ComparativeCategoryTooltip';
-ComparativeCategoryTooltip.defaultProps = {
-  names: EMPTY_ARRAY,
-  formatter: IDENTITY_FN,
-  index: 0
-};
 ComparativeCategoryTooltip.propTypes = {
   item: transposedCategoryItemPropTypes,
   names: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -82,13 +82,13 @@ ComparativeCategoryTooltip.propTypes = {
 
 function CategoryItem({
   item,
-  animation,
-  animationOptions,
+  animation = true,
+  animationOptions = {},
   maxValue,
   showCheckbox,
   checkboxChecked,
-  formatter,
-  tooltipFormatter,
+  formatter = IDENTITY_FN,
+  tooltipFormatter = IDENTITY_FN,
   onClick = IDENTITY_FN,
   names,
   tooltip
@@ -153,13 +153,6 @@ function CategoryItem({
 }
 
 CategoryItem.displayName = 'CategoryItem';
-CategoryItem.defaultProps = {
-  animation: true,
-  animationOptions: {},
-  formatter: IDENTITY_FN,
-  tooltipFormatter: IDENTITY_FN,
-  onClick: IDENTITY_FN
-};
 CategoryItem.propTypes = {
   item: transposedCategoryItemPropTypes,
   animation: PropTypes.bool,

--- a/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/ComparativeCategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/ComparativeCategoryWidgetUI.js
@@ -71,11 +71,11 @@ function ComparativeCategoryWidgetUI({
   names = EMPTY_ARRAY,
   data = EMPTY_ARRAY,
   labels = EMPTY_ARRAY,
-  colors,
+  colors = EMPTY_ARRAY,
   maxItems = 5,
   order = ORDER_TYPES.FIXED,
   animation = true,
-  animationOptions,
+  animationOptions = {},
   searchable = true,
   filterable = true,
   selectedCategories = EMPTY_ARRAY,
@@ -363,23 +363,6 @@ function ComparativeCategoryWidgetUI({
 }
 
 ComparativeCategoryWidgetUI.displayName = 'ComparativeCategoryWidgetUI';
-ComparativeCategoryWidgetUI.defaultProps = {
-  names: EMPTY_ARRAY,
-  data: EMPTY_ARRAY,
-  labels: EMPTY_ARRAY,
-  colors: EMPTY_ARRAY,
-  maxItems: 5,
-  order: ORDER_TYPES.FIXED,
-  animation: true,
-  animationOptions: {},
-  searchable: true,
-  filterable: true,
-  selectedCategories: [],
-  tooltip: true,
-  onSelectedCategoriesChange: IDENTITY_FN,
-  formatter: IDENTITY_FN,
-  tooltipFormatter: IDENTITY_FN
-};
 ComparativeCategoryWidgetUI.propTypes = {
   names: PropTypes.arrayOf(PropTypes.string).isRequired,
   data: PropTypes.arrayOf(

--- a/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/ComparativeCategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/ComparativeCategoryWidgetUI.js
@@ -30,6 +30,7 @@ import { ORDER_TYPES } from '../../utils/chartConstants';
 
 const IDENTITY_FN = (v) => v;
 const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
 export const OTHERS_KEY = 'others';
 
 function SearchIcon() {
@@ -75,7 +76,7 @@ function ComparativeCategoryWidgetUI({
   maxItems = 5,
   order = ORDER_TYPES.FIXED,
   animation = true,
-  animationOptions = {},
+  animationOptions = EMPTY_OBJECT,
   searchable = true,
   filterable = true,
   selectedCategories = EMPTY_ARRAY,

--- a/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/ComparativeCategoryWidgetUI.js
+++ b/packages/react-ui/src/widgets/comparative/ComparativeCategoryWidgetUI/ComparativeCategoryWidgetUI.js
@@ -364,7 +364,7 @@ function ComparativeCategoryWidgetUI({
 
 ComparativeCategoryWidgetUI.displayName = 'ComparativeCategoryWidgetUI';
 ComparativeCategoryWidgetUI.propTypes = {
-  names: PropTypes.arrayOf(PropTypes.string).isRequired,
+  names: PropTypes.arrayOf(PropTypes.string),
   data: PropTypes.arrayOf(
     PropTypes.arrayOf(
       PropTypes.shape({

--- a/packages/react-ui/src/widgets/comparative/ComparativeFormulaWidgetUI/ComparativeFormulaWidgetUI.js
+++ b/packages/react-ui/src/widgets/comparative/ComparativeFormulaWidgetUI/ComparativeFormulaWidgetUI.js
@@ -33,7 +33,7 @@ function ComparativeFormulaWidgetUI({
   data = EMPTY_ARRAY,
   colors = EMPTY_ARRAY,
   animated = true,
-  animationOptions,
+  animationOptions = {},
   formatter = IDENTITY_FN,
   isLoading = false
 }) {
@@ -77,13 +77,6 @@ function prepareFormulaValues(data, colors) {
 }
 
 ComparativeFormulaWidgetUI.displayName = 'ComparativeFormulaWidgetUI';
-ComparativeFormulaWidgetUI.defaultProps = {
-  data: EMPTY_ARRAY,
-  colors: EMPTY_ARRAY,
-  animated: true,
-  animationOptions: {},
-  formatter: IDENTITY_FN
-};
 
 const formulaDataPropTypes = PropTypes.shape({
   prefix: PropTypes.string,

--- a/packages/react-ui/src/widgets/comparative/ComparativeFormulaWidgetUI/ComparativeFormulaWidgetUI.js
+++ b/packages/react-ui/src/widgets/comparative/ComparativeFormulaWidgetUI/ComparativeFormulaWidgetUI.js
@@ -10,6 +10,7 @@ import FormulaSkeleton from '../../FormulaWidgetUI/FormulaSkeleton';
 
 const IDENTITY_FN = (v) => v;
 const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
 
 const FormulaGroup = styled('div')(({ theme }) => ({
   '&:nth-of-type(n+2)': {
@@ -33,7 +34,7 @@ function ComparativeFormulaWidgetUI({
   data = EMPTY_ARRAY,
   colors = EMPTY_ARRAY,
   animated = true,
-  animationOptions = {},
+  animationOptions = EMPTY_OBJECT,
   formatter = IDENTITY_FN,
   isLoading = false
 }) {

--- a/packages/react-ui/src/widgets/comparative/ComparativePieWidgetUI.js
+++ b/packages/react-ui/src/widgets/comparative/ComparativePieWidgetUI.js
@@ -81,7 +81,7 @@ function ComparativePieWidgetUI({
   labels = EMPTY_ARRAY,
   colors = EMPTY_ARRAY,
   height = '260px',
-  animation,
+  animation = true,
   formatter = IDENTITY_FN,
   tooltipFormatter = defaultTooltipFormatter,
   selectedCategories = [],
@@ -286,18 +286,6 @@ function ComparativePieWidgetUI({
 }
 
 ComparativePieWidgetUI.displayName = 'ComparativePieWidgetUI';
-ComparativePieWidgetUI.defaultProps = {
-  names: EMPTY_ARRAY,
-  data: EMPTY_ARRAY,
-  labels: EMPTY_ARRAY,
-  colors: EMPTY_ARRAY,
-  height: '260px',
-  animation: true,
-  formatter: IDENTITY_FN,
-  tooltipFormatter: defaultTooltipFormatter,
-  selectedCategories: [],
-  onCategorySelected: IDENTITY_FN
-};
 ComparativePieWidgetUI.propTypes = {
   names: PropTypes.arrayOf(PropTypes.string).isRequired,
   data: PropTypes.arrayOf(

--- a/packages/react-ui/src/widgets/legend/LegendLayer.js
+++ b/packages/react-ui/src/widgets/legend/LegendLayer.js
@@ -57,9 +57,9 @@ export default function LegendLayer({
   onChangeOpacity,
   onChangeVisibility,
   onChangeSelection,
-  maxZoom,
-  minZoom,
-  currentZoom
+  maxZoom = 21,
+  minZoom = 0,
+  currentZoom = 0
 }) {
   const intl = useIntl();
   const intlConfig = useImperativeIntl(intl);
@@ -206,11 +206,6 @@ LegendLayer.propTypes = {
   maxZoom: PropTypes.number,
   minZoom: PropTypes.number,
   currentZoom: PropTypes.number
-};
-LegendLayer.defaultProps = {
-  maxZoom: 21,
-  minZoom: 0,
-  currentZoom: 0
 };
 
 /**

--- a/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
+++ b/packages/react-ui/src/widgets/legend/LegendWidgetUI.js
@@ -40,7 +40,7 @@ function LegendWidgetUI({
   onChangeOpacity = EMPTY_FN,
   onChangeLegendRowCollapsed = EMPTY_FN,
   onChangeSelection = EMPTY_FN,
-  title,
+  title = 'Layers',
   maxZoom = 20,
   minZoom = 0,
   currentZoom,
@@ -125,18 +125,6 @@ function LegendWidgetUI({
     </LegendRoot>
   );
 }
-
-LegendWidgetUI.defaultProps = {
-  layers: EMPTY_ARR,
-  customLegendTypes: EMPTY_OBJ,
-  collapsed: false,
-  title: 'Layers',
-  onChangeCollapsed: EMPTY_FN,
-  onChangeLegendRowCollapsed: EMPTY_FN,
-  onChangeVisibility: EMPTY_FN,
-  onChangeOpacity: EMPTY_FN,
-  onChangeSelection: EMPTY_FN
-};
 
 LegendWidgetUI.propTypes = {
   customLegendTypes: PropTypes.objectOf(PropTypes.func),

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendCategories.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendCategories.js
@@ -15,7 +15,13 @@ const MAX_CATEGORIES = 20;
  * @param {import('../LegendWidgetUI').LegendLayerVariableBase & import('../LegendWidgetUI').LegendCategories} props.legend - legend variable data.
  * @returns {React.ReactNode}
  */
-function LegendCategories({ legend }) {
+function LegendCategories({
+  legend = {
+    labels: [],
+    colors: [],
+    isStrokeColor: false
+  }
+}) {
   const {
     labels = [],
     colors = [],
@@ -62,14 +68,6 @@ function LegendCategories({ legend }) {
     </>
   );
 }
-
-LegendCategories.defaultProps = {
-  legend: {
-    labels: [],
-    colors: [],
-    isStrokeColor: false
-  }
-};
 
 const ColorType = PropTypes.oneOfType([
   PropTypes.string,

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendCategories.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendCategories.js
@@ -10,18 +10,18 @@ import Typography from '../../../components/atoms/Typography';
 
 const MAX_CATEGORIES = 20;
 
+const DEFAULT_LEGEND = {
+  labels: [],
+  colors: [],
+  isStrokeColor: false
+};
+
 /**
  * @param {object} props
  * @param {import('../LegendWidgetUI').LegendLayerVariableBase & import('../LegendWidgetUI').LegendCategories} props.legend - legend variable data.
  * @returns {React.ReactNode}
  */
-function LegendCategories({
-  legend = {
-    labels: [],
-    colors: [],
-    isStrokeColor: false
-  }
-}) {
+function LegendCategories({ legend = DEFAULT_LEGEND }) {
   const {
     labels = [],
     colors = [],

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendIcon.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendIcon.js
@@ -13,7 +13,12 @@ import LegendLayerTitle from '../LegendLayerTitle';
  * @param {import('../LegendWidgetUI').LegendLayerVariableBase & import('../LegendWidgetUI').LegendIcons} props.legend - legend variable data.
  * @returns {React.ReactNode}
  */
-function LegendIcon({ legend }) {
+function LegendIcon({
+  legend = {
+    labels: [],
+    icons: []
+  }
+}) {
   const { labels = [], icons = [] } = legend;
   return (
     <LegendVariableList data-testid='icon-legend'>
@@ -32,13 +37,6 @@ function LegendIcon({ legend }) {
     </LegendVariableList>
   );
 }
-
-LegendIcon.defaultProps = {
-  legend: {
-    labels: [],
-    icons: []
-  }
-};
 
 LegendIcon.propTypes = {
   legend: PropTypes.shape({

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendIcon.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendIcon.js
@@ -8,17 +8,17 @@ import {
 } from '../LegendWidgetUI.styles';
 import LegendLayerTitle from '../LegendLayerTitle';
 
+const DEFAULT_LEGEND = {
+  labels: [],
+  icons: []
+};
+
 /**
  * @param {object} props
  * @param {import('../LegendWidgetUI').LegendLayerVariableBase & import('../LegendWidgetUI').LegendIcons} props.legend - legend variable data.
  * @returns {React.ReactNode}
  */
-function LegendIcon({
-  legend = {
-    labels: [],
-    icons: []
-  }
-}) {
+function LegendIcon({ legend = DEFAULT_LEGEND }) {
   const { labels = [], icons = [] } = legend;
   return (
     <LegendVariableList data-testid='icon-legend'>

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendProportion.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendProportion.js
@@ -58,16 +58,16 @@ const LabelList = styled(Box)(() => ({
   flexShrink: 1
 }));
 
+const DEFAULT_LEGEND = {
+  labels: []
+};
+
 /**
  * @param {object} props
  * @param {import('../LegendWidgetUI').LegendLayerVariableBase & import('../LegendWidgetUI').LegendProportion} props.legend - legend variable data.
  * @returns {React.ReactNode}
  */
-function LegendProportion({
-  legend = {
-    labels: []
-  }
-}) {
+function LegendProportion({ legend = DEFAULT_LEGEND }) {
   const intl = useIntl();
   const intlConfig = useImperativeIntl(intl);
 

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendProportion.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendProportion.js
@@ -63,7 +63,11 @@ const LabelList = styled(Box)(() => ({
  * @param {import('../LegendWidgetUI').LegendLayerVariableBase & import('../LegendWidgetUI').LegendProportion} props.legend - legend variable data.
  * @returns {React.ReactNode}
  */
-function LegendProportion({ legend }) {
+function LegendProportion({
+  legend = {
+    labels: []
+  }
+}) {
   const intl = useIntl();
   const intlConfig = useImperativeIntl(intl);
 
@@ -109,12 +113,6 @@ function LegendProportion({ legend }) {
     </LegendProportionWrapper>
   );
 }
-
-LegendProportion.defaultProps = {
-  legend: {
-    labels: []
-  }
-};
 
 LegendProportion.propTypes = {
   legend: PropTypes.shape({

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendRamp.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendRamp.js
@@ -11,7 +11,13 @@ import LegendProportion, { getMinMax } from './LegendProportion';
  * @param {boolean} [props.isContinuous] - If the legend is continuous.
  * @returns {React.ReactNode}
  */
-function LegendRamp({ isContinuous = false, legend }) {
+function LegendRamp({
+  isContinuous = false,
+  legend = {
+    labels: [],
+    colors: []
+  }
+}) {
   const { labels = [], colors = [], showMinMax = true } = legend;
 
   const palette = getPalette(
@@ -72,14 +78,6 @@ function LegendRamp({ isContinuous = false, legend }) {
     </Box>
   );
 }
-
-LegendRamp.defaultProps = {
-  legend: {
-    labels: [],
-    colors: []
-  },
-  isContinuous: false
-};
 
 const ColorType = PropTypes.oneOfType([
   PropTypes.string,

--- a/packages/react-ui/src/widgets/legend/legend-types/LegendRamp.js
+++ b/packages/react-ui/src/widgets/legend/legend-types/LegendRamp.js
@@ -5,19 +5,18 @@ import Typography from '../../../components/atoms/Typography';
 import { getPalette } from '../../../utils/palette';
 import LegendProportion, { getMinMax } from './LegendProportion';
 
+const DEFAULT_LEGEND = {
+  labels: [],
+  colors: []
+};
+
 /**
  * @param {object} props
  * @param {import('../LegendWidgetUI').LegendLayerVariableBase & import('../LegendWidgetUI').LegendRamp} props.legend - legend variable data.
  * @param {boolean} [props.isContinuous] - If the legend is continuous.
  * @returns {React.ReactNode}
  */
-function LegendRamp({
-  isContinuous = false,
-  legend = {
-    labels: [],
-    colors: []
-  }
-}) {
+function LegendRamp({ isContinuous = false, legend = DEFAULT_LEGEND }) {
   const { labels = [], colors = [], showMinMax = true } = legend;
 
   const palette = getPalette(

--- a/packages/react-widgets/src/widgets/BarWidget.js
+++ b/packages/react-widgets/src/widgets/BarWidget.js
@@ -16,6 +16,7 @@ import useWidgetFetch from '../hooks/useWidgetFetch';
 import WidgetWithAlert from './utils/WidgetWithAlert';
 
 const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
 
 /**
  * Renders a <BarWidget /> component
@@ -52,8 +53,8 @@ function BarWidget({
   operation,
   xAxisFormatter,
   yAxisFormatter,
-  order = [],
-  labels = {},
+  order = EMPTY_ARRAY,
+  labels = EMPTY_OBJECT,
   tooltip = true,
   tooltipFormatter,
   height,
@@ -62,8 +63,8 @@ function BarWidget({
   global = false,
   onError,
   onStateChange,
-  wrapperProps = {},
-  noDataAlertProps = {}
+  wrapperProps = EMPTY_OBJECT,
+  noDataAlertProps = EMPTY_OBJECT
 }) {
   const dispatch = useDispatch();
 

--- a/packages/react-widgets/src/widgets/BarWidget.js
+++ b/packages/react-widgets/src/widgets/BarWidget.js
@@ -53,17 +53,17 @@ function BarWidget({
   xAxisFormatter,
   yAxisFormatter,
   order = [],
-  labels,
-  tooltip,
+  labels = {},
+  tooltip = true,
   tooltipFormatter,
   height,
-  animation,
-  filterable,
-  global,
+  animation = true,
+  filterable = true,
+  global = false,
   onError,
   onStateChange,
-  wrapperProps,
-  noDataAlertProps
+  wrapperProps = {},
+  noDataAlertProps = {}
 }) {
   const dispatch = useDispatch();
 
@@ -189,17 +189,6 @@ BarWidget.propTypes = {
   wrapperProps: PropTypes.object,
   noDataAlertProps: PropTypes.object,
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
-};
-
-BarWidget.defaultProps = {
-  order: [],
-  labels: {},
-  animation: true,
-  filterable: true,
-  tooltip: true,
-  global: false,
-  wrapperProps: {},
-  noDataAlertProps: {}
 };
 
 export default BarWidget;

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -16,6 +16,7 @@ import useWidgetFetch from '../hooks/useWidgetFetch';
 import WidgetWithAlert from './utils/WidgetWithAlert';
 
 const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
 
 /**
  * Renders a <CategoryWidget /> component
@@ -48,15 +49,15 @@ function CategoryWidget(props) {
     joinOperation,
     operation,
     formatter,
-    labels = {},
+    labels = EMPTY_OBJECT,
     animation = true,
     filterable = true,
     searchable = true,
     global = false,
     onError,
-    wrapperProps = {},
+    wrapperProps = EMPTY_OBJECT,
     onStateChange,
-    noDataAlertProps = {}
+    noDataAlertProps = EMPTY_OBJECT
   } = props;
   const dispatch = useDispatch();
 

--- a/packages/react-widgets/src/widgets/CategoryWidget.js
+++ b/packages/react-widgets/src/widgets/CategoryWidget.js
@@ -37,7 +37,6 @@ const EMPTY_ARRAY = [];
  * @param  {object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default).
  * @param  {Function=} [props.onStateChange] - Callback to handle state updates of widgets
  * @param  {object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]().
-
  */
 function CategoryWidget(props) {
   const {
@@ -49,15 +48,15 @@ function CategoryWidget(props) {
     joinOperation,
     operation,
     formatter,
-    labels,
-    animation,
-    filterable,
-    searchable,
-    global,
+    labels = {},
+    animation = true,
+    filterable = true,
+    searchable = true,
+    global = false,
     onError,
-    wrapperProps,
+    wrapperProps = {},
     onStateChange,
-    noDataAlertProps
+    noDataAlertProps = {}
   } = props;
   const dispatch = useDispatch();
 
@@ -151,16 +150,6 @@ CategoryWidget.propTypes = {
   onError: PropTypes.func,
   wrapperProps: PropTypes.object,
   noDataAlertProps: PropTypes.object
-};
-
-CategoryWidget.defaultProps = {
-  labels: {},
-  animation: true,
-  filterable: true,
-  searchable: true,
-  global: false,
-  wrapperProps: {},
-  noDataAlertProps: {}
 };
 
 export default CategoryWidget;

--- a/packages/react-widgets/src/widgets/FeatureSelectionWidget.js
+++ b/packages/react-widgets/src/widgets/FeatureSelectionWidget.js
@@ -42,9 +42,12 @@ const EDIT_MODES_MAP = {
   }
 };
 
+const DEFAULT_SELECTION_MODES = Object.values(FEATURE_SELECTION_MODES);
+const DEFAULT_EDIT_MODES = Object.values(EDIT_MODES_MAP);
+
 function FeatureSelectionWidget({
-  selectionModes: selectionModesKeys = Object.values(FEATURE_SELECTION_MODES),
-  editModes: editModesKeys = Object.values(EDIT_MODES_KEYS),
+  selectionModes: selectionModesKeys = DEFAULT_SELECTION_MODES,
+  editModes: editModesKeys = DEFAULT_EDIT_MODES,
   tooltipPlacement,
   size,
   chipLabel

--- a/packages/react-widgets/src/widgets/FeatureSelectionWidget.js
+++ b/packages/react-widgets/src/widgets/FeatureSelectionWidget.js
@@ -43,8 +43,8 @@ const EDIT_MODES_MAP = {
 };
 
 function FeatureSelectionWidget({
-  selectionModes: selectionModesKeys,
-  editModes: editModesKeys,
+  selectionModes: selectionModesKeys = Object.values(FEATURE_SELECTION_MODES),
+  editModes: editModesKeys = Object.values(EDIT_MODES_KEYS),
   tooltipPlacement,
   size,
   chipLabel
@@ -111,11 +111,6 @@ function FeatureSelectionWidget({
     />
   );
 }
-
-FeatureSelectionWidget.defaultProps = {
-  selectionModes: Object.values(FEATURE_SELECTION_MODES),
-  editModes: Object.values(EDIT_MODES_KEYS)
-};
 
 FeatureSelectionWidget.propTypes = {
   selectionModes: PropTypes.arrayOf(

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -7,6 +7,8 @@ import { checkFormulaColumn, columnAggregationOn } from './utils/propTypesFns';
 import useWidgetFetch from '../hooks/useWidgetFetch';
 import WidgetWithAlert from './utils/WidgetWithAlert';
 
+const EMPTY_OBJECT = {};
+
 /**
  * Renders a <FormulaWidget /> component
  * @param  {object} props
@@ -37,7 +39,7 @@ function FormulaWidget({
   global = false,
   onError,
   onStateChange,
-  wrapperProps = {}
+  wrapperProps = EMPTY_OBJECT
 }) {
   const {
     data = { value: undefined },

--- a/packages/react-widgets/src/widgets/FormulaWidget.js
+++ b/packages/react-widgets/src/widgets/FormulaWidget.js
@@ -33,11 +33,11 @@ function FormulaWidget({
   joinOperation,
   operationExp,
   formatter,
-  animation,
-  global,
+  animation = true,
+  global = false,
   onError,
   onStateChange,
-  wrapperProps
+  wrapperProps = {}
 }) {
   const {
     data = { value: undefined },
@@ -86,12 +86,6 @@ FormulaWidget.propTypes = {
   global: PropTypes.bool,
   onError: PropTypes.func,
   wrapperProps: PropTypes.object
-};
-
-FormulaWidget.defaultProps = {
-  animation: true,
-  global: false,
-  wrapperProps: {}
 };
 
 export default FormulaWidget;

--- a/packages/react-widgets/src/widgets/GeocoderWidget.js
+++ b/packages/react-widgets/src/widgets/GeocoderWidget.js
@@ -96,6 +96,4 @@ GeocoderWidget.propTypes = {
   onError: PropTypes.func
 };
 
-GeocoderWidget.defaultProps = {};
-
 export default GeocoderWidget;

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -16,6 +16,7 @@ import WidgetWithAlert from './utils/WidgetWithAlert';
 import useStats from '../hooks/useStats';
 
 const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
 
 /**
  * Renders a <HistogramWidget /> component
@@ -48,7 +49,7 @@ function HistogramWidget({
   dataSource,
   column,
   operation = AggregationTypes.COUNT,
-  ticks: _ticks = [],
+  ticks: _ticks = EMPTY_ARRAY,
   min: externalMin = Number.MIN_SAFE_INTEGER,
   max: externalMax = Number.MAX_SAFE_INTEGER,
   xAxisFormatter,
@@ -62,8 +63,8 @@ function HistogramWidget({
   global = false,
   onError,
   onStateChange,
-  wrapperProps = {},
-  noDataAlertProps = {}
+  wrapperProps = EMPTY_OBJECT,
+  noDataAlertProps = EMPTY_OBJECT
 }) {
   const dispatch = useDispatch();
 

--- a/packages/react-widgets/src/widgets/HistogramWidget.js
+++ b/packages/react-widgets/src/widgets/HistogramWidget.js
@@ -41,30 +41,29 @@ const EMPTY_ARRAY = [];
  * @param  {object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default).
  * @param  {Function=} [props.onStateChange] - Callback to handle state updates of widgets
  * @param  {object} [props.noDataAlertProps] - Extra props to pass to [NoDataAlert]().
-
  */
 function HistogramWidget({
   id,
   title,
   dataSource,
   column,
-  operation,
+  operation = AggregationTypes.COUNT,
   ticks: _ticks = [],
-  min: externalMin,
-  max: externalMax,
+  min: externalMin = Number.MIN_SAFE_INTEGER,
+  max: externalMax = Number.MAX_SAFE_INTEGER,
   xAxisFormatter,
-  bins,
+  bins = 15,
   formatter,
-  yAxisType,
-  tooltip,
+  yAxisType = 'dense',
+  tooltip = true,
   tooltipFormatter,
-  animation,
-  filterable,
-  global,
+  animation = true,
+  filterable = true,
+  global = false,
   onError,
   onStateChange,
-  wrapperProps,
-  noDataAlertProps
+  wrapperProps = {},
+  noDataAlertProps = {}
 }) {
   const dispatch = useDispatch();
 
@@ -239,21 +238,6 @@ HistogramWidget.propTypes = {
   onError: PropTypes.func,
   wrapperProps: PropTypes.object,
   noDataAlertProps: PropTypes.object
-};
-
-HistogramWidget.defaultProps = {
-  bins: 15,
-  ticks: [],
-  min: Number.MIN_SAFE_INTEGER,
-  max: Number.MAX_SAFE_INTEGER,
-  operation: AggregationTypes.COUNT,
-  yAxisType: 'dense',
-  tooltip: true,
-  animation: true,
-  filterable: true,
-  global: false,
-  wrapperProps: {},
-  noDataAlertProps: {}
 };
 
 export default HistogramWidget;

--- a/packages/react-widgets/src/widgets/LegendWidget.js
+++ b/packages/react-widgets/src/widgets/LegendWidget.js
@@ -15,7 +15,12 @@ import { useMediaQuery } from '@mui/material';
  * @param  {string[]} [props.layerOrder] - Array of layer identifiers. Defines the order of layer legends. [] by default.
  * @returns {React.ReactNode}
  */
-function LegendWidget({ customLegendTypes, initialCollapsed, layerOrder = [], title }) {
+function LegendWidget({
+  customLegendTypes,
+  initialCollapsed = false,
+  layerOrder = [],
+  title
+}) {
   const dispatch = useDispatch();
   const reduxLayers = useSelector((state) => state.carto.layers);
   const layers = useMemo(() => {
@@ -108,11 +113,6 @@ LegendWidget.propTypes = {
   customLegendTypes: PropTypes.objectOf(PropTypes.func),
   initialCollapsed: PropTypes.bool,
   layerOrder: PropTypes.arrayOf(PropTypes.string)
-};
-
-LegendWidget.defaultProps = {
-  initialCollapsed: false,
-  layerOrder: []
 };
 
 export default LegendWidget;

--- a/packages/react-widgets/src/widgets/LegendWidget.js
+++ b/packages/react-widgets/src/widgets/LegendWidget.js
@@ -6,6 +6,8 @@ import PropTypes from 'prop-types';
 import sortLayers from './utils/sortLayers';
 import { useMediaQuery } from '@mui/material';
 
+const EMPTY_ARRAY = [];
+
 /**
  * Renders a <LegendWidget /> component
  * @param  {object} props
@@ -18,7 +20,7 @@ import { useMediaQuery } from '@mui/material';
 function LegendWidget({
   customLegendTypes,
   initialCollapsed = false,
-  layerOrder = [],
+  layerOrder = EMPTY_ARRAY,
   title
 }) {
   const dispatch = useDispatch();

--- a/packages/react-widgets/src/widgets/PieWidget.js
+++ b/packages/react-widgets/src/widgets/PieWidget.js
@@ -16,6 +16,7 @@ import useWidgetFetch from '../hooks/useWidgetFetch';
 import WidgetWithAlert from './utils/WidgetWithAlert';
 
 const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
 
 /**
  * Renders a <PieWidget /> component
@@ -58,8 +59,8 @@ function PieWidget({
   colors,
   onError,
   onStateChange,
-  wrapperProps = {},
-  noDataAlertProps = {}
+  wrapperProps = EMPTY_OBJECT,
+  noDataAlertProps = EMPTY_OBJECT
 }) {
   const dispatch = useDispatch();
 

--- a/packages/react-widgets/src/widgets/PieWidget.js
+++ b/packages/react-widgets/src/widgets/PieWidget.js
@@ -52,14 +52,14 @@ function PieWidget({
   formatter,
   tooltipFormatter,
   labels,
-  animation,
-  filterable,
-  global,
+  animation = true,
+  filterable = true,
+  global = false,
   colors,
   onError,
   onStateChange,
-  wrapperProps,
-  noDataAlertProps
+  wrapperProps = {},
+  noDataAlertProps = {}
 }) {
   const dispatch = useDispatch();
 
@@ -156,14 +156,6 @@ PieWidget.propTypes = {
   colors: PropTypes.arrayOf(PropTypes.string),
   wrapperProps: PropTypes.object,
   noDataAlertProps: PropTypes.object
-};
-
-PieWidget.defaultProps = {
-  animation: true,
-  filterable: true,
-  global: false,
-  wrapperProps: {},
-  noDataAlertProps: {}
 };
 
 export default PieWidget;

--- a/packages/react-widgets/src/widgets/RangeWidget.js
+++ b/packages/react-widgets/src/widgets/RangeWidget.js
@@ -14,6 +14,8 @@ import WidgetWithAlert from './utils/WidgetWithAlert';
 import { RangeWidgetUI } from '@carto/react-ui';
 import useStats from '../hooks/useStats';
 
+const EMPTY_OBJECT = {};
+
 /**
  * Renders a <RangeWidget /> component
  * @param  {object} props
@@ -38,7 +40,7 @@ function RangeWidget({
   global = false,
   onError,
   onStateChange,
-  wrapperProps = {}
+  wrapperProps = EMPTY_OBJECT
 }) {
   const dispatch = useDispatch();
   const { filters } = useSelector((state) => selectSourceById(state, dataSource) || {});

--- a/packages/react-widgets/src/widgets/RangeWidget.js
+++ b/packages/react-widgets/src/widgets/RangeWidget.js
@@ -27,7 +27,6 @@ import useStats from '../hooks/useStats';
  * @param  {Function} [props.onError] - Function to handle error messages from the widget.
  * @param  {Function=} [props.onStateChange] - Callback to handle state updates of widgets
  * @param  {object} [props.wrapperProps] - Extra props to pass to [WrapperWidgetUI](https://storybook-react.carto.com/?path=/docs/widgets-wrapperwidgetui--default).
-
  */
 function RangeWidget({
   id,
@@ -36,10 +35,10 @@ function RangeWidget({
   column,
   min: _min,
   max: _max,
-  global,
+  global = false,
   onError,
   onStateChange,
-  wrapperProps
+  wrapperProps = {}
 }) {
   const dispatch = useDispatch();
   const { filters } = useSelector((state) => selectSourceById(state, dataSource) || {});
@@ -175,11 +174,6 @@ RangeWidget.propTypes = {
   global: PropTypes.bool,
   onError: PropTypes.func,
   wrapperProps: PropTypes.object
-};
-
-RangeWidget.defaultProps = {
-  global: false,
-  wrapperProps: {}
 };
 
 export default RangeWidget;

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -7,6 +7,10 @@ import useWidgetFetch from '../hooks/useWidgetFetch';
 import WidgetWithAlert from './utils/WidgetWithAlert';
 import { _FeatureFlags, _hasFeatureFlag } from '@carto/react-core';
 
+const EMPTY_OBJECT = {};
+const IDENTITY_FN = (v) => v;
+const DEFAULT_TOOLTIP_FORMATTER = (v) => `[${v.value[0]}, ${v.value[1]})`;
+
 /**
  * Renders a <ScatterPlotWidget /> component
  * @param  {object} props
@@ -36,14 +40,14 @@ function ScatterPlotWidget({
   yAxisColumn,
   yAxisJoinOperation,
   animation = true,
-  yAxisFormatter = (v) => v,
-  xAxisFormatter = (v) => v,
-  tooltipFormatter = (v) => `[${v.value[0]}, ${v.value[1]})`,
+  yAxisFormatter = IDENTITY_FN,
+  xAxisFormatter = IDENTITY_FN,
+  tooltipFormatter = DEFAULT_TOOLTIP_FORMATTER,
   global,
   onError,
   onStateChange,
-  wrapperProps = {},
-  noDataAlertProps = {}
+  wrapperProps = EMPTY_OBJECT,
+  noDataAlertProps = EMPTY_OBJECT
 }) {
   const {
     data = [],

--- a/packages/react-widgets/src/widgets/ScatterPlotWidget.js
+++ b/packages/react-widgets/src/widgets/ScatterPlotWidget.js
@@ -35,15 +35,15 @@ function ScatterPlotWidget({
   xAxisJoinOperation,
   yAxisColumn,
   yAxisJoinOperation,
-  animation,
-  yAxisFormatter,
-  xAxisFormatter,
-  tooltipFormatter,
+  animation = true,
+  yAxisFormatter = (v) => v,
+  xAxisFormatter = (v) => v,
+  tooltipFormatter = (v) => `[${v.value[0]}, ${v.value[1]})`,
   global,
   onError,
   onStateChange,
-  wrapperProps,
-  noDataAlertProps
+  wrapperProps = {},
+  noDataAlertProps = {}
 }) {
   const {
     data = [],
@@ -103,16 +103,6 @@ ScatterPlotWidget.propTypes = {
   onError: PropTypes.func,
   wrapperProps: PropTypes.object,
   noDataAlertProps: PropTypes.object
-};
-
-ScatterPlotWidget.defaultProps = {
-  tooltip: true,
-  animation: true,
-  wrapperProps: {},
-  noDataAlertProps: {},
-  tooltipFormatter: (v) => `[${v.value[0]}, ${v.value[1]})`,
-  xAxisFormatter: (v) => v,
-  yAxisFormatter: (v) => v
 };
 
 export default ScatterPlotWidget;

--- a/packages/react-widgets/src/widgets/TimeSeriesWidget.js
+++ b/packages/react-widgets/src/widgets/TimeSeriesWidget.js
@@ -48,6 +48,8 @@ function calculateNextStep(time, stepType, stepMultiplier = 1) {
 }
 
 const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
+const IDENTITY_FN = (v) => v;
 
 const debounceTimeout = 250;
 
@@ -109,17 +111,17 @@ function TimeSeriesWidget({
   joinOperation,
   operation = AggregationTypes.COUNT,
   series,
-  stepSizeOptions = [],
+  stepSizeOptions = EMPTY_ARRAY,
   global,
   onError,
-  wrapperProps = {},
-  noDataAlertProps = {},
+  wrapperProps = EMPTY_OBJECT,
+  noDataAlertProps = EMPTY_OBJECT,
   // UI
   chartType = TIME_SERIES_CHART_TYPES.LINE,
   timeAxisSplitNumber,
   tooltip = true,
   tooltipFormatter,
-  formatter = (value) => value,
+  formatter = IDENTITY_FN,
   height,
   fitHeight,
   stableHeight,
@@ -132,7 +134,7 @@ function TimeSeriesWidget({
   onPause,
   onStop,
   onTimelineUpdate,
-  timeWindow = [],
+  timeWindow = EMPTY_ARRAY,
   onTimeWindowUpdate,
   onStateChange,
   palette,

--- a/packages/react-widgets/src/widgets/TimeSeriesWidget.js
+++ b/packages/react-widgets/src/widgets/TimeSeriesWidget.js
@@ -107,37 +107,37 @@ function TimeSeriesWidget({
   column,
   operationColumn,
   joinOperation,
-  operation,
+  operation = AggregationTypes.COUNT,
   series,
-  stepSizeOptions,
+  stepSizeOptions = [],
   global,
   onError,
-  wrapperProps,
-  noDataAlertProps,
+  wrapperProps = {},
+  noDataAlertProps = {},
   // UI
-  chartType,
+  chartType = TIME_SERIES_CHART_TYPES.LINE,
   timeAxisSplitNumber,
-  tooltip,
+  tooltip = true,
   tooltipFormatter,
-  formatter,
+  formatter = (value) => value,
   height,
   fitHeight,
   stableHeight,
-  showControls,
-  animation,
-  filterable,
-  isPlaying,
+  showControls = true,
+  animation = true,
+  filterable = true,
+  isPlaying = false,
   onPlay,
-  isPaused,
+  isPaused = false,
   onPause,
   onStop,
   onTimelineUpdate,
-  timeWindow,
+  timeWindow = [],
   onTimeWindowUpdate,
   onStateChange,
   palette,
   showLegend,
-  yAxisType,
+  yAxisType = 'dense',
   // Both
   stepSize,
   stepMultiplier,
@@ -539,25 +539,6 @@ TimeSeriesWidget.propTypes = {
   yAxisType: PropTypes.oneOf(['dense', 'full']),
   // Both
   stepSize: PropTypes.oneOf(Object.values(GroupDateTypes)).isRequired
-};
-
-TimeSeriesWidget.defaultProps = {
-  // Widget
-  operation: AggregationTypes.COUNT,
-  stepSizeOptions: [],
-  wrapperProps: {},
-  noDataAlertProps: {},
-  // UI
-  tooltip: true,
-  formatter: (value) => value,
-  animation: true,
-  filterable: true,
-  isPlaying: false,
-  isPaused: false,
-  timeWindow: [],
-  showControls: true,
-  chartType: TIME_SERIES_CHART_TYPES.LINE,
-  yAxisType: 'dense'
 };
 
 export default TimeSeriesWidget;


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/469139/bump-workspace-www-to-react-18

Removes use of `.defaultProps` throughout the codebase, for compatibility with React 18. Other than the obvious changes, this also requires using the pattern below ...

```diff
function MyComponent({
-  data = []
+  data = EMPTY_ARRAY
}) {
  ...
}
```

... because (unlike .defaultProps), JavaScript's default parameters are re-evaluated on each function invocation, which make change behavior (break caches, create infinite loops) in React hooks.

## Type of change

- Refactor

# Acceptance

n/a

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
