### PR TITLE
chore(ci): Update CI to Node.js v24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [24.x]
 
     steps:
       # Setup


### PR DESCRIPTION
# Description

Node.js v18 is past end-of-file and CI is failing, let's update Node.js version in CI.

## Type of change

- Chore

# Acceptance

Passing CI.



#### PR Dependency Tree


* **PR #937** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)