### PR TITLE
Fix useWidgetFetch to fetch data on source changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- Fix useWidgetFetch to fetch data on source changes [#xxx](https://github.com/CartoDB/carto-react/pull/xxx)
+- Fix useWidgetFetch to fetch data on source changes [#934](https://github.com/CartoDB/carto-react/pull/934)
 
 ## 3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix useWidgetFetch to fetch data on source changes [#xxx](https://github.com/CartoDB/carto-react/pull/xxx)
+
 ## 3.1.0
 
 ### 3.1.0-alpha.15 (2025-03-17)

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.1.0-alpha.14"
+  "version": "3.1.0-alpha.16-source-filter-fix.0"
 }

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-api",
-  "version": "3.1.0-alpha.14",
+  "version": "3.1.0-alpha.16-source-filter-fix.0",
   "description": "CARTO for React - Api",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-auth",
-  "version": "3.1.0-alpha.14",
+  "version": "3.1.0-alpha.16-source-filter-fix.0",
   "description": "CARTO for React - Auth",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-basemaps/package.json
+++ b/packages/react-basemaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-basemaps",
-  "version": "3.1.0-alpha.14",
+  "version": "3.1.0-alpha.16-source-filter-fix.0",
   "description": "CARTO for React - Basemaps",
   "keywords": [
     "carto",

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-core",
-  "version": "3.1.0-alpha.14",
+  "version": "3.1.0-alpha.16-source-filter-fix.0",
   "description": "CARTO for React - Core",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-redux/package.json
+++ b/packages/react-redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-redux",
-  "version": "3.1.0-alpha.14",
+  "version": "3.1.0-alpha.16-source-filter-fix.0",
   "description": "CARTO for React - Redux",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-ui",
-  "version": "3.1.0-alpha.14",
+  "version": "3.1.0-alpha.16-source-filter-fix.0",
   "description": "CARTO for React - UI",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-widgets/package.json
+++ b/packages/react-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-widgets",
-  "version": "3.1.0-alpha.14",
+  "version": "3.1.0-alpha.16-source-filter-fix.0",
   "description": "CARTO for React - Widgets",
   "author": "CARTO Dev Team",
   "keywords": [

--- a/packages/react-widgets/src/hooks/useWidgetFetch.js
+++ b/packages/react-widgets/src/hooks/useWidgetFetch.js
@@ -141,6 +141,7 @@ export default function useWidgetFetch(
     },
     [
       params,
+      source,
       onError,
       isSourceReady,
       global,

--- a/packages/react-workers/package.json
+++ b/packages/react-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/react-workers",
-  "version": "3.1.0-alpha.14",
+  "version": "3.1.0-alpha.16-source-filter-fix.0",
   "description": "CARTO for React - Workers",
   "author": "CARTO Dev Team",
   "keywords": [
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.9",
-    "@carto/react-core": "^3.1.0-alpha.14",
+    "@carto/react-core": "^3.1.0-alpha.16-source-filter-fix.0",
     "@turf/bbox-polygon": "^6.3.0",
     "@turf/boolean-intersects": "^6.3.0",
     "@turf/boolean-within": "^6.3.0",


### PR DESCRIPTION
# Description

Shortcut: https://app.shortcut.com/cartoteam/story/478442

In `useWidgetFetch` the `source` contains filters, so it's needed as dependency to `useEffect` that runs model against new parameters

## Type of change

- Fix

# Acceptance

Change of filters should refetch widgets automatically, not waiting for other changes like viewport.

If feature deals with theme / UI or internal elements used also in CARTO 3, please also add a note on how to do acceptance on that part.

# Basic checklist

- Good PR name
- Shortcut link
- Changelog entry
- Just one issue per PR
- GitHub labels
- Proper status & reviewers
- Tests
- Documentation
