### PR TITLE
chore(release): v3.1.0-alpha.14

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.1.0-alpha.12"
+  "version": "3.1.0-alpha.13"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.1.0-alpha.13"
+  "version": "3.1.0-alpha.14"
 }

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-api",
-  "version": "3.1.0-alpha.13",
+  "version": "3.1.0-alpha.14",
   "description": "CARTO for React - Api",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -80,5 +80,5 @@
     "react-redux": "^7.2.2 || 8.x",
     "redux": "^4.0.5"
   },
-  "gitHead": "1217fc677ddb467f64ed56bfd15fe1d92f140fff"
+  "gitHead": "766d93bf8ad50123edf2de35d33154542f94123d"
 }

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-api",
-  "version": "3.1.0-alpha.12",
+  "version": "3.1.0-alpha.13",
   "description": "CARTO for React - Api",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-auth",
-  "version": "3.1.0-alpha.12",
+  "version": "3.1.0-alpha.13",
   "description": "CARTO for React - Auth",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-auth",
-  "version": "3.1.0-alpha.13",
+  "version": "3.1.0-alpha.14",
   "description": "CARTO for React - Auth",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -72,5 +72,5 @@
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x"
   },
-  "gitHead": "1217fc677ddb467f64ed56bfd15fe1d92f140fff"
+  "gitHead": "766d93bf8ad50123edf2de35d33154542f94123d"
 }

--- a/packages/react-basemaps/package.json
+++ b/packages/react-basemaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-basemaps",
-  "version": "3.1.0-alpha.13",
+  "version": "3.1.0-alpha.14",
   "description": "CARTO for React - Basemaps",
   "keywords": [
     "carto",
@@ -73,5 +73,5 @@
     "react": "17.x || 18.x",
     "react-dom": "17.x || 18.x"
   },
-  "gitHead": "1217fc677ddb467f64ed56bfd15fe1d92f140fff"
+  "gitHead": "766d93bf8ad50123edf2de35d33154542f94123d"
 }

--- a/packages/react-basemaps/package.json
+++ b/packages/react-basemaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-basemaps",
-  "version": "3.1.0-alpha.12",
+  "version": "3.1.0-alpha.13",
   "description": "CARTO for React - Basemaps",
   "keywords": [
     "carto",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-core",
-  "version": "3.1.0-alpha.12",
+  "version": "3.1.0-alpha.13",
   "description": "CARTO for React - Core",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-core",
-  "version": "3.1.0-alpha.13",
+  "version": "3.1.0-alpha.14",
   "description": "CARTO for React - Core",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -80,5 +80,5 @@
     "h3-js": "^3.7.2",
     "quadbin": "^0.1.9"
   },
-  "gitHead": "1217fc677ddb467f64ed56bfd15fe1d92f140fff"
+  "gitHead": "766d93bf8ad50123edf2de35d33154542f94123d"
 }

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-redux",
-  "version": "3.1.0-alpha.13",
+  "version": "3.1.0-alpha.14",
   "description": "CARTO for React - Redux",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -73,5 +73,5 @@
     "@deck.gl/core": "^9.0.1",
     "@reduxjs/toolkit": "^1.5.0"
   },
-  "gitHead": "1217fc677ddb467f64ed56bfd15fe1d92f140fff"
+  "gitHead": "766d93bf8ad50123edf2de35d33154542f94123d"
 }

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-redux",
-  "version": "3.1.0-alpha.12",
+  "version": "3.1.0-alpha.13",
   "description": "CARTO for React - Redux",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-ui",
-  "version": "3.1.0-alpha.12",
+  "version": "3.1.0-alpha.13",
   "description": "CARTO for React - UI",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-ui",
-  "version": "3.1.0-alpha.13",
+  "version": "3.1.0-alpha.14",
   "description": "CARTO for React - UI",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -95,5 +95,5 @@
     "react-dom": "17.x || 18.x",
     "react-intl": "^6.5.0"
   },
-  "gitHead": "1217fc677ddb467f64ed56bfd15fe1d92f140fff"
+  "gitHead": "766d93bf8ad50123edf2de35d33154542f94123d"
 }

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-widgets",
-  "version": "3.1.0-alpha.13",
+  "version": "3.1.0-alpha.14",
   "description": "CARTO for React - Widgets",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -88,5 +88,5 @@
     "react-redux": "^7.2.2 || 8.x",
     "redux": "^4.0.5"
   },
-  "gitHead": "1217fc677ddb467f64ed56bfd15fe1d92f140fff"
+  "gitHead": "766d93bf8ad50123edf2de35d33154542f94123d"
 }

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-widgets",
-  "version": "3.1.0-alpha.12",
+  "version": "3.1.0-alpha.13",
   "description": "CARTO for React - Widgets",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-widgets/src/widgets/FeatureSelectionWidget.js
+++ b/packages/react-widgets/src/widgets/FeatureSelectionWidget.js
@@ -43,7 +43,7 @@ const EDIT_MODES_MAP = {
 };
 
 const DEFAULT_SELECTION_MODES = Object.values(FEATURE_SELECTION_MODES);
-const DEFAULT_EDIT_MODES = Object.values(EDIT_MODES_MAP);
+const DEFAULT_EDIT_MODES = Object.values(EDIT_MODES_KEYS);
 
 function FeatureSelectionWidget({
   selectionModes: selectionModesKeys = DEFAULT_SELECTION_MODES,

--- a/packages/react-workers/package.json
+++ b/packages/react-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-workers",
-  "version": "3.1.0-alpha.13",
+  "version": "3.1.0-alpha.14",
   "description": "CARTO for React - Workers",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -66,12 +66,12 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.9",
-    "@carto/react-core": "^3.1.0-alpha.13",
+    "@carto/react-core": "^3.1.0-alpha.14",
     "@turf/bbox-polygon": "^6.3.0",
     "@turf/boolean-intersects": "^6.3.0",
     "@turf/boolean-within": "^6.3.0",
     "@turf/intersect": "^6.3.0",
     "thenby": "^1.3.4"
   },
-  "gitHead": "1217fc677ddb467f64ed56bfd15fe1d92f140fff"
+  "gitHead": "766d93bf8ad50123edf2de35d33154542f94123d"
 }

--- a/packages/react-workers/package.json
+++ b/packages/react-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-workers",
-  "version": "3.1.0-alpha.12",
+  "version": "3.1.0-alpha.13",
   "description": "CARTO for React - Workers",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.9",
-    "@carto/react-core": "^3.1.0-alpha.12",
+    "@carto/react-core": "^3.1.0-alpha.13",
     "@turf/bbox-polygon": "^6.3.0",
     "@turf/boolean-intersects": "^6.3.0",
     "@turf/boolean-within": "^6.3.0",


### PR DESCRIPTION
Fixing a typo in the v3.1.0-alpha.12 release, from https://github.com/CartoDB/carto-react/pull/929, causing the "Edit mask" button to disappear:

![CleanShot 2025-03-20 at 18 01 07@2x](https://github.com/user-attachments/assets/277ba3dc-8199-4e37-9f83-27e6fe761070)
